### PR TITLE
Implements Sectigo CSR Client Method

### DIFF
--- a/pkg/sectigo/README.md
+++ b/pkg/sectigo/README.md
@@ -2,9 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/trisacrypto/directory/pkg/sectigo.svg)](https://pkg.go.dev/github.com/trisacrypto/directory/pkg/sectigo)
 
-
-**NOTE**: This README is included with the source code to facilitate forks and code sharing. However, if you're using the Sectigo integration with the TRISA TestNet Directory Service, please reference the documentation at [trisatest.net](https://trisatest.net).
-
+**NOTE**: This README is included with the source code to facilitate forks and code sharing. However, if you're using the Sectigo integration with the TRISA TestNet Directory Service, please reference the documentation at [trisa.dev](https://trisa.dev).
 
 The directory service issues certificates using Sectigo, please refer to the [API Documentation](https://support.sectigo.com/Com_KnowledgeDetailPage?Id=kA01N000000bvCJ) for more details on the endpoints and supported interactions. The `sectigo` package provides a simple client interface for interacting with the API; most of this code is handled by the server, but there is also a CLI interface that demonstrates usage.
 
@@ -127,6 +125,41 @@ $ openssl pkcs12 -in certs/example.com.p12 -out certs/example.com.pem -nodes
 ```
 
 For more on working with the PKCS12 file, see [Export Certificates and Private Key from a PKCS#12 File with OpenSSL](https://www.ssl.com/how-to/export-certificates-private-key-from-pkcs12-file-with-openssl/).
+
+## Uploading a CSR
+
+An alternative to certificate creation is to upload a certificate signing request (CSR). This mechanism is often preferable because it means that no private key material has to be transmitted accross the network and the private key can remain on secure hardware.
+
+To generate a CSR run the following command:
+
+```
+$ openssl req -nodes -newkey rsa:4096 -keyout <common_name>.key -out <common_name>.csr
+```
+
+Please carefully fill out the prompts for your certificate, this information must be correct and cannot be changed without reissuing the certificate. For more on generating CSRs, see [Manually Generate a Certificate Signing Request (CSR) Using OpenSSL](https://www.ssl.com/how-to/manually-generate-a-certificate-signing-request-csr-using-openssl/)
+
+You can then upload the CSR using the CLI program as follows:
+
+```
+$ sectigo upload -p 42 <common_name>.csr
+{
+  "batchId": 24,
+  "orderNumber": 1024,
+  "creationDate": "2020-12-10T16:35:32.805+0000",
+  "profile": "TRISA Profile",
+  "size": 1,
+  "status": "CREATED",
+  "active": false,
+  "batchName": "example.com certs",
+  "rejectReason": "",
+  "generatorParametersValues": null,
+  "userId": 10,
+  "downloadable": true,
+  "rejectable": true
+}
+```
+
+The `-p` flag specifies the profile to use the CSR batch request with and must be a valid profileId. The uploaded CSRs can be a single text file with multiple CSRs in PEM form using standard BEGIN/END separators.
 
 ## Managing Certificates
 

--- a/pkg/sectigo/README.md
+++ b/pkg/sectigo/README.md
@@ -145,12 +145,12 @@ $ sectigo upload -p 42 <common_name>.csr
 {
   "batchId": 24,
   "orderNumber": 1024,
-  "creationDate": "2020-12-10T16:35:32.805+0000",
+  "creationDate": "2021-07-22T16:30:02.990+0000",
   "profile": "TRISA Profile",
   "size": 1,
-  "status": "CREATED",
-  "active": false,
-  "batchName": "example.com certs",
+  "status": "PENDING",
+  "active": true,
+  "batchName": "<common_name>.csr",
   "rejectReason": "",
   "generatorParametersValues": null,
   "userId": 10,
@@ -160,6 +160,10 @@ $ sectigo upload -p 42 <common_name>.csr
 ```
 
 The `-p` flag specifies the profile to use the CSR batch request with and must be a valid profileId. The uploaded CSRs can be a single text file with multiple CSRs in PEM form using standard BEGIN/END separators.
+
+Possible CSR Errors:
+
+- BROKEN Error: Cert subject name error: SubjectAlternativeName dNSName value is missing
 
 ## Managing Certificates
 

--- a/pkg/sectigo/README.md
+++ b/pkg/sectigo/README.md
@@ -130,13 +130,37 @@ For more on working with the PKCS12 file, see [Export Certificates and Private K
 
 An alternative to certificate creation is to upload a certificate signing request (CSR). This mechanism is often preferable because it means that no private key material has to be transmitted accross the network and the private key can remain on secure hardware.
 
-To generate a CSR run the following command:
+To generate a CSR using `openssl` on the command line, first create a configuration file named `trisa.conf` in your current working directory, replacing `example.com` with the domain you plan to host your TRISA endpoint on:
+
+```conf
+[req]
+distinguished_name = dn_req
+req_extensions = v3ext_req
+prompt = no
+default_bits = 4096
+[dn_req]
+CN = example.com
+O = [Organization]
+L = [City]
+ST = [State or Province (fully spelled out, no abbreviations)]
+C = [2 digit country code]
+[v3ext_req]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment, nonRepudiation
+extendedKeyUsage = clientAuth, serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = example.com
+```
+
+Please carefully fill out the configuration for your certificate, this information must be correct and cannot be changed without reissuing the certificate. Also make sure that there are no spaces after the entries in the configuration!
+
+Then run the following command, replacing `example.com` with the domain name you will be using as your TRISA endpoint:
 
 ```
-$ openssl req -nodes -newkey rsa:4096 -keyout <common_name>.key -out <common_name>.csr
+$ openssl req -new -newkey rsa:4096 -nodes -sha384 -config trisa.conf \
+  -keyout example.com.key -out example.com.csr
 ```
-
-Please carefully fill out the prompts for your certificate, this information must be correct and cannot be changed without reissuing the certificate. For more on generating CSRs, see [Manually Generate a Certificate Signing Request (CSR) Using OpenSSL](https://www.ssl.com/how-to/manually-generate-a-certificate-signing-request-csr-using-openssl/)
 
 You can then upload the CSR using the CLI program as follows:
 
@@ -145,12 +169,12 @@ $ sectigo upload -p 42 <common_name>.csr
 {
   "batchId": 24,
   "orderNumber": 1024,
-  "creationDate": "2021-07-22T16:30:02.990+0000",
+  "creationDate": "2020-12-10T16:35:32.805+0000",
   "profile": "TRISA Profile",
   "size": 1,
-  "status": "PENDING",
-  "active": true,
-  "batchName": "<common_name>.csr",
+  "status": "CREATED",
+  "active": false,
+  "batchName": "example.com certs",
   "rejectReason": "",
   "generatorParametersValues": null,
   "userId": 10,

--- a/pkg/sectigo/endpoints.go
+++ b/pkg/sectigo/endpoints.go
@@ -98,7 +98,7 @@ const (
 	batchDevicesAuditLogEP          = "batchDevicesAuditLog"
 	batchPreviewEP                  = "batchPreview"
 	createSingleCertBatchEP         = "createSingleCertBatch"
-	uploadEP                        = "upload"
+	uploadEP                        = "uploadEP"
 	uploadCSREP                     = uploadEP
 	uploadCSVEP                     = "uploadCSV"
 	generatorsEP                    = "generators"

--- a/pkg/sectigo/endpoints.go
+++ b/pkg/sectigo/endpoints.go
@@ -41,7 +41,7 @@ var endpoints = map[string]*url.URL{
 	batchDevicesAuditLogEP:          {Path: "/api/v1/batches/%d/devices/auditLog"},
 	batchPreviewEP:                  {Path: "/api/v1/batches/preview"},
 	createSingleCertBatchEP:         {Path: "/api/v1/batches/createSingleCertBatch"},
-	uploadEP:                        {Path: "/api/v1/upload"},
+	uploadEP:                        {Path: "/api/v1/batches/upload"},
 	uploadCSVEP:                     {Path: "/api/v2/organizations/%d/profiles/%d/batches/csv-upload"},
 	generatorsEP:                    {Path: "/api/v1/generators"},
 	downloadEP:                      {Path: "/api/v1/batches/%d/download"},
@@ -99,6 +99,7 @@ const (
 	batchPreviewEP                  = "batchPreview"
 	createSingleCertBatchEP         = "createSingleCertBatch"
 	uploadEP                        = "upload"
+	uploadCSREP                     = uploadEP
 	uploadCSVEP                     = "uploadCSV"
 	generatorsEP                    = "generators"
 	downloadEP                      = "download"

--- a/pkg/sectigo/endpoints.go
+++ b/pkg/sectigo/endpoints.go
@@ -98,7 +98,7 @@ const (
 	batchDevicesAuditLogEP          = "batchDevicesAuditLog"
 	batchPreviewEP                  = "batchPreview"
 	createSingleCertBatchEP         = "createSingleCertBatch"
-	uploadEP                        = "uploadEP"
+	uploadEP                        = "upload"
 	uploadCSREP                     = uploadEP
 	uploadCSVEP                     = "uploadCSV"
 	generatorsEP                    = "generators"

--- a/pkg/sectigo/serializers.go
+++ b/pkg/sectigo/serializers.go
@@ -33,6 +33,12 @@ type CreateSingleCertBatchRequest struct {
 	ProfileParams map[string]string `json:"profileParams"` // should not be empty; represents the profile-specific params passed to batch request
 }
 
+// UploadCSRBatchRequest to POST data to the uploadCSREP
+type UploadCSRBatchRequest struct {
+	AuthorityID   int               `json:"authorityId"`
+	ProfileParams map[string]string `json:"profileParams"` // should not be empty; represents the profile-specific params passed to batch request
+}
+
 // BatchResponse received from createSingleCertBatchEP and batchDetailEP
 type BatchResponse struct {
 	BatchID         int         `json:"batchId"`

--- a/pkg/sectigo/serializers.go
+++ b/pkg/sectigo/serializers.go
@@ -35,8 +35,9 @@ type CreateSingleCertBatchRequest struct {
 
 // UploadCSRBatchRequest to POST data to the uploadCSREP
 type UploadCSRBatchRequest struct {
-	AuthorityID   int               `json:"authorityId"`
-	ProfileParams map[string]string `json:"profileParams"` // should not be empty; represents the profile-specific params passed to batch request
+	ProfileID     int               `json:"profileId"`
+	BatchType     string            `json:"batchType"`
+	ProfileParams map[string]string `json:"profileParams"`
 }
 
 // BatchResponse received from createSingleCertBatchEP and batchDetailEP
@@ -109,6 +110,22 @@ type ProfileDetailResponse struct {
 	RawProfileConfig string `json:"rawProfileConfig"`
 	Name             string `json:"name"`
 	KeyAlgorithmInfo string `json:"keyAlgorithmInfo"`
+}
+
+// OrganizationResponse received from currentUserOrganizationEP
+type OrganizationResponse struct {
+	OrganizationID      int                  `json:"organizationId"`
+	OrganizationName    string               `json:"organizationName"`
+	Address             string               `json:"address"`
+	PrimaryContactName  string               `json:"primaryContactName"`
+	PrimaryContactEmail string               `json:"primaryContactEmail"`
+	PrimaryContactPhone string               `json:"primaryContactPhone"`
+	ManufactureID       string               `json:"manufactureId"`
+	Logo                string               `json:"logo"`
+	Authorities         []*AuthorityResponse `json:"authorities"`
+	EcosystemID         int                  `json:"ecosystemId"`
+	Parameters          map[string]string    `json:"organizationParameters"`
+	Status              string               `json:"orgStatus"`
 }
 
 // FindCertificateRequest to POST to the findCertificateEP


### PR DESCRIPTION
Implements the Sectigo upload CSR method for the client, allowing multi-part uploads of certificate signing requests plus other form data required to create a certificate batch request using this method.

TODO: right now I'm getting 500 Internal Server Error responses from Sectigo … which does not make it easy to debug things. I've tried a bunch of different things to try to get around the error; but I'm going to have to put in a call to Sectigo support to figure out what is going on. 