### PR TITLE
Implements JSON logging with GCP severity

### DIFF
--- a/pkg/gds/config/config.go
+++ b/pkg/gds/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DatabaseURL string          `split_words:"true" required:"true"`
 	Maintenance bool            `split_words:"true" default:"false"`
 	LogLevel    LogLevelDecoder `split_words:"true" default:"info"`
+	ConsoleLog  bool            `split_words:"true" default:"false"`
 	Sectigo     SectigoConfig
 	Email       EmailConfig
 	CertMan     CertManConfig

--- a/pkg/gds/logger/logger.go
+++ b/pkg/gds/logger/logger.go
@@ -1,0 +1,40 @@
+package logger
+
+import "github.com/rs/zerolog"
+
+type severityGCP string
+
+const (
+	GCPAlertLevel    severityGCP = "ALERT"
+	GCPCriticalLevel severityGCP = "CRITICAL"
+	GCPErrorLevel    severityGCP = "ERROR"
+	GCPWarningLevel  severityGCP = "WARNING"
+	GCPInfoLevel     severityGCP = "INFO"
+	GCPDebugLevel    severityGCP = "DEBUG"
+
+	GCPFieldKeySeverity = "severity"
+	GCPFIeldKeyMsg      = "message"
+	GCPFieldKeyTime     = "time"
+)
+
+var (
+	zerologToGCPLevel = map[zerolog.Level]severityGCP{
+		zerolog.PanicLevel: GCPAlertLevel,
+		zerolog.FatalLevel: GCPCriticalLevel,
+		zerolog.ErrorLevel: GCPErrorLevel,
+		zerolog.WarnLevel:  GCPWarningLevel,
+		zerolog.InfoLevel:  GCPInfoLevel,
+		zerolog.DebugLevel: GCPDebugLevel,
+		zerolog.TraceLevel: GCPDebugLevel,
+	}
+)
+
+// SeverityHook adds GCP severity levels to zerolog output log messages.
+type SeverityHook struct{}
+
+// Run implements the zerolog.Hook interface.
+func (h SeverityHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+	if level != zerolog.NoLevel {
+		e.Str("severity", string(zerologToGCPLevel[level]))
+	}
+}

--- a/pkg/gds/logger/logger.go
+++ b/pkg/gds/logger/logger.go
@@ -13,7 +13,7 @@ const (
 	GCPDebugLevel    severityGCP = "DEBUG"
 
 	GCPFieldKeySeverity = "severity"
-	GCPFIeldKeyMsg      = "message"
+	GCPFieldKeyMsg      = "message"
 	GCPFieldKeyTime     = "time"
 )
 

--- a/pkg/gds/server.go
+++ b/pkg/gds/server.go
@@ -33,7 +33,7 @@ func init() {
 	// Initialize zerolog with GCP logging requirements
 	zerolog.TimeFieldFormat = time.RFC3339
 	zerolog.TimestampFieldName = logger.GCPFieldKeyTime
-	zerolog.MessageFieldName = logger.GCPFIeldKeyMsg
+	zerolog.MessageFieldName = logger.GCPFieldKeyMsg
 
 	// Add the severity hook for GCP logging
 	var gcpHook logger.SeverityHook

--- a/pkg/gds/server.go
+++ b/pkg/gds/server.go
@@ -15,6 +15,7 @@ import (
 	admin "github.com/trisacrypto/directory/pkg/gds/admin/v1"
 	"github.com/trisacrypto/directory/pkg/gds/config"
 	"github.com/trisacrypto/directory/pkg/gds/emails"
+	"github.com/trisacrypto/directory/pkg/gds/logger"
 	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	"github.com/trisacrypto/directory/pkg/gds/store"
 	"github.com/trisacrypto/directory/pkg/sectigo"
@@ -28,6 +29,15 @@ import (
 func init() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	// Initialize zerolog with GCP logging requirements
+	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.TimestampFieldName = logger.GCPFieldKeyTime
+	zerolog.MessageFieldName = logger.GCPFIeldKeyMsg
+
+	// Add the severity hook for GCP logging
+	var gcpHook logger.SeverityHook
+	log.Logger = zerolog.New(os.Stdout).Hook(gcpHook).With().Timestamp().Logger()
 }
 
 // New creates a TRISA Directory Service with the specified configuration and prepares
@@ -42,6 +52,11 @@ func New(conf config.Config) (s *Server, err error) {
 
 	// Set the global level
 	zerolog.SetGlobalLevel(zerolog.Level(conf.LogLevel))
+
+	// Set human readable logging if specified
+	if conf.ConsoleLog {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	}
 
 	// Create the server and open the connection to the database
 	s = &Server{conf: conf, echan: make(chan error, 1)}


### PR DESCRIPTION
By default GDS now emits JSON formatted logs for parsing in a cloud
console. This PR also adds GCP severity levels for GCP-specific parsing
of logs. The logger is added to its own module so other cloud-specific
handlers can be added as needed.

Fixes #33