### PR TITLE
GDS Admin API: VASP Detail Endpoint

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -298,6 +298,19 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:     "admin:detail",
+			Usage:    "retrieve a VASP detail recrod by id",
+			Category: "admin",
+			Action:   adminRetrieveVASPs,
+			Before:   initClient,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "the uuid of the VASP to retrieve",
+				},
+			},
+		},
 	}
 
 	app.Run(os.Args)
@@ -622,6 +635,18 @@ func adminListVASPs(c *cli.Context) (err error) {
 
 	var rep *admin.ListVASPsReply
 	if rep, err = adminClient.ListVASPs(ctx, params); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminRetrieveVASPs(c *cli.Context) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var rep *admin.RetrieveVASPReply
+	if rep, err = adminClient.RetrieveVASP(ctx, c.String("id")); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -136,6 +136,7 @@ func (s *Admin) setupRoutes() (err error) {
 	v2 := s.router.Group("/v2")
 	v2.GET("/status", s.Status)
 	v2.GET("/vasps", s.ListVASPs)
+	v2.GET("/vasps/:vaspID", s.RetrieveVASP)
 	v2.POST("/vasps/:vaspID/review", s.Review)
 	v2.POST("/vasps/:vaspID/resend", s.Resend)
 
@@ -236,6 +237,22 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 	}
 
 	// Successful request, return the VASP list JSON data
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Admin) RetrieveVASP(c *gin.Context) {
+	var (
+		err    error
+		vaspID string
+		out    *admin.RetrieveVASPReply
+	)
+	// Get vaspID from the URL
+	vaspID = c.Param("vaspID")
+
+	out = new(admin.RetrieveVASPReply)
+	log.Debug().Err(err).Str("id", vaspID).Msg("endpoint stub")
+
+	// Successful request, return the VASP detail JSON data
 	c.JSON(http.StatusOK, out)
 }
 

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -265,7 +265,9 @@ func (s *Admin) RetrieveVASP(c *gin.Context) {
 		Traveler:         models.IsTraveler(vasp),
 	}
 	if out.Name, err = vasp.Name(); err != nil {
-		log.Warn().Err(err).Msg("could not get VASP name")
+		// This is a serious data validation error that needs to be addressed ASAP by
+		// the operations team but should not block this API return.
+		log.Error().Err(err).Msg("could not get VASP name")
 	}
 
 	// Remove extra data from the VASP

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -2,6 +2,7 @@ package gds
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/trisacrypto/directory/pkg"
 	admin "github.com/trisacrypto/directory/pkg/gds/admin/v2"
@@ -244,13 +246,59 @@ func (s *Admin) RetrieveVASP(c *gin.Context) {
 	var (
 		err    error
 		vaspID string
+		vasp   *pb.VASP
 		out    *admin.RetrieveVASPReply
 	)
 	// Get vaspID from the URL
 	vaspID = c.Param("vaspID")
 
-	out = new(admin.RetrieveVASPReply)
-	log.Debug().Err(err).Str("id", vaspID).Msg("endpoint stub")
+	// Attempt to fetch the VASP from the database
+	if vasp, err = s.db.RetrieveVASP(vaspID); err != nil {
+		log.Warn().Err(err).Str("id", vaspID).Msg("could not retrieve vasp")
+		c.JSON(http.StatusNotFound, admin.ErrorResponse("could not retrieve VASP record by ID"))
+		return
+	}
+
+	// Create the response to send back
+	out = &admin.RetrieveVASPReply{
+		VerifiedContacts: models.VerifiedContacts(vasp),
+		Traveler:         models.IsTraveler(vasp),
+	}
+	if out.Name, err = vasp.Name(); err != nil {
+		log.Warn().Err(err).Msg("could not get VASP name")
+	}
+
+	// Remove extra data from the VASP
+	// Must be done after verified contacts is computed
+	// This is safe because nothing is saved back to the database
+	vasp.Extra = nil
+	vasp.Contacts.Administrative.Extra = nil
+	vasp.Contacts.Legal.Extra = nil
+	vasp.Contacts.Technical.Extra = nil
+	vasp.Contacts.Billing.Extra = nil
+
+	// Serialize the VASP from protojson
+	jsonpb := protojson.MarshalOptions{
+		Multiline:       false,
+		AllowPartial:    true,
+		UseProtoNames:   true,
+		UseEnumNumbers:  false,
+		EmitUnpopulated: true,
+	}
+
+	var data []byte
+	if data, err = jsonpb.Marshal(vasp); err != nil {
+		log.Warn().Err(err).Str("id", vaspID).Msg("could marshal vasp json")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not create VASP json detail"))
+		return
+	}
+
+	// Remarshal the JSON (unnecessary work, but done to make things easier)
+	if err = json.Unmarshal(data, &out.VASP); err != nil {
+		log.Warn().Err(err).Str("id", vaspID).Msg("could unmarshal vasp json")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not create VASP json detail"))
+		return
+	}
 
 	// Successful request, return the VASP detail JSON data
 	c.JSON(http.StatusOK, out)

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -57,6 +57,7 @@ type ListVASPsReply struct {
 	PageSize int           `json:"page_size"`
 }
 
+// VASPSnippet provides summary information about a VASP.
 type VASPSnippet struct {
 	ID                 string   `json:"id"`
 	Name               string   `json:"name"`
@@ -67,10 +68,19 @@ type VASPSnippet struct {
 	VerifiedContacts   []string `json:"verified_contacts"`
 }
 
-// RetrieveVASPReply converts a pb.VASP record into a meaningful record for the Admin API
-// including extra information such as verified contacts, whether or not the VASP is a
-// Traveler node, and other pre-computed data to facilitate administrative actions.
-type RetrieveVASPReply struct{}
+// RetrieveVASPReply returns a pb.VASP record that has been marshaled by protojson and
+// includes extra information such as verified contacts, whether or not the VASP is a
+// Traveler node, and other pre-computed data to facilitate administrative actions. The
+// serialized pb.VASP record is returned to make sure that the Admin API keeps up with
+// changes in the TRISA library. Admin API developers should reference the
+// trisacrypto/trisa library to ensure they have all of the requried data that is
+// returned. Go developers should unmarshal the data into a *pb.VASP struct.
+type RetrieveVASPReply struct {
+	Name             string                 `json:"name"`
+	VASP             map[string]interface{} `json:"vasp"`
+	VerifiedContacts map[string]string      `json:"verified_contacts"`
+	Traveler         bool                   `json:"traveler"`
+}
 
 //===========================================================================
 // VASP Action RPCs

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -13,6 +13,7 @@ import (
 type DirectoryAdministrationClient interface {
 	Status(ctx context.Context) (out *StatusReply, err error)
 	ListVASPs(ctx context.Context, params *ListVASPsParams) (out *ListVASPsReply, err error)
+	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
 	Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error)
 	Resend(ctx context.Context, in *ResendRequest) (out *ResendReply, err error)
 }
@@ -65,6 +66,11 @@ type VASPSnippet struct {
 	Traveler           bool     `json:"traveler"`
 	VerifiedContacts   []string `json:"verified_contacts"`
 }
+
+// RetrieveVASPReply converts a pb.VASP record into a meaningful record for the Admin API
+// including extra information such as verified contacts, whether or not the VASP is a
+// Traveler node, and other pre-computed data to facilitate administrative actions.
+type RetrieveVASPReply struct{}
 
 //===========================================================================
 // VASP Action RPCs

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -89,6 +89,28 @@ func (s APIv2) ListVASPs(ctx context.Context, in *ListVASPsParams) (out *ListVAS
 	return out, nil
 }
 
+func (s APIv2) RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error) {
+	// Compute the path based on the id
+	if id == "" {
+		return nil, errors.New("id is required to compute the URL for the VASP")
+	}
+	path := fmt.Sprintf("/v2/vasps/%s", id)
+
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, path, nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &RetrieveVASPReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func (s APIv2) Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error) {
 	// The ID is required for the review request to determine the endpoint
 	if in.ID == "" {

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -165,6 +165,34 @@ func TestListVASPs(t *testing.T) {
 	require.Equal(t, fixture.Count, out.Count)
 }
 
+func TestRetrieveVASP(t *testing.T) {
+	fixture := &admin.RetrieveVASPReply{}
+	id := "83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5"
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v2/vasps/83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := admin.New(ts.URL)
+	require.NoError(t, err)
+
+	// Ensure an ID is required to retrieve the VASP
+	_, err = client.RetrieveVASP(context.TODO(), "")
+	require.Error(t, err)
+
+	out, err := client.RetrieveVASP(context.TODO(), id)
+	require.NoError(t, err)
+	require.NotZero(t, out)
+}
+
 func TestReview(t *testing.T) {
 	fixture := &admin.ReviewReply{
 		Status:  "reviewed",

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -166,7 +166,20 @@ func TestListVASPs(t *testing.T) {
 }
 
 func TestRetrieveVASP(t *testing.T) {
-	fixture := &admin.RetrieveVASPReply{}
+	// For a more complete VASP record see: https://tinyurl.com/4xm7774w
+	fixture := &admin.RetrieveVASPReply{
+		Name: "Alice VASP",
+		VASP: map[string]interface{}{
+			"id":          "83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5",
+			"common_name": "trisa.alice.us",
+			"endpoint":    "trisa.alice.us:443",
+		},
+		VerifiedContacts: map[string]string{
+			"legal":     "legal@alice.us",
+			"technical": "technical@alice.us",
+		},
+		Traveler: false,
+	}
 	id := "83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5"
 
 	// Create a Test Server
@@ -191,6 +204,10 @@ func TestRetrieveVASP(t *testing.T) {
 	out, err := client.RetrieveVASP(context.TODO(), id)
 	require.NoError(t, err)
 	require.NotZero(t, out)
+	require.Equal(t, fixture.Name, out.Name)
+	require.Equal(t, fixture.VASP, out.VASP)
+	require.Equal(t, fixture.VerifiedContacts, out.VerifiedContacts)
+	require.Equal(t, fixture.Traveler, out.Traveler)
 }
 
 func TestReview(t *testing.T) {


### PR DESCRIPTION
This endpoint provides a mechanism to retrieve the details for a VASP
that are required for the Admin UI - including some computed values and
extra information that are not standard in the pb.VASP record.

Fixes SC-571

TODO:
- [x] create endpoint stub in client and server
- [x] define vasp detail record
- [x] implement admin api endpoint