### PR TITLE
Write certificates to Secret Manager

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/gds/certs.go
+++ b/pkg/gds/certs.go
@@ -95,7 +95,7 @@ func (s *Server) submitCertificateRequest(r *models.CertificateRequest) (err err
 
 	// Step 2: get the password
 	secretType := "password"
-	pkcs12Password, err := s.secret.With(r.Id, secretType).GetLatestVersion(context.Background(), secretType)
+	pkcs12Password, err := s.secret.With(r.Id).GetLatestVersion(context.Background(), secretType)
 	if err != nil {
 		return fmt.Errorf("could not retrieve pkcs12password: %s", err)
 	}
@@ -273,7 +273,7 @@ func (s *Server) downloadCertificateRequest(r *models.CertificateRequest) {
 	// Store zipped cert in Google Secrets using certRequestId
 	sctx := context.Background()
 	secretType = "cert"
-	if err = s.secret.With(r.Id, secretType).CreateSecret(sctx, secretType); err != nil {
+	if err = s.secret.With(r.Id).CreateSecret(sctx, secretType); err != nil {
 		log.Error().Err(err).Msg("could not create cert secret")
 		return
 	}
@@ -281,7 +281,7 @@ func (s *Server) downloadCertificateRequest(r *models.CertificateRequest) {
 		log.Error().Err(err).Msg("could not read in cert payload")
 		return
 	}
-	if err = s.secret.With(r.Id, secretType).AddSecretVersion(sctx, secretType, payload); err != nil {
+	if err = s.secret.With(r.Id).AddSecretVersion(sctx, secretType, payload); err != nil {
 		log.Error().Err(err).Msg("could not add secret version for cert payload")
 		return
 	}
@@ -307,7 +307,7 @@ func (s *Server) downloadCertificateRequest(r *models.CertificateRequest) {
 
 	// Retrieve the latest secret version for the password
 	secretType = "password"
-	pkcs12password, err := s.secret.With(r.Id, secretType).GetLatestVersion(sctx, secretType)
+	pkcs12password, err := s.secret.With(r.Id).GetLatestVersion(sctx, secretType)
 	if err != nil {
 		log.Error().Err(err).Msg("could not retrieve password from secret manager to extract public key")
 		return

--- a/pkg/gds/certs.go
+++ b/pkg/gds/certs.go
@@ -251,9 +251,11 @@ func (s *Server) findCertAuthority() (id int, err error) {
 // as an attachment to the technical contact if available.
 func (s *Server) downloadCertificateRequest(r *models.CertificateRequest) {
 	var (
-		err     error
-		path    string
-		certDir string
+		err        error
+		path       string
+		certDir    string
+		payload    []byte
+		secretType string
 	)
 
 	// Get the cert storage directory to download certs to
@@ -268,13 +270,33 @@ func (s *Server) downloadCertificateRequest(r *models.CertificateRequest) {
 		return
 	}
 
+	// Store zipped cert in Google Secrets using certRequestId
+	sctx := context.Background()
+	secretType = "cert"
+	if err = s.secret.With(r.Id, secretType).CreateSecret(sctx, secretType); err != nil {
+		log.Error().Err(err).Msg("could not create cert secret")
+		return
+	}
+	if payload, err = ioutil.ReadFile(path); err != nil {
+		log.Error().Err(err).Msg("could not read in cert payload")
+		return
+	}
+	if err = s.secret.With(r.Id, secretType).AddSecretVersion(sctx, secretType, payload); err != nil {
+		log.Error().Err(err).Msg("could not add secret version for cert payload")
+		return
+	}
+
 	// Mark as downloaded.
 	r.Status = models.CertificateRequestState_DOWNLOADED
 	if err = s.db.SaveCertRequest(r); err != nil {
 		log.Error().Err(err).Msg("could not save updated cert request")
 		return
 	}
-	log.Info().Str(path, path).Msg("certificates downloaded")
+
+	// Delete the temporary file
+	defer os.Remove(path)
+
+	log.Info().Str(path, path).Msg("certificates written to secret manager")
 
 	// Fetch the VASP to get contact info and store certificate data
 	var vasp *pb.VASP
@@ -284,8 +306,8 @@ func (s *Server) downloadCertificateRequest(r *models.CertificateRequest) {
 	}
 
 	// Retrieve the latest secret version for the password
-	secretType := "password"
-	pkcs12password, err := s.secret.With(r.Id, secretType).GetLatestVersion(context.Background(), secretType)
+	secretType = "password"
+	pkcs12password, err := s.secret.With(r.Id, secretType).GetLatestVersion(sctx, secretType)
 	if err != nil {
 		log.Error().Err(err).Msg("could not retrieve password from secret manager to extract public key")
 		return

--- a/pkg/gds/secret.go
+++ b/pkg/gds/secret.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"github.com/rs/zerolog/log"
 	"github.com/trisacrypto/directory/pkg/gds/config"
 	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"google.golang.org/grpc/codes"
@@ -147,6 +148,8 @@ func (smc *SecretManagerContext) AddSecretVersion(ctx context.Context, secret st
 		if errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
+
+		log.Error().Err(err).Msg("error returned from secret manager")
 
 		serr, ok := status.FromError(err)
 		if ok {

--- a/pkg/gds/secret.go
+++ b/pkg/gds/secret.go
@@ -44,11 +44,10 @@ type SecretManagerContext struct {
 	secretType string
 }
 
-func (sm *SecretManager) With(certRequest, secretType string) *SecretManagerContext {
+func (sm *SecretManager) With(certRequest string) *SecretManagerContext {
 	return &SecretManagerContext{
-		manager:    sm,
-		requestId:  certRequest,
-		secretType: secretType,
+		manager:   sm,
+		requestId: certRequest,
 	}
 }
 

--- a/pkg/gds/secret_test.go
+++ b/pkg/gds/secret_test.go
@@ -54,13 +54,13 @@ func TestSecrets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a secret for the testSecretType
-	require.NoError(t, sm.With(testRequestId, testSecretType).CreateSecret(testContext, testSecretType))
+	require.NoError(t, sm.With(testRequestId).CreateSecret(testContext, testSecretType))
 
 	// Create a version to hold the testPayload
-	require.NoError(t, sm.With(testRequestId, testSecretType).AddSecretVersion(testContext, testSecretType, testPayload))
+	require.NoError(t, sm.With(testRequestId).AddSecretVersion(testContext, testSecretType, testPayload))
 
 	// Retrieve the testPayload
-	testResult, err := sm.With(testRequestId, testSecretType).GetLatestVersion(testContext, testSecretType)
+	testResult, err := sm.With(testRequestId).GetLatestVersion(testContext, testSecretType)
 	require.Equal(t, testResult, testPayload)
 	require.NoError(t, err)
 
@@ -87,5 +87,5 @@ func TestSecrets(t *testing.T) {
 	require.NotNil(t, cert)
 
 	// Delete the secret
-	require.NoError(t, sm.With(testRequestId, testSecretType).DeleteSecret(testContext, testSecretType))
+	require.NoError(t, sm.With(testRequestId).DeleteSecret(testContext, testSecretType))
 }

--- a/pkg/gds/secret_test.go
+++ b/pkg/gds/secret_test.go
@@ -2,21 +2,34 @@ package gds_test
 
 import (
 	"context"
+	"crypto/x509"
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/trisacrypto/directory/pkg/gds"
 	"github.com/trisacrypto/directory/pkg/gds/config"
+	"github.com/trisacrypto/trisa/pkg/trust"
 )
 
-// Three environment variables are required to run this test;
-// The first can be included when the tests are run, e.g.
-// GDS_TEST_GOOGLE_SECRETS=1 go test ./pkg/gds/secret_test.go
-// The others, $GOOGLE_APPLICATION_CREDENTIALS and $GOOGLE_PROJECT_NAME
-// are both required to be a valid google secret manager service
-// credentials JSON (absolute path), and a valid google secret manager
-// project name.
+// Six environment variables are required to run this test:
+// $GDS_TEST_GOOGLE_SECRETS
+//     Required; can be included when the tests are run, e.g.
+//     GDS_TEST_GOOGLE_SECRETS=1 go test ./pkg/gds/secret_test.go
+// $GOOGLE_APPLICATION_CREDENTIALS
+//     Required; must be a valid google secret manager service
+//     credentials JSON (absolute path)
+// $GOOGLE_PROJECT_NAME
+//     Required; must be a valid google secret manager project name
+// $TRISA_TEST_PASSWORD
+//     Required; must be a valid pkcs12password that matches the TRISA_TEST_CERT
+// $TRISA_TEST_CERT
+//     Required; must be a valid TRISA certificate that matches the TRISA_TEST_PASSWORD
+// $TRISA_TEST_FILE
+//     Required; absolute path for an intermediate tempfile to write the retrieved cert
+//     TODO: Temp file write & delete can be removed once trust serializer can unzip raw bytes, see:
+//     https://github.com/trisacrypto/trisa/issues/51
 // Note: tests execute against live secret manager API, so use caution!
 func TestSecrets(t *testing.T) {
 	if os.Getenv("GDS_TEST_GOOGLE_SECRETS") == "" {
@@ -27,26 +40,52 @@ func TestSecrets(t *testing.T) {
 		Project:     os.Getenv("GOOGLE_PROJECT_NAME"),
 	}
 
-	// create secret manager
+	// Prep test fixtures
+	testRequestId := "123"
+	testSecretType := "testCert"
+	testContext := context.Background()
+	tempFile := os.Getenv("TRISA_TEST_FILE")
+	testPassword := os.Getenv("TRISA_TEST_PASSWORD")
+	testPayload, err := ioutil.ReadFile(os.Getenv("TRISA_TEST_CERT"))
+	require.NoError(t, err)
+
+	// Create secret manager
 	sm, err := gds.NewSecretManager(testConf)
 	require.NoError(t, err)
 
-	testRequestId := "123"
-	testSecretType := "test"
-	testPayload := []byte("test payload")
+	// Create a secret for the testSecretType
+	require.NoError(t, sm.With(testRequestId, testSecretType).CreateSecret(testContext, testSecretType))
 
-	// create a secret
-	require.NoError(t, sm.With(testRequestId, testSecretType).CreateSecret(context.Background(), testSecretType))
+	// Create a version to hold the testPayload
+	require.NoError(t, sm.With(testRequestId, testSecretType).AddSecretVersion(testContext, testSecretType, testPayload))
 
-	// create a version
-	require.NoError(t, sm.With(testRequestId, testSecretType).AddSecretVersion(context.Background(), testSecretType, testPayload))
-
-	// access version
-	result, err := sm.With(testRequestId, testSecretType).GetLatestVersion(context.Background(), testSecretType)
-	require.Equal(t, result, testPayload)
+	// Retrieve the testPayload
+	testResult, err := sm.With(testRequestId, testSecretType).GetLatestVersion(testContext, testSecretType)
+	require.Equal(t, testResult, testPayload)
 	require.NoError(t, err)
 
-	// delete the secret
-	require.NoError(t, sm.With(testRequestId, testSecretType).DeleteSecret(context.Background(), testSecretType))
+	// Create a serializer to read in the retrieved payload
+	var archive *trust.Serializer
+	archive, err = trust.NewSerializer(true, testPassword, trust.CompressionZIP)
+	require.NoError(t, err)
 
+	// Write the cert to a temp file
+	require.NoError(t, ioutil.WriteFile(tempFile, testResult, 0777))
+
+	// Create provider to read in the bytes of the zipfile
+	var provider *trust.Provider
+	provider, err = archive.ReadFile(tempFile)
+	require.NoError(t, err)
+
+	// Delete the temporary file now that we're done with it
+	require.NoError(t, os.Remove(tempFile))
+
+	// Verify that the leaves of the retrieved cert can be extracted
+	var cert *x509.Certificate
+	cert, err = provider.GetLeafCertificate()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+
+	// Delete the secret
+	require.NoError(t, sm.With(testRequestId, testSecretType).DeleteSecret(testContext, testSecretType))
 }

--- a/pkg/gds/server.go
+++ b/pkg/gds/server.go
@@ -227,12 +227,12 @@ func (s *Server) Register(ctx context.Context, in *api.RegisterRequest) (out *ap
 
 	// Make a new secret of type "password"
 	secretType := "password"
-	if err = s.secret.With(certRequest.Id, secretType).CreateSecret(ctx, secretType); err != nil {
+	if err = s.secret.With(certRequest.Id).CreateSecret(ctx, secretType); err != nil {
 		log.Error().Err(err).Msg("could not create new secret on registration")
 		out.Error = &api.Error{Code: 500, Message: "internal error with registration, please contact admins"}
 		return out, nil
 	}
-	if err = s.secret.With(certRequest.Id, secretType).AddSecretVersion(ctx, secretType, []byte(password)); err != nil {
+	if err = s.secret.With(certRequest.Id).AddSecretVersion(ctx, secretType, []byte(password)); err != nil {
 		log.Error().Err(err).Msg("unable to add secret version on registration")
 		out.Error = &api.Error{Code: 500, Message: "internal error during registration, please contact admins"}
 		return out, nil


### PR DESCRIPTION
In #14 we introduced the new secret package, which allowed us to refactor the password storage and retrieval process to Google Secret Manager for consistency across projects. 

In this PR, I have similarly updated the certificate storage to store zipped certificates directly to Secret Manager as bytes. The only catch is that as currently implemented, the TRISA trust package requires that zipped certificates be [read in as files from disk](https://github.com/trisacrypto/trisa/issues/51); so the tests added to validate that cert storage is working as expected leverage an intermediate temporary file write/delete.  

In the process of working on this PR, I also experimented more with the Google Secret Manager API to see what other kinds of errors can arise; the main one that I think we want to capture is the file size limit error (`rpc error: code = InvalidArgument desc = Secret payload data length must be at most [65536] bytes.`), now that we'll be storing the zipped certificates. The limit is 65KiB (or 64KiB, [depending on where you look](https://cloud.google.com/secret-manager/quotas)), so we probably won't hit it, but I've added a new error code to `secret.go` to try to catch this just in case.

Closes #11