### PR TITLE
GDS Admin API: Filter VASP list by status

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -292,6 +292,10 @@ func main() {
 					Name:  "s, page-size",
 					Usage: "specify the number of items per page",
 				},
+				cli.StringFlag{
+					Name:  "S, status",
+					Usage: "filter by verification status",
+				},
 			},
 		},
 	}
@@ -613,6 +617,7 @@ func adminListVASPs(c *cli.Context) (err error) {
 	params := &admin.ListVASPsParams{
 		Page:     c.Int("page"),
 		PageSize: c.Int("page-size"),
+		Status:   c.String("status"),
 	}
 
 	var rep *admin.ListVASPsReply

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -41,8 +41,9 @@ type StatusReply struct {
 // ListVASPsParams is a request-like struct that passes query params to the ListVASPs
 // GET request. All query params are optional and modify how and what data is retrieved.
 type ListVASPsParams struct {
-	Page     int `url:"page,omitempty" form:"page" default:"1"`             // defaults to page 1 if not included
-	PageSize int `url:"page_size,omitempty" form:"page_size" default:"100"` // defaults to 100 if not included
+	Status   string `url:"status,omitempty" form:"status"`
+	Page     int    `url:"page,omitempty" form:"page" default:"1"`             // defaults to page 1 if not included
+	PageSize int    `url:"page_size,omitempty" form:"page_size" default:"100"` // defaults to 100 if not included
 }
 
 // ListVASPsReply contains a summary data structure of all VASPs managed by the directory.

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -136,6 +136,7 @@ func TestListVASPs(t *testing.T) {
 	}
 
 	params := &admin.ListVASPsParams{
+		Status:   "pending_review",
 		Page:     2,
 		PageSize: 10,
 	}
@@ -144,7 +145,7 @@ func TestListVASPs(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/v2/vasps", r.URL.Path)
-		require.Equal(t, "page=2&page_size=10", r.URL.RawQuery)
+		require.Equal(t, "page=2&page_size=10&status=pending_review", r.URL.RawQuery)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Adds a query param to the vasp list endpoint to filter by verification
status. The verification status must match one of the protocol buffer
verification status strings, but is case and whitespace insensitive.

Fixes SC-577