### PR TITLE
Gossip cleanup

### DIFF
--- a/pkg/gds/config/config.go
+++ b/pkg/gds/config/config.go
@@ -41,11 +41,13 @@ type AdminConfig struct {
 }
 
 type ReplicaConfig struct {
-	Enabled  bool   `split_words:"true" default:"true"`
-	BindAddr string `split_words:"true" default:":4435"`
-	PID      uint64 `split_words:"true" required:"false"`
-	Region   string `split_words:"true" required:"false"`
-	Name     string `split_words:"true" required:"false"`
+	Enabled        bool          `split_words:"true" default:"true"`
+	BindAddr       string        `split_words:"true" default:":4435"`
+	PID            uint64        `split_words:"true" required:"false"`
+	Region         string        `split_words:"true" required:"false"`
+	Name           string        `split_words:"true" required:"false"`
+	GossipInterval time.Duration `split_words:"true" default:"1m"`
+	GossipSigma    time.Duration `split_words:"true" default:"5s"`
 }
 
 type DatabaseConfig struct {
@@ -113,6 +115,10 @@ func (c ReplicaConfig) Validate() error {
 
 		if c.Region == "" {
 			return errors.New("invalid configuration: region required for enabled replica")
+		}
+
+		if c.GossipInterval == time.Duration(0) || c.GossipSigma == time.Duration(0) {
+			return errors.New("invalid configuration: specify non-zero gossip interval and sigma")
 		}
 	}
 	return nil

--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -25,6 +25,8 @@ var testEnv = map[string]string{
 	"GDS_REPLICA_PID":                "8",
 	"GDS_REPLICA_NAME":               "mitchell",
 	"GDS_REPLICA_REGION":             "us-east-1c",
+	"GDS_REPLICA_GOSSIP_INTERVAL":    "30m",
+	"GDS_REPLICA_GOSSIP_SIGMA":       "3m",
 	"GDS_DATABASE_URL":               "fixtures/db",
 	"GDS_DATABASE_REINDEX_ON_BOOT":   "false",
 	"SECTIGO_USERNAME":               "foo",
@@ -74,6 +76,8 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, uint64(8), conf.Replica.PID)
 	require.Equal(t, testEnv["GDS_REPLICA_NAME"], conf.Replica.Name)
 	require.Equal(t, testEnv["GDS_REPLICA_REGION"], conf.Replica.Region)
+	require.Equal(t, 30*time.Minute, conf.Replica.GossipInterval)
+	require.Equal(t, 3*time.Minute, conf.Replica.GossipSigma)
 	require.Equal(t, testEnv["GDS_DATABASE_URL"], conf.Database.URL)
 	require.Equal(t, false, conf.Database.ReindexOnBoot)
 	require.Equal(t, testEnv["SECTIGO_USERNAME"], conf.Sectigo.Username)

--- a/pkg/gds/global/v1/interface.go
+++ b/pkg/gds/global/v1/interface.go
@@ -6,7 +6,7 @@ package global
 type ObjectStore interface {
 	Iter(namespace string) ObjectIterator
 	Get(namespace, key string, withData bool) (*Object, error)
-	Put(namespace, key string, obj *Object) error
+	Put(obj *Object) error
 }
 
 // ObjectIterator mirrors the leveldb iterator interface but requires the Store to

--- a/pkg/gds/global/v1/interface.go
+++ b/pkg/gds/global/v1/interface.go
@@ -1,0 +1,20 @@
+package global
+
+// ObjectStore allows Replicas to directly interact with the underlying objects managed
+// by the interfaces described above, rather than by going through their versioned
+// change mechanisms. This is a very low-level interface for object management.
+type ObjectStore interface {
+	Iter(namespace string) ObjectIterator
+	Get(namespace, key string, withData bool) (*Object, error)
+	Put(namespace, key string, obj *Object) error
+}
+
+// ObjectIterator mirrors the leveldb iterator interface but requires the Store to
+// directly manipulate the keys and values into the expected object interface.
+type ObjectIterator interface {
+	Next() bool
+	Error() error
+	Key() string
+	Object(withData bool) (*Object, error)
+	Release()
+}

--- a/pkg/gds/global/v1/namespaces.go
+++ b/pkg/gds/global/v1/namespaces.go
@@ -1,0 +1,13 @@
+package global
+
+// Namespace constants for all managed objects in GDS
+const (
+	NamespaceVASPs    = "vasps"
+	NamespaceCertReqs = "certreqs"
+	NamespaceReplicas = "peers"
+	NamespaceIndices  = "index"
+	NamespaceSequence = "sequence"
+)
+
+// Namespaces defines all possible namespaces that GDS manages
+var Namespaces = [3]string{NamespaceVASPs, NamespaceCertReqs, NamespaceReplicas}

--- a/pkg/gds/jitter/jitter.go
+++ b/pkg/gds/jitter/jitter.go
@@ -1,0 +1,58 @@
+/*
+Package jitter provides a stochastic ticker that returns ticks at a random interval
+specified by a normal distribution with a mean periodicity and a standard deviation,
+sigma both of which are time.Durations.
+
+This is a simplified version of https://github.com/lthibault/jitterbug.
+*/
+package jitter
+
+import (
+	"math/rand"
+	"time"
+)
+
+// New returns a new stochastic timer with the specified interval and standard deviation.
+func New(interval, sigma time.Duration) (j *Ticker) {
+	c := make(chan time.Time)
+	j = &Ticker{
+		C:        c,
+		Interval: interval,
+		Sigma:    sigma,
+		done:     make(chan struct{}),
+	}
+	go j.loop(c)
+	return j
+}
+
+// Ticker behaves like time.Ticker (listen on Ticker.C for timestamps).
+type Ticker struct {
+	C        <-chan time.Time
+	Interval time.Duration
+	Sigma    time.Duration
+	done     chan struct{}
+}
+
+// Stop the Ticker.
+func (j *Ticker) Stop() {
+	close(j.done)
+}
+
+func (t *Ticker) loop(c chan<- time.Time) {
+	defer close(c)
+	for {
+		time.Sleep(t.calcDelay())
+
+		select {
+		case <-t.done:
+			return
+		case c <- time.Now():
+		default: // there may be no recv
+		}
+	}
+}
+
+func (j *Ticker) calcDelay() time.Duration {
+	s := rand.NormFloat64() * float64(j.Sigma)
+	return j.Interval + time.Duration(s)
+}

--- a/pkg/gds/jitter/jitter_test.go
+++ b/pkg/gds/jitter/jitter_test.go
@@ -1,0 +1,28 @@
+package jitter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/jitter"
+)
+
+// NOTE: because this is a stochastic test it might fail; run again to make sure the
+// failure wasn't a fluke of some extremely unlikely event in the normal distribution.
+func TestTicker(t *testing.T) {
+	ticker := jitter.New(100*time.Millisecond, 5*time.Millisecond)
+	prev := time.Now()
+	prevDelta := time.Duration(0)
+	for i := 0; i < 10; i++ {
+		now := <-ticker.C
+		delta := now.Sub(prev)
+		require.NotEqual(t, prevDelta, delta)
+		require.Less(t, time.Duration(10*time.Millisecond), delta)
+		require.Greater(t, time.Duration(200*time.Millisecond), delta)
+		prev = now
+		prevDelta = delta
+	}
+
+	ticker.Stop()
+}

--- a/pkg/gds/store/leveldb/leveldb.go
+++ b/pkg/gds/store/leveldb/leveldb.go
@@ -105,14 +105,6 @@ func (s *Store) Close() error {
 	return nil
 }
 
-// DB returns the underlying leveldb connection for direct access. Use with care, you'll
-// have to manage your own thread safety and this will go around any of the indices.
-// NOTE: Only use to read from the database, not to write!
-// TODO: remove this when the Replica can interact with generic stores.
-func (s *Store) DB() *leveldb.DB {
-	return s.db
-}
-
 //===========================================================================
 // DirectoryStore Implementation
 //===========================================================================
@@ -184,7 +176,7 @@ func (s *Store) RetrieveVASP(id string) (v *pb.VASP, err error) {
 		if err == leveldb.ErrNotFound {
 			return nil, ErrEntityNotFound
 		}
-		return v, err
+		return nil, err
 	}
 
 	v = new(pb.VASP)

--- a/pkg/gds/store/leveldb/objects.go
+++ b/pkg/gds/store/leveldb/objects.go
@@ -42,7 +42,7 @@ func (s *Store) Get(namespace, key string, withData bool) (obj *global.Object, e
 // Put puts an object into the specified key, the Data Any field should be present.
 // NOTE: there is no delete method because replication requires the Put of a tombstone.
 // TODO: implementation required!
-func (s *Store) Put(namespace, key string, obj *global.Object) error {
+func (s *Store) Put(obj *global.Object) error {
 	return errors.New("not implemented yet")
 }
 

--- a/pkg/gds/store/leveldb/objects.go
+++ b/pkg/gds/store/leveldb/objects.go
@@ -1,0 +1,85 @@
+package leveldb
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/trisacrypto/directory/pkg/gds/global/v1"
+	"github.com/trisacrypto/directory/pkg/gds/store/wire"
+)
+
+// Iter returns a wrapper for the leveldb iterator that produces global.Object
+// references for replication, unmarshaling the object representation as needed. If the
+// namespace is provided then a bytes prefix is used to scan over a portion of the db.
+func (s *Store) Iter(namespace string) global.ObjectIterator {
+	var prefix *util.Range
+	if namespace != "" {
+		prefix = util.BytesPrefix([]byte(namespace))
+	}
+	return &objectIterator{ldb: s.db.NewIterator(prefix, nil)}
+}
+
+// Get retrieves an object by the specified key. If withData is specified then the
+// object bytes are loaded into the Data Any field; otherwise just metadata is returned.
+func (s *Store) Get(namespace, key string, withData bool) (obj *global.Object, err error) {
+	var data []byte
+	if data, err = s.db.Get([]byte(key), nil); err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return nil, wire.ErrObjectNotFound
+		}
+		return nil, err
+	}
+
+	if obj, err = wire.UnmarshalObject(namespace, data, withData); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// Put puts an object into the specified key, the Data Any field should be present.
+// NOTE: there is no delete method because replication requires the Put of a tombstone.
+// TODO: implementation required!
+func (s *Store) Put(namespace, key string, obj *global.Object) error {
+	return errors.New("not implemented yet")
+}
+
+// ObjectIterator mirrors the leveldb iterator interface but requires the Store to
+// directly manipulate the keys and values into the expected object interface.
+type objectIterator struct {
+	ldb iterator.Iterator
+}
+
+// Next moves the iterator to the next key/value pair. It returns false if the iterator is exhausted.
+func (it *objectIterator) Next() bool {
+	return it.ldb.Next()
+}
+
+// Error returns any accumulated error. Exhausting all the key/value pairs is not
+// considered to be an error.
+func (it *objectIterator) Error() error {
+	return it.ldb.Error()
+}
+
+// Key returns the key of the current key/value pair, or nil if done. The caller should
+// not modify the contents of the returned slice, and its contents may change on the
+// next call to any 'seeks method'.
+func (it *objectIterator) Key() string {
+	return string(it.ldb.Key())
+}
+
+// Object returns the parsed object using wire.UnmarshalObject. If withData is specified
+// then the Data Any field is populated, otherwise just metadata is returned.
+func (it *objectIterator) Object(withData bool) (*global.Object, error) {
+	data := it.ldb.Value()
+	prefix := strings.Split(it.Key(), "::")[0]
+	return wire.UnmarshalObject(prefix, data, withData)
+}
+
+// Release releases associated resources. Release should always success and can be
+// called multiple times without causing error.
+func (it *objectIterator) Release() {
+	it.ldb.Release()
+}

--- a/pkg/gds/store/leveldb/objects_test.go
+++ b/pkg/gds/store/leveldb/objects_test.go
@@ -1,0 +1,19 @@
+package leveldb
+
+func (s *leveldbTestSuite) TestObjectIterator() {
+	iter := s.db.Iter("")
+	defer iter.Release()
+
+	objs := 0
+	for iter.Next() {
+		objs++
+		key := iter.Key()
+		obj, err := iter.Object(false)
+		s.NoError(err)
+		s.Equal(key, obj.Key)
+		s.Empty(obj.Data)
+	}
+
+	s.NoError(iter.Error())
+	s.Equal(2, objs)
+}

--- a/pkg/gds/store/store.go
+++ b/pkg/gds/store/store.go
@@ -46,18 +46,6 @@ import (
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 )
 
-// Namespace constants for all managed objects in GDS
-const (
-	NamespaceVASPs    = "vasps"
-	NamespaceCertReqs = "certreqs"
-	NamespaceReplicas = "peers"
-	NamespaceIndices  = "index"
-	NamespaceSequence = "sequence"
-)
-
-// Namespaces defines all possible namespaces that GDS manages
-var Namespaces = [3]string{NamespaceVASPs, NamespaceCertReqs, NamespaceReplicas}
-
 // Open a directory storage provider with the specified URI. Database URLs should either
 // specify protocol+transport://user:pass@host/dbname?opt1=a&opt2=b for servers or
 // protocol:///relative/path/to/file for embedded databases (for absolute paths, specify

--- a/pkg/gds/store/wire/wire_test.go
+++ b/pkg/gds/store/wire/wire_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/global/v1"
 	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	"github.com/trisacrypto/directory/pkg/gds/peers/v1"
-	"github.com/trisacrypto/directory/pkg/gds/store"
 	. "github.com/trisacrypto/directory/pkg/gds/store/wire"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 )
@@ -28,49 +28,61 @@ func TestWire(t *testing.T) {
 	// Test unmarshal VASP records
 	in, err := ioutil.ReadFile("testdata/vasps::838b1f57-1646-488d-a231-d71d88681cfa.json")
 	require.NoError(t, err)
-	out, err := RemarshalJSON(store.NamespaceVASPs, in)
+	out, err := RemarshalJSON(global.NamespaceVASPs, in)
 	require.NoError(t, err)
-	vasp, err := UnmarshalProto(store.NamespaceVASPs, out)
+	vasp, err := UnmarshalProto(global.NamespaceVASPs, out)
 	require.NoError(t, err)
 	_, ok := vasp.(*pb.VASP)
 	require.True(t, ok)
-	obj, err := UnmarshalObject(store.NamespaceVASPs, out)
+	obj, err := UnmarshalObject(global.NamespaceVASPs, out, false)
 	require.NoError(t, err)
 	require.Equal(t, "vasps::838b1f57-1646-488d-a231-d71d88681cfa", obj.Key)
 	require.Equal(t, uint64(8), obj.Version.Version)
+	require.Empty(t, obj.Data)
+	obj, err = UnmarshalObject(global.NamespaceVASPs, out, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, obj.Data)
 
 	// Test unmarshal certificate requests
 	in, err = ioutil.ReadFile("testdata/certreqs::87657b4d-e72c-4526-9332-c8fc56adb367.json")
 	require.NoError(t, err)
-	out, err = RemarshalJSON(store.NamespaceCertReqs, in)
+	out, err = RemarshalJSON(global.NamespaceCertReqs, in)
 	require.NoError(t, err)
-	certreq, err := UnmarshalProto(store.NamespaceCertReqs, out)
+	certreq, err := UnmarshalProto(global.NamespaceCertReqs, out)
 	require.NoError(t, err)
 	_, ok = certreq.(*models.CertificateRequest)
 	require.True(t, ok)
-	obj, err = UnmarshalObject(store.NamespaceCertReqs, out)
+	obj, err = UnmarshalObject(global.NamespaceCertReqs, out, false)
 	require.NoError(t, err)
 	require.Equal(t, "certreqs::87657b4d-e72c-4526-9332-c8fc56adb367", obj.Key)
 	require.Equal(t, uint64(3), obj.Version.Version)
+	require.Empty(t, obj.Data)
+	obj, err = UnmarshalObject(global.NamespaceCertReqs, out, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, obj.Data)
 
 	// Test Unmarshal Peers
 	in, err = ioutil.ReadFile("testdata/peers::8.json")
 	require.NoError(t, err)
-	out, err = RemarshalJSON(store.NamespaceReplicas, in)
+	out, err = RemarshalJSON(global.NamespaceReplicas, in)
 	require.NoError(t, err)
-	peer, err := UnmarshalProto(store.NamespaceReplicas, out)
+	peer, err := UnmarshalProto(global.NamespaceReplicas, out)
 	require.NoError(t, err)
 	_, ok = peer.(*peers.Peer)
 	require.True(t, ok)
-	obj, err = UnmarshalObject(store.NamespaceReplicas, out)
+	obj, err = UnmarshalObject(global.NamespaceReplicas, out, false)
 	require.NoError(t, err)
 	require.Equal(t, "peers::8", obj.Key)
 	require.Equal(t, uint64(1), obj.Version.Version)
+	require.Empty(t, obj.Data)
+	obj, err = UnmarshalObject(global.NamespaceReplicas, out, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, obj.Data)
 
 	// Test Unmarshal category index
 	in, err = ioutil.ReadFile("testdata/index::categories.json")
 	require.NoError(t, err)
-	out, err = RemarshalJSON(store.NamespaceIndices, in)
+	out, err = RemarshalJSON(global.NamespaceIndices, in)
 	require.NoError(t, err)
 	index, err := UnmarshalIndex(out)
 	require.NoError(t, err)
@@ -79,14 +91,14 @@ func TestWire(t *testing.T) {
 	// Test Unmarshal names index
 	in, err = ioutil.ReadFile("testdata/index::names.json")
 	require.NoError(t, err)
-	out, err = RemarshalJSON(store.NamespaceIndices, in)
+	out, err = RemarshalJSON(global.NamespaceIndices, in)
 	require.NoError(t, err)
 	index, err = UnmarshalIndex(out)
 	require.NoError(t, err)
 	require.Equal(t, 8, len(index))
 
 	// Test Unmarshal Sequence
-	out, err = RemarshalJSON(store.NamespaceSequence, []byte("42"))
+	out, err = RemarshalJSON(global.NamespaceSequence, []byte("42"))
 	require.NoError(t, err)
 	seq, err := UnmarshalSequence(out)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR finalizes the v1.1 Gossip implementation though it is not ready
for production release quite yet. Our intent is to run GDS with the
replica server disabled but to have object versioning in place. The
cleanup PR creates the ObjectStore abstraction to remove directly use of
leveldb and implements the routine that initiates Gossip with remote
replicas.