### PR TITLE
Make Admin contact and phone number required

### DIFF
--- a/cmd/gdsutil/main.go
+++ b/cmd/gdsutil/main.go
@@ -551,6 +551,8 @@ func ldbList(c *cli.Context) (err error) {
 		record["common_name"] = vasp.CommonName
 		record["name"], _ = vasp.Name()
 		record["key"] = string(iter.Key())
+		record["registered_directory"] = vasp.RegisteredDirectory
+		record["vasp_status"] = vasp.VerificationStatus.String()
 		data[vasp.Id] = record
 	}
 

--- a/web/src/components/Contact.js
+++ b/web/src/components/Contact.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Form from 'react-bootstrap/Form';
 
-const Contact = ({contact, onChange}) => {
+const Contact = ({contact, onChange, required}) => {
   const createChangeHandler = (field) => (event) => {
     let data = {...contact};
     data[[field]] = event.target.value;
@@ -16,6 +16,7 @@ const Contact = ({contact, onChange}) => {
         type="text"
         value={contact.name}
         onChange={createChangeHandler("name")}
+        required={required}
       />
       <Form.Text className="text-muted">
         Preferred name for email communication.
@@ -27,6 +28,7 @@ const Contact = ({contact, onChange}) => {
         type="email"
         value={contact.email}
         onChange={createChangeHandler("email")}
+        required={required}
       />
       <Form.Text className="text-muted">
         Please use the email address associated with your organization.
@@ -41,12 +43,13 @@ const Contact = ({contact, onChange}) => {
         type="tel"
         value={contact.phone}
         onChange={createChangeHandler("phone")}
+        required={required}
       />
       <Form.Text className="text-muted">
-        Optional - if supplied, use full phone number with country code.
+        {required ? "Required - please supply " : "Optional - if supplied, use"} full phone number with country code.
       </Form.Text>
       <Form.Control.Feedback type="invalid">
-        Please supply a valid phone number or omit entirely.
+        Please supply a valid phone number or omit entirely if not required.
       </Form.Control.Feedback>
     </Form.Group>
 

--- a/web/src/components/Registration.js
+++ b/web/src/components/Registration.js
@@ -354,6 +354,7 @@ class Registration extends React.Component {
                         type="url"
                         value={this.state.formData.website}
                         onChange={this.createFlatChangeHandler("website")}
+                        required={true}
                       />
                     </Form.Group>
                     <Form.Group>
@@ -455,6 +456,7 @@ class Registration extends React.Component {
                             <Contact
                               contact={this.state.formData.contacts.technical}
                               onChange={this.createChangeHandler("technical", "contacts")}
+                              required={true}
                             />
                           </Card.Body>
                         </Accordion.Collapse>
@@ -472,6 +474,7 @@ class Registration extends React.Component {
                             <Contact
                               contact={this.state.formData.contacts.legal}
                               onChange={this.createChangeHandler("legal", "contacts")}
+                              required={false}
                             />
                           </Card.Body>
                         </Accordion.Collapse>
@@ -484,11 +487,12 @@ class Registration extends React.Component {
                           <Card.Body>
                             <p>
                               Administrative or executive contact for your organization to field
-                              high-level requests or queries. (Optional).
+                              high-level requests or queries. (Required).
                             </p>
                             <Contact
                               contact={this.state.formData.contacts.administrative}
                               onChange={this.createChangeHandler("administrative", "contacts")}
+                              required={true}
                             />
                           </Card.Body>
                         </Accordion.Collapse>
@@ -506,6 +510,7 @@ class Registration extends React.Component {
                             <Contact
                               contact={this.state.formData.contacts.billing}
                               onChange={this.createChangeHandler("billing", "contacts")}
+                              requried={false}
                             />
                           </Card.Body>
                         </Accordion.Collapse>


### PR DESCRIPTION
Per the attribution team: the admin contact and phone number is required
for verification. This PR enables Front-End validation of these fields,
though the backend does not enforce it.