### PR TITLE
Better contact handling in email client senders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.82.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.2.0
 	github.com/joho/godotenv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/gds/certs.go
+++ b/pkg/gds/certs.go
@@ -327,7 +327,9 @@ func (s *Server) downloadCertificateRequest(r *models.CertificateRequest) {
 
 	// Email the certificates to the technical contacts
 	if err = s.email.SendDeliverCertificates(vasp, path); err != nil {
+		// If there is an error delivering emails, return here so we don't mark as completed
 		log.Error().Err(err).Msg("could not deliver certificates to technical contact")
+		return
 	}
 
 	// Mark certificate request as complete.

--- a/pkg/gds/emails/client_test.go
+++ b/pkg/gds/emails/client_test.go
@@ -1,0 +1,63 @@
+package emails_test
+
+import (
+	"net/mail"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/joho/godotenv"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/config"
+	"github.com/trisacrypto/directory/pkg/gds/emails"
+	"github.com/trisacrypto/directory/pkg/gds/models/v1"
+	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
+)
+
+func TestClientSendEmails(t *testing.T) {
+	// NOTE: if you place a .env file in this directory alongside the test file, it
+	// will be read, making it simpler to run tests and set environment variables.
+	godotenv.Load()
+
+	if os.Getenv("GDS_TEST_SENDING_CLIENT_EMAILS") == "" {
+		t.Skip("skip client send emails test")
+	}
+
+	// This test uses the environment to send rendered emails with context specific
+	// emails - this is to test the rendering of the emails with data only; it does not
+	// go through any of the server workflow for generating tokens, etc.
+	var conf config.EmailConfig
+	err := envconfig.Process("gds", &conf)
+	require.NoError(t, err)
+
+	// This test sends emails from the serviceEmail using SendGrid to the adminsEmail
+	email, err := emails.New(conf)
+	require.NoError(t, err)
+
+	receipient, err := mail.ParseAddress(conf.AdminEmail)
+	require.NoError(t, err)
+
+	vasp := &pb.VASP{
+		Id:            uuid.NewString(),
+		CommonName:    "test.example.com",
+		TrisaEndpoint: "test.example.com:443",
+		Contacts: &pb.Contacts{
+			Technical: &pb.Contact{
+				Name:  receipient.Name,
+				Email: receipient.Address,
+			},
+		},
+		IdentityCertificate: &pb.Certificate{
+			SerialNumber: []byte("notarealcertificate"),
+		},
+	}
+
+	err = models.SetContactVerification(vasp.Contacts.Technical, "", true)
+	require.NoError(t, err)
+
+	require.NoError(t, email.SendVerifyContacts(vasp))
+	require.NoError(t, email.SendReviewRequest(vasp))
+	require.NoError(t, email.SendRejectRegistration(vasp, "this is a test rejection from the test runner"))
+	require.NoError(t, email.SendDeliverCertificates(vasp, "testdata/foo.zip"))
+}

--- a/pkg/gds/emails/emails_test.go
+++ b/pkg/gds/emails/emails_test.go
@@ -74,11 +74,13 @@ func TestVerifyContactURL(t *testing.T) {
 }
 
 func TestSendEmails(t *testing.T) {
+	// NOTE: if you place a .env file in this directory alongside the test file, it
+	// will be read, making it simpler to run tests and set environment variables.
+	godotenv.Load()
+
 	if os.Getenv("GDS_TEST_SENDING_EMAILS") == "" {
 		t.Skip("skip generate and send emails test")
 	}
-
-	godotenv.Load()
 
 	// This test uses the environment to send rendered emails with context specific
 	// emails - this is to test the rendering of the emails with data only; it does not

--- a/pkg/gds/emails/templates/review_request.html
+++ b/pkg/gds/emails/templates/review_request.html
@@ -3,7 +3,7 @@
 <p>We have received a new TRISA Global Directory registration request from a VASP that
 needs to be reviewed. The requestor has verified their email address(es) and received a
 PKCS12 password to decrypt a certificate which will be generated only if you approve this
-request. The request JSON is:</p>
+request. The request YAML is:</p>
 
 <pre>{{ .Request }}</pre>
 

--- a/pkg/gds/emails/templates/review_request.txt
+++ b/pkg/gds/emails/templates/review_request.txt
@@ -3,7 +3,7 @@ Hello TRISA Admins,
 We have received a new TRISA Global Directory registration request from a VASP that
 needs to be reviewed. The requestor has verified their email address(es) and received a
 PKCS12 password to decrypt a certificate which will be generated only if you approve this
-request. The request JSON is:
+request. The request YAML is:
 
 {{ .Request }}
 


### PR DESCRIPTION
Performs better handling of sending emails to technical, admin, billing,
and legal contacts. First, a check is added to ensure the contact is not
nil and that it has an email address, otherwise it is skipped. Sending
does not stop on the first error, but all email addresses are tried to
make sure at least one email can get out. The number of errors are
reported via logging rather than returned. If no messages were delivered
then the function returns an error.

This PR also updates the Registration Review email to be nicely rendered
YAML with string enums and no empty fields.

Fixes #31
Fixes #32