### PR TITLE
GDS Admin API: Autocomplete Endpoint

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -277,6 +277,14 @@ func main() {
 			Flags:    []cli.Flag{},
 		},
 		{
+			Name:     "admin:autocomplete",
+			Usage:    "get autocomplete names for the admin searchbar",
+			Category: "admin",
+			Action:   adminAutocomplete,
+			Before:   initClient,
+			Flags:    []cli.Flag{},
+		},
+		{
 			Name:     "admin:list",
 			Usage:    "list all VASPs summary detail",
 			Category: "admin",
@@ -628,6 +636,18 @@ func adminSummary(c *cli.Context) (err error) {
 
 	var rep *admin.SummaryReply
 	if rep, err = adminClient.Summary(ctx); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminAutocomplete(c *cli.Context) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var rep *admin.AutocompleteReply
+	if rep, err = adminClient.Autocomplete(ctx); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
       dockerfile: ./containers/gds-ui/Dockerfile
       args:
         REACT_APP_GDS_API_ENDPOINT: http://localhost:8080/
-        REACT_APP_GDS_IS_TESTNET: true
+        REACT_APP_GDS_IS_TESTNET: "true"
     image: trisa/gds-ui
     ports:
       - 3000:80
@@ -80,7 +80,7 @@ services:
       dockerfile: ./containers/gds-admin-ui/Dockerfile
       args:
         REACT_APP_GDS_API_ENDPOINT: http://localhost:4434/
-        REACT_APP_GDS_IS_TESTNET: true
+        REACT_APP_GDS_IS_TESTNET: "true"
     image: trisa/gds-admin-ui
     ports:
       - 3001:80

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -159,7 +159,11 @@ func (s *Admin) Summary(c *gin.Context) {
 	iter := s.db.ListVASPs()
 	for iter.Next() {
 		// Fetch VASP from the database
-		vasp := iter.VASP()
+		var vasp *pb.VASP
+		if vasp = iter.VASP(); vasp == nil {
+			// VASP could not be parsed; error logged in VASP() method continue iteration
+			continue
+		}
 
 		// Count VASPs
 		out.VASPsCount++
@@ -198,7 +202,13 @@ func (s *Admin) Summary(c *gin.Context) {
 	// Loop over certificate requests next
 	iter2 := s.db.ListCertReqs()
 	for iter2.Next() {
-		certreq := iter2.CertReq()
+		// Fetch CertificateRequest from the database
+		var certreq *models.CertificateRequest
+		if certreq = iter2.CertReq(); certreq == nil {
+			// CertificateRequest could not be parsed; error logged in CertReq() method continue iteration
+			continue
+		}
+
 		out.CertReqs[certreq.Status.String()]++
 		if certreq.Status == models.CertificateRequestState_COMPLETED {
 			out.CertificatesIssued++
@@ -233,7 +243,11 @@ func (s *Admin) Autocomplete(c *gin.Context) {
 	defer iter.Release()
 	for iter.Next() {
 		// Fetch VASP from the database
-		vasp := iter.VASP()
+		var vasp *pb.VASP
+		if vasp = iter.VASP(); vasp == nil {
+			// VASP could not be parsed; error logged in VASP() method continue iteration
+			continue
+		}
 
 		// Add top level names to the autocomplete
 		out.Names[vasp.CommonName] = vasp.Id
@@ -320,7 +334,12 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 		out.Count++
 		if out.Count >= minIndex && out.Count < maxIndex {
 			// In the page range so add to the list reply
-			vasp := iter.VASP()
+			// Fetch VASP from the database
+			var vasp *pb.VASP
+			if vasp = iter.VASP(); vasp == nil {
+				// VASP could not be parsed; error logged in VASP() method continue iteration
+				continue
+			}
 
 			// Check the status before continuing
 			if status != pb.VerificationState_NO_VERIFICATION && vasp.VerificationStatus != status {

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -138,6 +138,7 @@ func (s *Admin) setupRoutes() (err error) {
 	v2 := s.router.Group("/v2")
 	v2.GET("/status", s.Status)
 	v2.GET("/summary", s.Summary)
+	v2.GET("/autocomplete", s.Autocomplete)
 	v2.GET("/vasps", s.ListVASPs)
 	v2.GET("/vasps/:vaspID", s.RetrieveVASP)
 	v2.POST("/vasps/:vaspID/review", s.Review)
@@ -211,6 +212,53 @@ func (s *Admin) Summary(c *gin.Context) {
 		return
 	}
 	iter2.Release()
+
+	// Successful request, return the VASP list JSON data
+	c.JSON(http.StatusOK, out)
+}
+
+// Autocomplete returns a mapping of name to VASP UUID for the search bar.
+func (s *Admin) Autocomplete(c *gin.Context) {
+	// Prepare the output response
+	out := &admin.AutocompleteReply{
+		Names: make(map[string]string),
+	}
+
+	// Query the list of VASPs from the data store to perform aggregation counts.
+	// NOTE: we could have just queried the names index, which would be a lot faster
+	// than iterating over the VASPs; if the UI requires more complex information
+	// storage then the VASP iteration is better (or a better index). If it doesn't,
+	// then this should be refactored to simply fetch the index and return it.
+	iter := s.db.ListVASPs()
+	defer iter.Release()
+	for iter.Next() {
+		// Fetch VASP from the database
+		vasp := iter.VASP()
+
+		// Add top level names to the autocomplete
+		out.Names[vasp.CommonName] = vasp.Id
+		out.Names[vasp.Website] = vasp.Website
+
+		// Add all legal person names
+		if vasp.Entity != nil {
+			for _, name := range vasp.Entity.Names() {
+				if _, ok := out.Names[name]; !ok {
+					out.Names[name] = vasp.Id
+				} else {
+					log.Warn().Str("name", name).Msg("duplicate name detected")
+				}
+			}
+		}
+	}
+
+	if err := iter.Error(); err != nil {
+		log.Warn().Err(err).Msg("could not iterate over vasps in store")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse(err))
+		return
+	}
+
+	// In case any of the names were empty string, delete it (no guard required)
+	delete(out.Names, "")
 
 	// Successful request, return the VASP list JSON data
 	c.JSON(http.StatusOK, out)

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -13,6 +13,7 @@ import (
 type DirectoryAdministrationClient interface {
 	Status(ctx context.Context) (out *StatusReply, err error)
 	Summary(ctx context.Context) (out *SummaryReply, err error)
+	Autocomplete(ctx context.Context) (out *AutocompleteReply, err error)
 	ListVASPs(ctx context.Context, params *ListVASPsParams) (out *ListVASPsReply, err error)
 	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
 	Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error)
@@ -40,7 +41,7 @@ type StatusReply struct {
 // Admin v2 API Requests and Responses
 //===========================================================================
 
-// Summary provides aggregate statistics that describe the state of the GDS.
+// SummaryReply provides aggregate statistics that describe the state of the GDS.
 type SummaryReply struct {
 	VASPsCount           int            `json:"vasps_count"`           // the total number of VASPs in any state in GDS
 	PendingRegistrations int            `json:"pending_registrations"` // the number of registrations pending (in any pre-review status)
@@ -49,6 +50,11 @@ type SummaryReply struct {
 	CertificatesIssued   int            `json:"certificates_issued"`   // the number of certificates issued by the GDS
 	Statuses             map[string]int `json:"statuses"`              // the counts of all statuses in the system
 	CertReqs             map[string]int `json:"certreqs"`              // The counts of all certificate request statuses
+}
+
+// AutocompleteReply contains a mapping of name to VASP UUID for the search bar.
+type AutocompleteReply struct {
+	Names map[string]string `json:"names"`
 }
 
 // ListVASPsParams is a request-like struct that passes query params to the ListVASPs

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -82,6 +82,21 @@ func (s APIv2) Summary(ctx context.Context) (out *SummaryReply, err error) {
 	return out, nil
 }
 
+func (s APIv2) Autocomplete(ctx context.Context) (out *AutocompleteReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v2/autocomplete", nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &AutocompleteReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s APIv2) ListVASPs(ctx context.Context, in *ListVASPsParams) (out *ListVASPsReply, err error) {
 	// Create the query params from the input
 	var params url.Values

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -154,6 +154,38 @@ func TestSummary(t *testing.T) {
 	require.Equal(t, fixture.CertReqs, out.CertReqs)
 }
 
+func TestAutocomplete(t *testing.T) {
+	fixture := &admin.AutocompleteReply{
+		Names: map[string]string{
+			"Bob VASP":              "5b180719-62c4-4674-ab2a-279ddb0e487a",
+			"api.bob.vaspbot.net":   "5b180719-62c4-4674-ab2a-279ddb0e487a",
+			"https://bobvasp.co.uk": "5b180719-62c4-4674-ab2a-279ddb0e487a",
+			"Alice VASP":            "24e8efd3-c97a-4973-a76d-290f3bb4be95",
+			"api.alice.vaspbot.net": "24e8efd3-c97a-4973-a76d-290f3bb4be95",
+			"https://alicevasp.us":  "24e8efd3-c97a-4973-a76d-290f3bb4be95",
+		},
+	}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v2/autocomplete", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := admin.New(ts.URL)
+	require.NoError(t, err)
+
+	out, err := client.Autocomplete(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, fixture.Names, out.Names)
+}
+
 func TestListVASPs(t *testing.T) {
 	fixture := &admin.ListVASPsReply{
 		VASPs: []admin.VASPSnippet{

--- a/pkg/gds/store/leveldb/iterator.go
+++ b/pkg/gds/store/leveldb/iterator.go
@@ -41,7 +41,7 @@ func (i *iterWrapper) Release() {
 func (i *vaspIterator) VASP() *pb.VASP {
 	vasp := new(pb.VASP)
 	if err := proto.Unmarshal(i.iter.Value(), vasp); err != nil {
-		log.Error().Err(err).Str("type", wire.NamespaceVASPs).Msg("corrupted data encountered")
+		log.Error().Err(err).Str("type", wire.NamespaceVASPs).Str("key", string(i.iter.Key())).Msg("corrupted data encountered")
 		return nil
 	}
 	return vasp
@@ -68,7 +68,7 @@ func (i *vaspIterator) All() (vasps []*pb.VASP, err error) {
 func (i *certReqIterator) CertReq() *models.CertificateRequest {
 	r := new(models.CertificateRequest)
 	if err := proto.Unmarshal(i.iter.Value(), r); err != nil {
-		log.Error().Err(err).Str("type", wire.NamespaceCertReqs).Msg("corrupted data encountered")
+		log.Error().Err(err).Str("type", wire.NamespaceCertReqs).Str("key", string(i.iter.Key())).Msg("corrupted data encountered")
 		return nil
 	}
 	return r
@@ -95,7 +95,7 @@ func (i *certReqIterator) All() (reqs []*models.CertificateRequest, err error) {
 func (i *peerIterator) Peer() *peers.Peer {
 	peer := new(peers.Peer)
 	if err := proto.Unmarshal(i.iter.Value(), peer); err != nil {
-		log.Error().Err(err).Str("type", wire.NamespaceReplicas).Msg("corrupted data encountered")
+		log.Error().Err(err).Str("type", wire.NamespaceReplicas).Str("key", string(i.iter.Key())).Msg("corrupted data encountered")
 		return nil
 	}
 	return peer


### PR DESCRIPTION
Implements an endpoint that returns a mapping of all VASP names (legal
entity names, common name, website) to its UUID for use in the search
bar of the Admin UI. The result is a simple mapping, but more
requirements are required from the front end to know what data is
required in the return statement.

Fixes SC-583

Blocked by #103 