### PR TITLE
Fix front-end crash on empty country

### DIFF
--- a/web/src/components/LookupResults.js
+++ b/web/src/components/LookupResults.js
@@ -25,8 +25,12 @@ const LookupResults = (props) => {
             <dt className="col-sm-3">TRISA Service Endpoint</dt>
             <dd className="col-sm-9">{results.endpoint}</dd>
 
-            <dt className="col-sm-3">Country</dt>
-            <dd className="col-sm-9">{countryCodeEmoji(results.country)} <span className="sr-only">{results.country}</span></dd>
+            {results.country &&
+              <>
+              <dt className="col-sm-3">Country</dt>
+              <dd className="col-sm-9">{countryCodeEmoji(results.country)} <span className="sr-only">{results.country}</span></dd>
+              </>
+            }
 
             {results.verifiedOn &&
               <>

--- a/web/src/lib/country.js
+++ b/web/src/lib/country.js
@@ -15,6 +15,11 @@ const OFFSET = 127397;
  * @returns {string} flag emoji
  */
 export function countryCodeEmoji(cc) {
+  // Ignore empty strings, null, and undefined
+  if (!cc) {
+    return "";
+  }
+
   if (!CC_REGEX.test(cc)) {
     const type = typeof cc;
     throw new TypeError(


### PR DESCRIPTION
If the country field of the VASP record was missing, the UI crashed and
displayed a blank page. This PR fixes this by checking for the presence
of the country field and not displaying it rather than trying to produce
the flag emoji.