### PR TITLE
Better Verified Contacts Handling

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -359,11 +359,7 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 			snippet.Name, _ = vasp.Name()
 
 			// Add verified contacts to snippet
-			contacts := models.VerifiedContacts(vasp)
-			snippet.VerifiedContacts = make([]string, 0, len(contacts))
-			for key := range contacts {
-				snippet.VerifiedContacts = append(snippet.VerifiedContacts, key)
-			}
+			snippet.VerifiedContacts = models.ContactVerifications(vasp)
 
 			// Append to list in reply
 			out.VASPs = append(out.VASPs, snippet)

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -77,13 +77,13 @@ type ListVASPsReply struct {
 
 // VASPSnippet provides summary information about a VASP.
 type VASPSnippet struct {
-	ID                 string   `json:"id"`
-	Name               string   `json:"name"`
-	CommonName         string   `json:"common_name"`
-	VerificationStatus string   `json:"verification_status,omitempty"`
-	LastUpdated        string   `json:"last_updated,omitempty"`
-	Traveler           bool     `json:"traveler"`
-	VerifiedContacts   []string `json:"verified_contacts"`
+	ID                 string          `json:"id"`
+	Name               string          `json:"name"`
+	CommonName         string          `json:"common_name"`
+	VerificationStatus string          `json:"verification_status,omitempty"`
+	LastUpdated        string          `json:"last_updated,omitempty"`
+	Traveler           bool            `json:"traveler"`
+	VerifiedContacts   map[string]bool `json:"verified_contacts"`
 }
 
 // RetrieveVASPReply returns a pb.VASP record that has been marshaled by protojson and

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -196,7 +196,7 @@ func TestListVASPs(t *testing.T) {
 				VerificationStatus: "verified",
 				LastUpdated:        "2021-08-15T12:32:41Z",
 				Traveler:           false,
-				VerifiedContacts:   []string{"administrative", "technical"},
+				VerifiedContacts:   map[string]bool{"administrative": true, "technical": false},
 			},
 			{
 				ID:                 "5a26150d-ac6b-4bc8-973f-9065b815286c",
@@ -205,7 +205,7 @@ func TestListVASPs(t *testing.T) {
 				VerificationStatus: "pending review",
 				LastUpdated:        "2021-09-11T22:02:39Z",
 				Traveler:           false,
-				VerifiedContacts:   []string{"billing", "technical"},
+				VerifiedContacts:   map[string]bool{"billing": false, "technical": true},
 			},
 		},
 		Page:     2,


### PR DESCRIPTION
The VASP List endpoint required both verified and unverified contacts to
display badges correctly in the UI. This PR adapts the response to
return a map of contact name to verified bool rather than just a list of
verified contacts.

Unblocks SC-594