### PR TITLE
GDS Admin API: Summary Endpoint

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -262,20 +262,19 @@ func main() {
 		},
 		{
 			Name:     "admin:status",
-			Usage:    "collect aggregate information about current registration status",
+			Usage:    "perform a health check against the admin API",
 			Category: "admin",
 			Action:   adminStatus,
 			Before:   initClient,
-			Flags: []cli.Flag{
-				cli.BoolFlag{
-					Name:  "r, no-registrations",
-					Usage: "do not return registrations status",
-				},
-				cli.BoolFlag{
-					Name:  "c, no-certificate-requests",
-					Usage: "do not return certificate requests status",
-				},
-			},
+			Flags:    []cli.Flag{},
+		},
+		{
+			Name:     "admin:summary",
+			Usage:    "collect aggregate information about current GDS status",
+			Category: "admin",
+			Action:   adminSummary,
+			Before:   initClient,
+			Flags:    []cli.Flag{},
 		},
 		{
 			Name:     "admin:list",
@@ -617,6 +616,18 @@ func adminStatus(c *cli.Context) (err error) {
 
 	var rep *admin.StatusReply
 	if rep, err = adminClient.Status(ctx); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminSummary(c *cli.Context) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var rep *admin.SummaryReply
+	if rep, err = adminClient.Summary(ctx); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -178,9 +178,9 @@ func (s *Admin) Summary(c *gin.Context) {
 			}
 		}
 
-		// Count Statuses
+		// Count Statuses and any status that is "pending" -- awaiting action by a reviewer.
 		out.Statuses[vasp.VerificationStatus.String()]++
-		if int32(vasp.VerificationStatus) < int32(pb.VerificationState_VERIFIED) {
+		if int32(vasp.VerificationStatus) < int32(pb.VerificationState_VERIFIED) || vasp.VerificationStatus == pb.VerificationState_APPEALED {
 			out.PendingRegistrations++
 		}
 
@@ -204,7 +204,7 @@ func (s *Admin) Summary(c *gin.Context) {
 		}
 	}
 
-	if err := iter.Error(); err != nil {
+	if err := iter2.Error(); err != nil {
 		iter2.Release()
 		log.Warn().Err(err).Msg("could not iterate over certreqs in store")
 		c.JSON(http.StatusInternalServerError, admin.ErrorResponse(err))

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -12,6 +12,7 @@ import (
 // DirectoryAdministrationClient defines client-side interactions with the API.
 type DirectoryAdministrationClient interface {
 	Status(ctx context.Context) (out *StatusReply, err error)
+	Summary(ctx context.Context) (out *SummaryReply, err error)
 	ListVASPs(ctx context.Context, params *ListVASPsParams) (out *ListVASPsReply, err error)
 	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
 	Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error)
@@ -38,6 +39,17 @@ type StatusReply struct {
 //===========================================================================
 // Admin v2 API Requests and Responses
 //===========================================================================
+
+// Summary provides aggregate statistics that describe the state of the GDS.
+type SummaryReply struct {
+	VASPsCount           int            `json:"vasps_count"`           // the total number of VASPs in any state in GDS
+	PendingRegistrations int            `json:"pending_registrations"` // the number of registrations pending (in any pre-review status)
+	ContactsCount        int            `json:"contacts_count"`        // the number of contacts in the system
+	VerifiedContacts     int            `json:"verified_contacts"`     // the number of verified contacts in the system
+	CertificatesIssued   int            `json:"certificates_issued"`   // the number of certificates issued by the GDS
+	Statuses             map[string]int `json:"statuses"`              // the counts of all statuses in the system
+	CertReqs             map[string]int `json:"certreqs"`              // The counts of all certificate request statuses
+}
 
 // ListVASPsParams is a request-like struct that passes query params to the ListVASPs
 // GET request. All query params are optional and modify how and what data is retrieved.

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -67,6 +67,21 @@ func (s APIv2) Status(ctx context.Context) (out *StatusReply, err error) {
 	return out, nil
 }
 
+func (s APIv2) Summary(ctx context.Context) (out *SummaryReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v2/summary", nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &SummaryReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s APIv2) ListVASPs(ctx context.Context, in *ListVASPsParams) (out *ListVASPsReply, err error) {
 	// Create the query params from the input
 	var params url.Values


### PR DESCRIPTION
Implements a summary endpoint to create a dashboard for TRISA admins
that lets them know the current state of the GDS including aggregate
counts of contacts, registrations, and certificate requests.

Fixes SC-576