### PR TITLE
Remove bang from token special characters

### DIFF
--- a/pkg/gds/secret.go
+++ b/pkg/gds/secret.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	chars                = []rune("ABCDEFGHIJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz1234567890")
-	specialChars         = []rune("!#$%&()*+-<=>?@[]^_{|}~")
+	specialChars         = []rune("#$%&()*+-<=>?@[]^_{|}~")
 	ErrSecretNotFound    = errors.New("could not add secret version - not found")
 	ErrFileSizeLimit     = errors.New("could not add secret version - file size exceeds limit")
 	ErrPermissionsDenied = errors.New("could not add secret version - permissions denied at project level")


### PR DESCRIPTION
Removes the bang character from the token generation function for creating pkcs12 passwords, which was causing an issue on the command line since bang wasn't getting escaped.