### PR TITLE
Reindex and gzip index sync without DB in maintenance mode

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -265,7 +265,7 @@ func load(c *cli.Context) (err error) {
 	}
 
 	var db store.Store
-	if db, err = store.Open(dsn); err != nil {
+	if db, err = store.Open(config.DatabaseConfig{URL: dsn}); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	defer db.Close()

--- a/pkg/gds/config/config.go
+++ b/pkg/gds/config/config.go
@@ -15,16 +15,21 @@ type Config struct {
 	BindAddr    string          `split_words:"true" default:":4433"`
 	DirectoryID string          `split_words:"true" default:"vaspdirectory.net"`
 	SecretKey   string          `split_words:"true" required:"true"`
-	DatabaseURL string          `split_words:"true" required:"true"`
 	Maintenance bool            `split_words:"true" default:"false"`
 	LogLevel    LogLevelDecoder `split_words:"true" default:"info"`
 	ConsoleLog  bool            `split_words:"true" default:"false"`
+	Database    DatabaseConfig
 	Sectigo     SectigoConfig
 	Email       EmailConfig
 	CertMan     CertManConfig
 	Backup      BackupConfig
 	Secrets     SecretsConfig
 	processed   bool
+}
+
+type DatabaseConfig struct {
+	URL           string `split_words:"true" required:"true"`
+	ReindexOnBoot bool   `split_words:"true" default:"false"`
 }
 
 type SectigoConfig struct {

--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -11,21 +11,25 @@ import (
 )
 
 var testEnv = map[string]string{
+	"GDS_MAINTENANCE":                "false",
 	"GDS_BIND_ADDR":                  ":443",
-	"GDS_DATABASE_URL":               "fixtures/db",
-	"SECTIGO_USERNAME":               "foo",
-	"SECTIGO_PASSWORD":               "supersecret",
-	"SENDGRID_API_KEY":               "bar1234",
-	"GDS_SERVICE_EMAIL":              "test@example.com",
-	"GDS_ADMIN_EMAIL":                "admin@example.com",
-	"GDS_LOG_LEVEL":                  "debug",
 	"GDS_DIRECTORY_ID":               "testdirectory.org",
 	"GDS_SECRET_KEY":                 "theeaglefliesatmidnight",
+	"GDS_LOG_LEVEL":                  "debug",
+	"GDS_CONSOLE_LOG":                "true",
+	"GDS_DATABASE_URL":               "fixtures/db",
+	"GDS_DATABASE_REINDEX_ON_BOOT":   "false",
+	"SECTIGO_USERNAME":               "foo",
+	"SECTIGO_PASSWORD":               "supersecret",
+	"GDS_SERVICE_EMAIL":              "test@example.com",
+	"GDS_ADMIN_EMAIL":                "admin@example.com",
+	"SENDGRID_API_KEY":               "bar1234",
 	"GDS_CERTMAN_INTERVAL":           "60s",
 	"GDS_CERTMAN_STORAGE":            "fixtures/certs",
 	"GDS_BACKUP_ENABLED":             "true",
 	"GDS_BACKUP_INTERVAL":            "36h",
 	"GDS_BACKUP_STORAGE":             "fixtures/backups",
+	"GDS_BACKUP_KEEP":                "7",
 	"GOOGLE_APPLICATION_CREDENTIALS": "test.json",
 	"GOOGLE_PROJECT_NAME":            "test",
 }
@@ -48,21 +52,25 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test configuration set from the environment
+	require.Equal(t, false, conf.Maintenance)
 	require.Equal(t, testEnv["GDS_BIND_ADDR"], conf.BindAddr)
-	require.Equal(t, testEnv["GDS_DATABASE_URL"], conf.DatabaseURL)
-	require.Equal(t, testEnv["SECTIGO_USERNAME"], conf.Sectigo.Username)
-	require.Equal(t, testEnv["SECTIGO_PASSWORD"], conf.Sectigo.Password)
-	require.Equal(t, testEnv["SENDGRID_API_KEY"], conf.Email.SendGridAPIKey)
-	require.Equal(t, testEnv["GDS_SERVICE_EMAIL"], conf.Email.ServiceEmail)
-	require.Equal(t, testEnv["GDS_ADMIN_EMAIL"], conf.Email.AdminEmail)
-	require.Equal(t, zerolog.DebugLevel, conf.GetLogLevel())
 	require.Equal(t, testEnv["GDS_DIRECTORY_ID"], conf.DirectoryID)
 	require.Equal(t, testEnv["GDS_SECRET_KEY"], conf.SecretKey)
+	require.Equal(t, zerolog.DebugLevel, conf.GetLogLevel())
+	require.Equal(t, true, conf.ConsoleLog)
+	require.Equal(t, testEnv["GDS_DATABASE_URL"], conf.Database.URL)
+	require.Equal(t, false, conf.Database.ReindexOnBoot)
+	require.Equal(t, testEnv["SECTIGO_USERNAME"], conf.Sectigo.Username)
+	require.Equal(t, testEnv["SECTIGO_PASSWORD"], conf.Sectigo.Password)
+	require.Equal(t, testEnv["GDS_SERVICE_EMAIL"], conf.Email.ServiceEmail)
+	require.Equal(t, testEnv["GDS_ADMIN_EMAIL"], conf.Email.AdminEmail)
+	require.Equal(t, testEnv["SENDGRID_API_KEY"], conf.Email.SendGridAPIKey)
 	require.Equal(t, 1*time.Minute, conf.CertMan.Interval)
 	require.Equal(t, testEnv["GDS_CERTMAN_STORAGE"], conf.CertMan.Storage)
 	require.Equal(t, true, conf.Backup.Enabled)
 	require.Equal(t, 36*time.Hour, conf.Backup.Interval)
 	require.Equal(t, testEnv["GDS_BACKUP_STORAGE"], conf.Backup.Storage)
+	require.Equal(t, 7, conf.Backup.Keep)
 	require.Equal(t, testEnv["GOOGLE_APPLICATION_CREDENTIALS"], conf.Secrets.Credentials)
 	require.Equal(t, testEnv["GOOGLE_PROJECT_NAME"], conf.Secrets.Project)
 }
@@ -88,7 +96,7 @@ func TestRequiredConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test required configuration
-	require.Equal(t, testEnv["GDS_DATABASE_URL"], conf.DatabaseURL)
+	require.Equal(t, testEnv["GDS_DATABASE_URL"], conf.Database.URL)
 	require.Equal(t, testEnv["GDS_SECRET_KEY"], conf.SecretKey)
 }
 

--- a/pkg/gds/server.go
+++ b/pkg/gds/server.go
@@ -58,8 +58,15 @@ func New(conf config.Config) (s *Server, err error) {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
 
-	// Create the server and open the connection to the database
+	// Create the server and prepare to serve
 	s = &Server{conf: conf, echan: make(chan error, 1)}
+
+	if s.conf.Maintenance {
+		// Stop configuration at this point for maintenance mode (no error)
+		return s, nil
+	}
+
+	// Everything that follows here assumes we're not in maintenance mode.
 	if s.db, err = store.Open(conf.Database); err != nil {
 		return nil, err
 	}
@@ -115,14 +122,15 @@ func (s *Server) Serve() (err error) {
 		s.echan <- s.Shutdown()
 	}()
 
-	// Start the certificate manager go routine process
-	go s.CertManager()
-
-	// Start the backup manager go routine process
-	go s.BackupManager()
-
+	// Run management routines only if we're not in maintenance mode
 	if s.conf.Maintenance {
 		log.Warn().Msg("starting server in maintenance mode")
+	} else {
+		// Start the certificate manager go routine process
+		go s.CertManager()
+
+		// Start the backup manager go routine process
+		go s.BackupManager()
 	}
 
 	// Listen for TCP requests on the specified address and port
@@ -155,10 +163,15 @@ func (s *Server) Serve() (err error) {
 func (s *Server) Shutdown() (err error) {
 	log.Info().Msg("gracefully shutting down")
 	s.srv.GracefulStop()
-	if err = s.db.Close(); err != nil {
-		log.Error().Err(err).Msg("could not shutdown database")
-		return err
+
+	if !s.conf.Maintenance {
+		// Close the database correctly
+		if err = s.db.Close(); err != nil {
+			log.Error().Err(err).Msg("could not shutdown database")
+			return err
+		}
 	}
+
 	log.Debug().Msg("successful shutdown")
 	return nil
 }

--- a/pkg/gds/server.go
+++ b/pkg/gds/server.go
@@ -60,7 +60,7 @@ func New(conf config.Config) (s *Server, err error) {
 
 	// Create the server and open the connection to the database
 	s = &Server{conf: conf, echan: make(chan error, 1)}
-	if s.db, err = store.Open(conf.DatabaseURL); err != nil {
+	if s.db, err = store.Open(conf.Database); err != nil {
 		return nil, err
 	}
 

--- a/pkg/gds/store/leveldb/leveldb.go
+++ b/pkg/gds/store/leveldb/leveldb.go
@@ -207,8 +207,10 @@ func (s *Store) Update(v *pb.VASP) (err error) {
 
 	// Update indices to match new record, removing the old indices and updating the
 	// new indices with any changes to ensure the index correctly reflects the state.
-	// TODO: check errors from index removal in case the index must be reset.
-	s.removeIndices(o)
+	if err = s.removeIndices(o); err != nil {
+		// NOTE: if this error is triggered, admins may want to reindex the database
+		log.Error().Err(err).Msg("could not remove previous indices on update: reindex required")
+	}
 	if err = s.insertIndices(v); err != nil {
 		return err
 	}

--- a/pkg/gds/store/leveldb/leveldb.go
+++ b/pkg/gds/store/leveldb/leveldb.go
@@ -507,6 +507,11 @@ func (s *Store) Reindex() (err error) {
 // Backup copies the leveldb database to a new directory and archives it as gzip tar.
 // See: https://github.com/wbolster/plyvel/issues/46
 func (s *Store) Backup(path string) (err error) {
+	// Before backup ensure the indices are sync'd to disk
+	if err = s.sync(); err != nil {
+		return fmt.Errorf("could not syncrhonize indices prior to backup: %s", err)
+	}
+
 	// Create the directory for the copied leveldb database
 	archive := filepath.Join(path, time.Now().UTC().Format("gdsdb-200601021504"))
 	if err = os.Mkdir(archive, 0744); err != nil {

--- a/pkg/gds/store/store.go
+++ b/pkg/gds/store/store.go
@@ -42,7 +42,11 @@ func Open(conf config.DatabaseConfig) (s Store, err error) {
 
 	if conf.ReindexOnBoot {
 		if indexer, ok := s.(Indexer); ok {
-			indexer.Reindex()
+			if err = indexer.Reindex(); err != nil {
+				// NOTE: the database is not closed here, so if reindexing fails,
+				// something very bad might have occurred and the server should stop.
+				return nil, err
+			}
 			log.Info().Str("scheme", dsn.Scheme).Msg("store reindexed")
 		} else {
 			log.Warn().Str("scheme", dsn.Scheme).Msg("store is not an indexer - skipping reindex")

--- a/pkg/gds/store/store.go
+++ b/pkg/gds/store/store.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/directory/pkg/gds/config"
 	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	"github.com/trisacrypto/directory/pkg/gds/store/leveldb"
 	"github.com/trisacrypto/directory/pkg/gds/store/sqlite"
@@ -19,20 +21,34 @@ import (
 // specify protocol+transport://user:pass@host/dbname?opt1=a&opt2=b for servers or
 // protocol:///relative/path/to/file for embedded databases (for absolute paths, specify
 // protocol:////absolute/path/to/file).
-func Open(uri string) (_ Store, err error) {
+func Open(conf config.DatabaseConfig) (s Store, err error) {
 	var dsn *DSN
-	if dsn, err = ParseDSN(uri); err != nil {
+	if dsn, err = ParseDSN(conf.URL); err != nil {
 		return nil, err
 	}
 
 	switch dsn.Scheme {
 	case "leveldb":
-		return leveldb.Open(dsn.Path)
+		if s, err = leveldb.Open(dsn.Path); err != nil {
+			return nil, err
+		}
 	case "sqlite", "sqlite3":
-		return sqlite.Open(dsn.Path)
+		if s, err = sqlite.Open(dsn.Path); err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("unhandled database scheme %q", dsn.Scheme)
 	}
+
+	if conf.ReindexOnBoot {
+		if indexer, ok := s.(Indexer); ok {
+			indexer.Reindex()
+			log.Info().Str("scheme", dsn.Scheme).Msg("store reindexed")
+		} else {
+			log.Warn().Str("scheme", dsn.Scheme).Msg("store is not an indexer - skipping reindex")
+		}
+	}
+	return s, nil
 }
 
 // Store provides an interface for directory storage services to abstract the underlying


### PR DESCRIPTION
This PR more intelligently handles leveldb indices and reindexing by allowing a configuration that forces reindex on boot and creates a maintenance mode that allows database interactions from the command line. 

Updates the database configuration to accept a bool for reindexing on
boot and the store reindexes if necessary on open. Adds a call to sync
to on Backup so that the indices are resync'd routinely.

Fixes #30

This commit enables more compact LevelDB indices by compressing them
before writing them to disk. However, this requires deleting old indices
and regenerating them. To facilitate this, during maintenance mode, the
database no longer opens a connection to the database or runs any
management processes. This will allow us to ssh into the server and
access the database as needed to perform any changes.

Fixes #47

**Warning: Before Deployment a Maintenance Mode is Required to Delete Old Indices!!**