### PR TITLE
Registration Export Tool

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -362,6 +362,16 @@ func register(c *cli.Context) (err error) {
 		return cli.NewExitError(err, 1)
 	}
 
+	// Check if this is a form downloaded from the UI
+	tmp := make(map[string]interface{})
+	if err = json.Unmarshal(data, &tmp); err == nil {
+		if form, ok := tmp["registrationForm"]; ok {
+			if data, err = json.Marshal(form); err != nil {
+				return cli.NewExitError(fmt.Errorf("could not extract registration form: %s", err), 1)
+			}
+		}
+	}
+
 	var req *api.RegisterRequest
 	if err = json.Unmarshal(data, &req); err != nil {
 		return cli.NewExitError(err, 1)


### PR DESCRIPTION
This PR is the first step towards automatic transferal of TestNet registrations to Production registrations; it allows us to directly access the database and export a registration form that can be uploaded manually to the production UI.

- [x] `gdsutil register:Export` CLI tool
- [x] Fixes to UI to not error on missing fields

The UI fix is to remarshal the registration form JSON to ensure that all fields are included even if they have the `omitempty` tag from the Go files generated from the protocol buffers. 