### PR TITLE
Better object management

### DIFF
--- a/cmd/gdsutil/main.go
+++ b/cmd/gdsutil/main.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +27,7 @@ import (
 	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	"github.com/trisacrypto/directory/pkg/gds/peers/v1"
 	"github.com/trisacrypto/directory/pkg/gds/store"
+	"github.com/trisacrypto/directory/pkg/gds/store/wire"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
@@ -58,8 +57,8 @@ func main() {
 					EnvVar: "GDS_DATABASE_URL",
 				},
 				cli.BoolFlag{
-					Name:  "s, stringify",
-					Usage: "stringify keys otherwise they are base64 encoded",
+					Name:  "b, b64encode",
+					Usage: "base64 encode keys (otherwise they will be utf-8 decoded)",
 				},
 				cli.StringFlag{
 					Name:  "p, prefix",
@@ -288,17 +287,7 @@ func main() {
 // LevelDB Actions
 //===========================================================================
 
-var (
-	ldb            *leveldb.DB
-	vaspPrefix     = []byte("vasps::")
-	certreqsPrefix = []byte("certreqs::")
-	// replicaPrefix  = []byte("peers::")
-	indexPrefix    = []byte("index::")
-	sequencePrefix = []byte("sequence::")
-	indexNames     = []byte("index::names")
-	indexCountries = []byte("index::countries")
-	sequencePK     = []byte("sequence::pks")
-)
+var ldb *leveldb.DB
 
 func ldbKeys(c *cli.Context) (err error) {
 	defer ldb.Close()
@@ -311,13 +300,9 @@ func ldbKeys(c *cli.Context) (err error) {
 	iter := ldb.NewIterator(prefix, nil)
 	defer iter.Release()
 
-	stringify := c.Bool("stringify")
+	b64encode := c.Bool("b64encode")
 	for iter.Next() {
-		if stringify {
-			fmt.Printf("- %s\n", string(iter.Key()))
-		} else {
-			fmt.Printf("- %s\n", base64.RawStdEncoding.EncodeToString(iter.Key()))
-		}
+		fmt.Printf("- %s\n", wire.EncodeKey(iter.Key(), b64encode))
 	}
 
 	if err = iter.Error(); err != nil {
@@ -335,7 +320,7 @@ func ldbGet(c *cli.Context) (err error) {
 		// Check that out is a directory
 		var info fs.FileInfo
 		if info, err = os.Stat(out); err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.NewExitError("specify an existing, writeable directory to output files to", 1)
 		}
 		if !info.IsDir() {
 			return cli.NewExitError("specify a directory to write files out to", 1)
@@ -345,12 +330,8 @@ func ldbGet(c *cli.Context) (err error) {
 	b64decode := c.Bool("b64decode")
 	for _, keys := range c.Args() {
 		var key []byte
-		if b64decode {
-			if key, err = base64.RawStdEncoding.DecodeString(keys); err != nil {
-				return cli.NewExitError(err, 1)
-			}
-		} else {
-			key = []byte(keys)
+		if key, err = wire.DecodeKey(keys, b64decode); err != nil {
+			return cli.NewExitError(fmt.Errorf("could not decode key: %s", err), 1)
 		}
 
 		var data []byte
@@ -364,47 +345,32 @@ func ldbGet(c *cli.Context) (err error) {
 			pbValue   proto.Message
 		)
 
-		// Determine how to unmarshal the data
-		if bytes.HasPrefix(key, vaspPrefix) {
-			vasp := new(pb.VASP)
-			if err = proto.Unmarshal(data, vasp); err != nil {
+		prefix := strings.Split(keys, "::")[0]
+		switch prefix {
+		case store.NamespaceVASPs, store.NamespaceCertReqs, store.NamespaceReplicas:
+			if pbValue, err = wire.UnmarshalProto(prefix, data); err != nil {
 				return cli.NewExitError(err, 1)
 			}
-			pbValue = vasp
-		} else if bytes.HasPrefix(key, certreqsPrefix) {
-			careq := new(models.CertificateRequest)
-			if err = proto.Unmarshal(data, careq); err != nil {
+		case store.NamespaceIndices:
+			if jsonValue, err = wire.UnmarshalIndex(data); err != nil {
 				return cli.NewExitError(err, 1)
 			}
-			pbValue = careq
-		} else if bytes.Equal(key, indexNames) {
-			jsonValue = make(map[string]string)
-			if err = unmarshalGZJSON(data, &jsonValue); err != nil {
+		case store.NamespaceSequence:
+			if jsonValue, err = wire.UnmarshalSequence(data); err != nil {
 				return cli.NewExitError(err, 1)
 			}
-		} else if bytes.Equal(key, indexCountries) {
-			jsonValue = make(map[string][]string)
-			if err = unmarshalGZJSON(data, &jsonValue); err != nil {
-				return cli.NewExitError(err, 1)
-			}
-		} else if bytes.HasPrefix(key, sequencePrefix) {
-			pk, n := binary.Uvarint(data)
-			if n <= 0 {
-				return cli.NewExitError("could not parse sequence", 1)
-			}
-			jsonValue = pk
-		} else {
-			return cli.NewExitError("could not determine unmarshal type", 1)
+		default:
+			fmt.Fprintf(os.Stderr, "warning: cannot unmarshal unknown namespace %q, printing raw data\n", prefix)
 		}
 
-		// Marshal JSON representation
+		// Marshal JSON representation for pretty-printing
 		var outdata []byte
-		if jsonValue != nil {
+		switch {
+		case jsonValue != nil:
 			if outdata, err = json.MarshalIndent(jsonValue, "", "  "); err != nil {
 				return cli.NewExitError(err, 1)
 			}
-		}
-		if pbValue != nil {
+		case pbValue != nil:
 			jsonpb := protojson.MarshalOptions{
 				Multiline:       true,
 				Indent:          "  ",
@@ -416,6 +382,8 @@ func ldbGet(c *cli.Context) (err error) {
 			if outdata, err = jsonpb.Marshal(pbValue); err != nil {
 				return cli.NewExitError(err, 1)
 			}
+		default:
+			outdata = data
 		}
 
 		if out != "" {
@@ -494,77 +462,23 @@ func ldbPut(c *cli.Context) (err error) {
 	// Unmarshal the thing from data then
 	// Marshal the database representation
 	if format != "raw" && format != "bytes" {
-		jsonpb := &protojson.UnmarshalOptions{
-			AllowPartial:   true,
-			DiscardUnknown: true,
+		// Prefix is required on key to determine how to unmarshal the data
+		prefix := strings.Split(string(key), "::")[0]
+		switch format {
+		case "json":
+			if value, err = wire.RemarshalJSON(prefix, data); err != nil {
+				return cli.NewExitError(err, 1)
+			}
+		case "pb", "proto", "protobuf":
+			// Check if the protocol buffers can be unmarshaled; if so, the data is good to go
+			if _, err = wire.UnmarshalProto(prefix, data); err != nil {
+				return cli.NewExitError(err, 1)
+			}
+			value = data
+		default:
+			return cli.NewExitError("unknown format: specify raw, bytes, json, or proto", 1)
 		}
 
-		if bytes.HasPrefix(key, vaspPrefix) {
-			vasp := new(pb.VASP)
-			switch format {
-			case "json":
-				if err = jsonpb.Unmarshal(data, vasp); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-				if value, err = proto.Marshal(vasp); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-			case "pb", "proto", "protobuf":
-				if err = proto.Unmarshal(data, vasp); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-				value = data
-			default:
-				return cli.NewExitError(fmt.Errorf("cannot unmarshal VASP format %q", format), 1)
-			}
-
-		} else if bytes.HasPrefix(key, certreqsPrefix) {
-			careq := new(models.CertificateRequest)
-			switch format {
-			case "json":
-				if err = jsonpb.Unmarshal(data, careq); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-				if value, err = proto.Marshal(careq); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-			case "pb", "proto", "protobuf":
-				if err = proto.Unmarshal(data, careq); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-				value = data
-			default:
-				return cli.NewExitError(fmt.Errorf("cannot unmarshal Certificate Request format %q", format), 1)
-			}
-		} else if bytes.HasPrefix(key, indexPrefix) {
-			switch format {
-			case "json":
-				// gzip compress the index data
-				buf := &bytes.Buffer{}
-				gz := gzip.NewWriter(buf)
-				if _, err = gz.Write(data); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-				value = buf.Bytes()
-			default:
-				return cli.NewExitError(fmt.Errorf("cannot unmarshal index format %q", format), 1)
-			}
-		} else if bytes.Equal(key, sequencePK) {
-			switch format {
-			case "json":
-				var pk uint64
-				if err = json.Unmarshal(data, &pk); err != nil {
-					return cli.NewExitError(err, 1)
-				}
-				value = make([]byte, binary.MaxVarintLen64)
-				binary.PutUvarint(value, pk)
-			default:
-				return cli.NewExitError(fmt.Errorf("cannot unmarshal sequence format %q", format), 1)
-			}
-
-		} else {
-			return cli.NewExitError("could not determine unmarshal type from key", 1)
-		}
 	} else {
 		// Raw or bytes data is just the data
 		value = data
@@ -591,12 +505,8 @@ func ldbDelete(c *cli.Context) (err error) {
 	b64decode := c.Bool("b64decode")
 	for _, keys := range c.Args() {
 		var key []byte
-		if b64decode {
-			if key, err = base64.RawStdEncoding.DecodeString(keys); err != nil {
-				return cli.NewExitError(err, 1)
-			}
-		} else {
-			key = []byte(keys)
+		if key, err = wire.DecodeKey(keys, b64decode); err != nil {
+			return cli.NewExitError(err, 1)
 		}
 
 		if err = ldb.Delete(key, nil); err != nil {
@@ -638,33 +548,6 @@ func isFile(path string) bool {
 		return !os.IsNotExist(err)
 	}
 	return fi.Mode().IsRegular()
-}
-
-func unmarshalGZJSON(data []byte, val interface{}) (err error) {
-	buf := bytes.NewBuffer(data)
-	var gz *gzip.Reader
-	if gz, err = gzip.NewReader(buf); err != nil {
-		return fmt.Errorf("could not decompress data: %s", err)
-	}
-	decoder := json.NewDecoder(gz)
-	if err = decoder.Decode(&val); err != nil {
-		return fmt.Errorf("could not decode json data: %s", err)
-	}
-	return nil
-}
-
-//lint:ignore U1000 leaving this function to pair with unmarshalGZJSON in the future
-func marshalGZJSON(val interface{}) (data []byte, err error) {
-	var buf *bytes.Buffer
-	gz := gzip.NewWriter(buf)
-	encoder := json.NewEncoder(gz)
-	if err = encoder.Encode(val); err != nil {
-		return data, fmt.Errorf("could not encode data: %s", err)
-	}
-	if err = gz.Close(); err != nil {
-		return data, fmt.Errorf("could not compress data: %s", err)
-	}
-	return buf.Bytes(), nil
 }
 
 //===========================================================================

--- a/pkg/gds/store/store.go
+++ b/pkg/gds/store/store.go
@@ -52,6 +52,7 @@ const (
 	NamespaceCertReqs = "certreqs"
 	NamespaceReplicas = "peers"
 	NamespaceIndices  = "index"
+	NamespaceSequence = "sequence"
 )
 
 // Namespaces defines all possible namespaces that GDS manages

--- a/pkg/gds/store/wire/testdata/certreqs::87657b4d-e72c-4526-9332-c8fc56adb367.json
+++ b/pkg/gds/store/wire/testdata/certreqs::87657b4d-e72c-4526-9332-c8fc56adb367.json
@@ -1,0 +1,36 @@
+{
+  "id":  "87657b4d-e72c-4526-9332-c8fc56adb367",
+  "owner":  "838b1f57-1646-488d-a231-d71d88681cfa",
+  "vasp":  "api.bob.vaspbot.net",
+  "common_name":  "",
+  "status":  23,
+  "authority_id":  "1234",
+  "batch_id":  "0",
+  "batch_name":  "READY_FOR_DOWNLOAD",
+  "batch_status":  "",
+  "order_number":  "0",
+  "creation_date":  "",
+  "profile":  "TEST PROFILE",
+  "reject_reason":  "",
+  "created":  "2021-01-27T18:26:37Z",
+  "modified":  "2021-01-27T18:30:57Z",
+  "deleted":  "",
+  "metadata":  {
+    "key":  "certreqs::87657b4d-e72c-4526-9332-c8fc56adb367",
+    "namespace":  "certreqs",
+    "version":  {
+      "pid":  "8",
+      "version":  "3",
+      "region":  "localhost",
+      "parent":  {
+        "pid":  "0",
+        "version":  "2",
+        "region":  "",
+        "parent":  null
+      }
+    },
+    "region":  "localhost",
+    "owner":  "8:frontier",
+    "data":  null
+  }
+}

--- a/pkg/gds/store/wire/testdata/index::categories.json
+++ b/pkg/gds/store/wire/testdata/index::categories.json
@@ -1,0 +1,27 @@
+{
+  "business_entity": [
+    "84e60a41-37b2-4d52-bfa5-b2af8da7eae7",
+    "99917cee-31cb-43a9-86c9-44e29cbb3a1a"
+  ],
+  "exchange": [
+    "99917cee-31cb-43a9-86c9-44e29cbb3a1a",
+    "dd9ad626-b68f-47cd-a1fc-ae3a0ca371be",
+    "d42e6807-3835-49da-9a07-5ef5f445383d",
+    "838b1f57-1646-488d-a231-d71d88681cfa"
+  ],
+  "individual": [
+    "84e60a41-37b2-4d52-bfa5-b2af8da7eae7",
+    "a91d6094-9b88-4d5f-91ed-1f1d0407b75d"
+  ],
+  "non_commercial_entity": [
+    "a91d6094-9b88-4d5f-91ed-1f1d0407b75d"
+  ],
+  "other": [
+    "84e60a41-37b2-4d52-bfa5-b2af8da7eae7"
+  ],
+  "private_organization": [
+    "dd9ad626-b68f-47cd-a1fc-ae3a0ca371be",
+    "d42e6807-3835-49da-9a07-5ef5f445383d",
+    "838b1f57-1646-488d-a231-d71d88681cfa"
+  ]
+}

--- a/pkg/gds/store/wire/testdata/index::names.json
+++ b/pkg/gds/store/wire/testdata/index::names.json
@@ -1,0 +1,10 @@
+{
+  "alice vasp": "227b9424-3c2d-421a-9cf0-25878ab93016",
+  "alicecoin": "227b9424-3c2d-421a-9cf0-25878ab93016",
+  "alicecoin, inc.": "227b9424-3c2d-421a-9cf0-25878ab93016",
+  "api.alice.vaspbot.net": "227b9424-3c2d-421a-9cf0-25878ab93016",
+  "api.bob.vaspbot.net": "838b1f57-1646-488d-a231-d71d88681cfa",
+  "api.test123456.vaspbot.net": "0fa1872d-1786-4733-b26b-c518ec075182",
+  "bob vasp": "838b1f57-1646-488d-a231-d71d88681cfa",
+  "bob's discount vasp, plc": "838b1f57-1646-488d-a231-d71d88681cfa"
+}

--- a/pkg/gds/store/wire/testdata/peers::8.json
+++ b/pkg/gds/store/wire/testdata/peers::8.json
@@ -1,0 +1,23 @@
+{
+    "id": 8,
+    "addr": "localhost:4435",
+    "name": "frontier",
+    "region": "localhost",
+    "created": "2021-07-07T18:57:21-04:00",
+    "modified": "2021-07-07T18:57:21-04:00",
+    "deleted": "",
+    "extra": {},
+    "metadata": {
+      "key":  "peers::8",
+      "namespace":  "peers",
+      "version":  {
+        "pid":  "8",
+        "version":  "1",
+        "region":  "localhost",
+        "parent":  {}
+      },
+      "region":  "localhost",
+      "owner":  "8:frontier",
+      "data":  null
+    }
+}

--- a/pkg/gds/store/wire/testdata/vasps::838b1f57-1646-488d-a231-d71d88681cfa.json
+++ b/pkg/gds/store/wire/testdata/vasps::838b1f57-1646-488d-a231-d71d88681cfa.json
@@ -1,0 +1,185 @@
+{
+  "id":  "838b1f57-1646-488d-a231-d71d88681cfa",
+  "registered_directory":  "vaspdirectory.net",
+  "entity":  {
+    "name":  {
+      "name_identifiers":  [
+        {
+          "legal_person_name":  "Bob's Discount VASP, PLC",
+          "legal_person_name_identifier_type":  "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
+        },
+        {
+          "legal_person_name":  "Bob VASP",
+          "legal_person_name_identifier_type":  "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
+        }
+      ],
+      "local_name_identifiers":  [],
+      "phonetic_name_identifiers":  []
+    },
+    "geographic_addresses":  [
+      {
+        "address_type":  "ADDRESS_TYPE_CODE_BIZZ",
+        "department":  "",
+        "sub_department":  "",
+        "street_name":  "Grimsby Road",
+        "building_number":  "762",
+        "building_name":  "",
+        "floor":  "",
+        "post_box":  "",
+        "room":  "",
+        "post_code":  "OX8 U89",
+        "town_name":  "Oxford",
+        "town_location_name":  "",
+        "district_name":  "",
+        "country_sub_division":  "",
+        "address_line":  [],
+        "country":  "GB"
+      }
+    ],
+    "customer_number":  "",
+    "national_identification":  {
+      "national_identifier":  "213800AQUAUP6I215N33",
+      "national_identifier_type":  "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
+      "country_of_issue":  "GB",
+      "registration_authority":  "RA000589"
+    },
+    "country_of_registration":  "GB"
+  },
+  "contacts":  {
+    "technical":  {
+      "name":  "TRISA Support",
+      "email":  "support@trisa.io",
+      "phone":  "",
+      "person":  null,
+      "extra":  {
+        "@type":  "type.googleapis.com/gds.models.v1.GDSContactExtraData",
+        "verified":  true,
+        "token":  ""
+      }
+    },
+    "administrative":  {
+      "name":  "TRISA Admin",
+      "email":  "admin@trisa.io",
+      "phone":  "",
+      "person":  null,
+      "extra":  {
+        "@type":  "type.googleapis.com/gds.models.v1.GDSContactExtraData",
+        "verified":  true,
+        "token":  ""
+      }
+    },
+    "legal":  null,
+    "billing":  null
+  },
+  "identity_certificate":  {
+    "version":  "3",
+    "serial_number":  "",
+    "signature":  "",
+    "signature_algorithm":  "SHA384-RSA",
+    "public_key_algorithm":  "RSA",
+    "subject":  {
+      "common_name":  "api.bob.vaspbot.net",
+      "serial_number":  "",
+      "organization":  [
+        "CipherTrace Inc"
+      ],
+      "organizational_unit":  [],
+      "street_address":  [],
+      "locality":  [
+        "Menlo Park"
+      ],
+      "province":  [
+        "California"
+      ],
+      "postal_code":  [],
+      "country":  [
+        "US"
+      ]
+    },
+    "issuer":  {
+      "common_name":  "CipherTrace Issuing CA",
+      "serial_number":  "",
+      "organization":  [
+        "CipherTrace Inc"
+      ],
+      "organizational_unit":  [],
+      "street_address":  [],
+      "locality":  [
+        "Menlo Park"
+      ],
+      "province":  [
+        "California"
+      ],
+      "postal_code":  [],
+      "country":  [
+        "US"
+      ]
+    },
+    "not_before":  "2021-01-27T18:29:07Z",
+    "not_after":  "2022-02-27T18:29:06Z",
+    "revoked":  false,
+    "data":  "",
+    "chain":  ""
+  },
+  "signing_certificates":  [],
+  "common_name":  "api.bob.vaspbot.net",
+  "trisa_endpoint":  "api.bob.vaspbot.net:443",
+  "website":  "https://bob.vaspbot.net/",
+  "business_category":  "PRIVATE_ORGANIZATION",
+  "vasp_categories":  [
+    "Exchange"
+  ],
+  "established_on":  "2020-11-11",
+  "trixo":  {
+    "primary_national_jurisdiction":  "GB",
+    "primary_regulator":  "Financial Conduct Authority",
+    "financial_transfers_permitted":  "yes",
+    "other_jurisdictions":  [],
+    "has_required_regulatory_program":  "yes",
+    "conducts_customer_kyc":  true,
+    "kyc_threshold":  100,
+    "kyc_threshold_currency":  "USD",
+    "must_comply_travel_rule":  false,
+    "applicable_regulations":  [
+      "Legal statement on cryptoassets and smart contracts",
+      "FCA Cryptoassets: AML / CTF regime"
+    ],
+    "compliance_threshold":  10000,
+    "compliance_threshold_currency":  "USD",
+    "must_safeguard_pii":  true,
+    "safeguards_pii":  true
+  },
+  "verification_status":  "VERIFIED",
+  "service_status":  "UNKNOWN",
+  "verified_on":  "",
+  "first_listed":  "2021-01-27T18:26:21Z",
+  "last_updated":  "2021-01-27T18:30:57Z",
+  "signature":  "",
+  "version":  {
+    "pid":  "8",
+    "version":  "8"
+  },
+  "extra":  {
+    "@type":  "type.googleapis.com/gds.models.v1.GDSExtraData",
+    "admin_verification_token":  "",
+    "deleted_on":  "",
+    "metadata":  {
+      "key":  "vasps::838b1f57-1646-488d-a231-d71d88681cfa",
+      "namespace":  "vasps",
+      "version":  {
+        "pid":  "8",
+        "version":  "8",
+        "region":  "localhost",
+        "parent":  {
+          "pid":  "0",
+          "version":  "7",
+          "region":  "",
+          "parent":  null
+        }
+      },
+      "region":  "localhost",
+      "owner":  "8:frontier",
+      "data":  null
+    }
+  }
+}

--- a/pkg/gds/store/wire/wire.go
+++ b/pkg/gds/store/wire/wire.go
@@ -170,6 +170,7 @@ func RemarshalJSON(namespace string, in []byte) (out []byte, err error) {
 		if _, err = gz.Write(in); err != nil {
 			return nil, fmt.Errorf("could not compress index: %s", err)
 		}
+		gz.Close()
 		return buf.Bytes(), nil
 	case store.NamespaceSequence:
 		var seq uint64

--- a/pkg/gds/store/wire/wire.go
+++ b/pkg/gds/store/wire/wire.go
@@ -1,0 +1,204 @@
+/*
+Package wire is a store helper package that handles "wire" representations of the
+objects being managed in the store - e.g. marshalling and unmarshalling data from
+protocol buffers or json data and performing common operations across multiple data
+types that would otherwise require a switch statement and type checking.
+*/
+package wire
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/trisacrypto/directory/pkg/gds/global/v1"
+	"github.com/trisacrypto/directory/pkg/gds/models/v1"
+	"github.com/trisacrypto/directory/pkg/gds/peers/v1"
+	"github.com/trisacrypto/directory/pkg/gds/store"
+	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+var ErrCannotReplicate = errors.New("object in namespace cannot be replicated")
+
+// UnmarshalProto expects protocol buffer data and unmarshals it to the correct type
+// based on the namespace. This is a utility function for dealing with the various
+// namespaces and types that GDS manages and is not a substitute for direct unmarshaling.
+func UnmarshalProto(namespace string, data []byte) (_ proto.Message, err error) {
+	switch namespace {
+	case store.NamespaceVASPs:
+		vasp := &pb.VASP{}
+		if err = proto.Unmarshal(data, vasp); err != nil {
+			return nil, fmt.Errorf("could not unmarshal %s to %T: %s", namespace, vasp, err)
+		}
+		return vasp, nil
+	case store.NamespaceCertReqs:
+		certreq := &models.CertificateRequest{}
+		if err = proto.Unmarshal(data, certreq); err != nil {
+			return nil, fmt.Errorf("could not unmarshal %s to %T: %s", namespace, certreq, err)
+		}
+		return certreq, nil
+	case store.NamespaceReplicas:
+		peer := &peers.Peer{}
+		if err = proto.Unmarshal(data, peer); err != nil {
+			return nil, fmt.Errorf("could not unmarshal %s to %T: %s", namespace, peer, err)
+		}
+		return peer, nil
+	default:
+		return nil, fmt.Errorf("unknown namespaces %q", namespace)
+	}
+}
+
+// UnmarshalObject expects protocol buffer data and unmarshals it to a *global.Object,
+// including the original data as a marshaled anypb.Any on the Object data.
+func UnmarshalObject(namespace string, data []byte) (obj *global.Object, err error) {
+	switch namespace {
+	case store.NamespaceVASPs:
+		// Unmarshal the VASP
+		vasp := &pb.VASP{}
+		if err = proto.Unmarshal(data, vasp); err != nil {
+			return nil, fmt.Errorf("could not unmarshal %s to %T: %s", namespace, vasp, err)
+		}
+
+		// Fetch the object metadata for the VASP
+		if obj, _, err = models.GetMetadata(vasp); err != nil {
+			return nil, err
+		}
+
+		// Marshal the VASP data back onto the Any field of the object
+		if obj.Data, err = anypb.New(vasp); err != nil {
+			return nil, err
+		}
+	case store.NamespaceCertReqs:
+		certreq := &models.CertificateRequest{}
+		if err = proto.Unmarshal(data, certreq); err != nil {
+			return nil, fmt.Errorf("could not unmarshal %s to %T: %s", namespace, certreq, err)
+		}
+
+		// Fetch the object metadata and add the CertificateRequest data back onto the Any field
+		obj = certreq.Metadata
+		if obj.Data, err = anypb.New(certreq); err != nil {
+			return nil, err
+		}
+	case store.NamespaceReplicas:
+		peer := &peers.Peer{}
+		if err = proto.Unmarshal(data, peer); err != nil {
+			return nil, fmt.Errorf("could not unmarshal %s to %T: %s", namespace, peer, err)
+		}
+
+		// Fetch the object metadata and add the CertificateRequest data back onto the Any field
+		obj = peer.Metadata
+		if obj.Data, err = anypb.New(peer); err != nil {
+			return nil, err
+		}
+	case store.NamespaceIndices:
+		return nil, ErrCannotReplicate
+	default:
+		return nil, fmt.Errorf("unknown namespaces %q", namespace)
+	}
+
+	return obj, nil
+}
+
+// UnmarshalIndex extracts a map[string]interface{} from the gzip compressed index.
+func UnmarshalIndex(data []byte) (index map[string]interface{}, err error) {
+	buf := bytes.NewBuffer(data)
+	index = make(map[string]interface{})
+
+	var gz *gzip.Reader
+	if gz, err = gzip.NewReader(buf); err != nil {
+		return nil, fmt.Errorf("could not decompress data: %s", err)
+	}
+
+	decoder := json.NewDecoder(gz)
+	if err = decoder.Decode(&index); err != nil {
+		return nil, fmt.Errorf("could not decode json data: %s", err)
+	}
+
+	return index, nil
+}
+
+// UnmarshalSequence extracts a uint64 from the binary data
+func UnmarshalSequence(data []byte) (seq uint64, err error) {
+	var n int
+	if seq, n = binary.Uvarint(data); n <= 0 {
+		return 0, errors.New("could not parse sequence")
+	}
+	return seq, nil
+}
+
+// RemarshalJSON is an odd utility, it takes raw JSON data and converts it to the
+// appropriate type for database storage, e.g. marshaled protocol buffers or compressed
+// json for an index. This is primarily used to take JSON data from disk and put it into
+// a form that UnmarshalProto or UnmarshalIndex can use.
+func RemarshalJSON(namespace string, in []byte) (out []byte, err error) {
+	jsonpb := &protojson.UnmarshalOptions{
+		AllowPartial:   true,
+		DiscardUnknown: true,
+	}
+
+	switch namespace {
+	case store.NamespaceVASPs:
+		vasp := &pb.VASP{}
+		if err = jsonpb.Unmarshal(in, vasp); err != nil {
+			return nil, fmt.Errorf("could not unmarshal json %s into %T: %s", namespace, vasp, err)
+		}
+		return proto.Marshal(vasp)
+	case store.NamespaceCertReqs:
+		certreq := &models.CertificateRequest{}
+		if err = jsonpb.Unmarshal(in, certreq); err != nil {
+			return nil, fmt.Errorf("could not unmarshal json %s into %T: %s", namespace, certreq, err)
+		}
+		return proto.Marshal(certreq)
+	case store.NamespaceReplicas:
+		peer := &peers.Peer{}
+		if err = jsonpb.Unmarshal(in, peer); err != nil {
+			return nil, fmt.Errorf("could not unmarshal json %s into %T: %s", namespace, peer, err)
+		}
+		return proto.Marshal(peer)
+	case store.NamespaceIndices:
+		// For now, we're just compressing the JSON data, not checking if it is the correct type for the index
+		// TODO: should we handle indices better?
+		buf := &bytes.Buffer{}
+		gz := gzip.NewWriter(buf)
+		if _, err = gz.Write(in); err != nil {
+			return nil, fmt.Errorf("could not compress index: %s", err)
+		}
+		return buf.Bytes(), nil
+	case store.NamespaceSequence:
+		var seq uint64
+		if err = json.Unmarshal(in, &seq); err != nil {
+			return nil, fmt.Errorf("could not unmarshal json %s into %T: %s", namespace, seq, err)
+		}
+		out = make([]byte, binary.MaxVarintLen64)
+		binary.PutUvarint(out, seq)
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unknown namespace %q: cannot remarshal json", namespace)
+	}
+}
+
+// DecodeKey returns the byte representation of the key, base64 decoding if necessary.
+func DecodeKey(keys string, b64decode bool) (key []byte, err error) {
+	if b64decode {
+		if key, err = base64.RawStdEncoding.DecodeString(keys); err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	return []byte(keys), nil
+}
+
+// EncodeKey returns the string representation of the key, base64 encoding if necessary.
+func EncodeKey(key []byte, b64encode bool) string {
+	if b64encode {
+		return base64.RawStdEncoding.EncodeToString(key)
+	}
+	return string(key)
+}

--- a/pkg/gds/store/wire/wire_test.go
+++ b/pkg/gds/store/wire/wire_test.go
@@ -1,0 +1,94 @@
+package wire_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/models/v1"
+	"github.com/trisacrypto/directory/pkg/gds/peers/v1"
+	"github.com/trisacrypto/directory/pkg/gds/store"
+	. "github.com/trisacrypto/directory/pkg/gds/store/wire"
+	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
+)
+
+func TestWire(t *testing.T) {
+	// Without base64 encoding of keys
+	key, err := DecodeKey("foo", false)
+	require.NoError(t, err)
+	require.Equal(t, "foo", EncodeKey(key, false))
+
+	// With base64 encoding of keys
+	key, err = DecodeKey("foo", true)
+	require.NoError(t, err)
+	require.Equal(t, "foo", EncodeKey(key, true))
+
+	// The basic test pattern here is to load data from disk, then remarshal JSON
+	// and testing unmarshal of the specific namespace.
+	// Test unmarshal VASP records
+	in, err := ioutil.ReadFile("testdata/vasps::838b1f57-1646-488d-a231-d71d88681cfa.json")
+	require.NoError(t, err)
+	out, err := RemarshalJSON(store.NamespaceVASPs, in)
+	require.NoError(t, err)
+	vasp, err := UnmarshalProto(store.NamespaceVASPs, out)
+	require.NoError(t, err)
+	_, ok := vasp.(*pb.VASP)
+	require.True(t, ok)
+	obj, err := UnmarshalObject(store.NamespaceVASPs, out)
+	require.NoError(t, err)
+	require.Equal(t, "vasps::838b1f57-1646-488d-a231-d71d88681cfa", obj.Key)
+	require.Equal(t, uint64(8), obj.Version.Version)
+
+	// Test unmarshal certificate requests
+	in, err = ioutil.ReadFile("testdata/certreqs::87657b4d-e72c-4526-9332-c8fc56adb367.json")
+	require.NoError(t, err)
+	out, err = RemarshalJSON(store.NamespaceCertReqs, in)
+	require.NoError(t, err)
+	certreq, err := UnmarshalProto(store.NamespaceCertReqs, out)
+	require.NoError(t, err)
+	_, ok = certreq.(*models.CertificateRequest)
+	require.True(t, ok)
+	obj, err = UnmarshalObject(store.NamespaceCertReqs, out)
+	require.NoError(t, err)
+	require.Equal(t, "certreqs::87657b4d-e72c-4526-9332-c8fc56adb367", obj.Key)
+	require.Equal(t, uint64(3), obj.Version.Version)
+
+	// Test Unmarshal Peers
+	in, err = ioutil.ReadFile("testdata/peers::8.json")
+	require.NoError(t, err)
+	out, err = RemarshalJSON(store.NamespaceReplicas, in)
+	require.NoError(t, err)
+	peer, err := UnmarshalProto(store.NamespaceReplicas, out)
+	require.NoError(t, err)
+	_, ok = peer.(*peers.Peer)
+	require.True(t, ok)
+	obj, err = UnmarshalObject(store.NamespaceReplicas, out)
+	require.NoError(t, err)
+	require.Equal(t, "peers::8", obj.Key)
+	require.Equal(t, uint64(1), obj.Version.Version)
+
+	// Test Unmarshal category index
+	in, err = ioutil.ReadFile("testdata/index::categories.json")
+	require.NoError(t, err)
+	out, err = RemarshalJSON(store.NamespaceIndices, in)
+	require.NoError(t, err)
+	index, err := UnmarshalIndex(out)
+	require.NoError(t, err)
+	require.Equal(t, 6, len(index))
+
+	// Test Unmarshal names index
+	in, err = ioutil.ReadFile("testdata/index::names.json")
+	require.NoError(t, err)
+	out, err = RemarshalJSON(store.NamespaceIndices, in)
+	require.NoError(t, err)
+	index, err = UnmarshalIndex(out)
+	require.NoError(t, err)
+	require.Equal(t, 8, len(index))
+
+	// Test Unmarshal Sequence
+	out, err = RemarshalJSON(store.NamespaceSequence, []byte("42"))
+	require.NoError(t, err)
+	seq, err := UnmarshalSequence(out)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), seq)
+}


### PR DESCRIPTION
This PR creates a helper pkg, wire for marshaling and unmarshaling
object data from disk and memory - standardizing how we handle objects
for replication. It also adds NamespaceReplicas to ensure that Peers are
also replicated. This PR should delete and simplify a lot of code.