### PR TITLE
Implements Double Cookie Middleware

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -136,15 +136,35 @@ func (s *Admin) setupRoutes() (err error) {
 
 	// Add the v2 API routes
 	v2 := s.router.Group("/v2")
+	v2.POST("/authenticate", s.Authenticate)
+	v2.POST("/reauthenticate", admin.DoubleCookie(), s.Reauthenticate)
 	v2.GET("/status", s.Status)
 	v2.GET("/summary", s.Summary)
 	v2.GET("/autocomplete", s.Autocomplete)
 	v2.GET("/vasps", s.ListVASPs)
 	v2.GET("/vasps/:vaspID", s.RetrieveVASP)
-	v2.POST("/vasps/:vaspID/review", s.Review)
-	v2.POST("/vasps/:vaspID/resend", s.Resend)
+	v2.POST("/vasps/:vaspID/review", admin.DoubleCookie(), s.Review)
+	v2.POST("/vasps/:vaspID/resend", admin.DoubleCookie(), s.Resend)
 
 	return nil
+}
+
+func (s *Admin) Authenticate(c *gin.Context) {
+	if err := admin.SetDoubleCookieTokens(c, time.Now().Add(time.Minute*10).Unix()); err != nil {
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not set cookies"))
+		return
+	}
+
+	c.JSON(http.StatusNotImplemented, admin.ErrorResponse("not implemented yet"))
+}
+
+func (s *Admin) Reauthenticate(c *gin.Context) {
+	if err := admin.SetDoubleCookieTokens(c, time.Now().Add(time.Minute*10).Unix()); err != nil {
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not set cookies"))
+		return
+	}
+
+	c.JSON(http.StatusNotImplemented, admin.ErrorResponse("not implemented yet"))
 }
 
 // Summary provides aggregate statistics that describe the state of the GDS.

--- a/pkg/gds/admin/v2/csurf.go
+++ b/pkg/gds/admin/v2/csurf.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -36,6 +37,13 @@ func DoubleCookie() gin.HandlerFunc {
 		}
 
 		header := c.GetHeader(CSRFHeader)
+		if header, err = url.QueryUnescape(header); err != nil {
+			log.Warn().Err(err).Msg("could not unescape csrf token")
+			c.JSON(http.StatusBadRequest, ErrorResponse(err))
+			c.Abort()
+			return
+		}
+
 		if cookie != header {
 			log.Warn().Bool("header_exists", header != "").Bool("cookie_exists", cookie != "").Msg("csrf token cookie/header mismatch")
 			c.JSON(http.StatusForbidden, ErrorResponse(ErrCSRFVerification))

--- a/pkg/gds/admin/v2/csurf.go
+++ b/pkg/gds/admin/v2/csurf.go
@@ -1,0 +1,92 @@
+package admin
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+)
+
+// Parameters and names for double-cookie submit CSRF protection
+const (
+	CSRFCookie          = "csrf_token"
+	CSRFReferenceCookie = "csrf_reference_token"
+	CSRFHeader          = "X-CSRF-TOKEN"
+)
+
+// DoubleCookie is Cross Site Request Forgery (CSRF/XSRF) protection middleware that
+// checks the presence of an X-CSRF-TOKEN header containing a cryptographically random
+// token that matches a token contained in the CSRF-TOKEN cookie in the request.
+// Because of the same-origin policy, an attacker cannot access the cookies or scripts
+// of the safe site therefore it will not be able to guess what token to put in the
+// request, thereby protecting from CSRF attacks. Note that Double Cookie CSRF
+// protection requires TLS to prevent MITM attacks.
+func DoubleCookie() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		cookie, err := c.Cookie(CSRFReferenceCookie)
+		if err != nil {
+			log.Warn().Err(err).Msg("no csrf token cookie in request")
+			c.JSON(http.StatusForbidden, ErrorResponse(ErrCSRFVerification))
+			c.Abort()
+			return
+		}
+
+		header := c.GetHeader(CSRFHeader)
+		if cookie != header {
+			log.Warn().Bool("header_exists", header != "").Bool("cookie_exists", cookie != "").Msg("csrf token cookie/header mismatch")
+			c.JSON(http.StatusForbidden, ErrorResponse(ErrCSRFVerification))
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// SetDoubleCookieTokens is a helper function to set cookies on a gin-request.
+func SetDoubleCookieTokens(c *gin.Context, nbf int64) error {
+	// Generate the CSRF token
+	token, err := GenerateCSRFToken()
+	if err != nil {
+		return err
+	}
+
+	// Compute max age from the not before unix timestamp of the access token.
+	maxAge := int((time.Until(time.Unix(nbf, 0))).Seconds())
+
+	// Set the reference cookie
+	c.SetCookie(CSRFReferenceCookie, token, maxAge, "/", "", true, true)
+
+	// Set the csrf token cookie
+	c.SetCookie(CSRFCookie, token, maxAge, "/", "", true, false)
+	return nil
+}
+
+// This is random seed that is meant to present an additional barrier to cryptanalysis
+// and is unique to each process in the network.
+var seed []byte
+
+func GenerateCSRFToken() (_ string, err error) {
+	// If the process seed is not generated, generate it now.
+	if len(seed) == 0 {
+		seed = make([]byte, 16)
+		if _, err = rand.Read(seed); err != nil {
+			return "", err
+		}
+	}
+
+	nonce := make([]byte, 32)
+	if _, err = rand.Read(nonce); err != nil {
+		return "", err
+	}
+
+	sig := sha256.New()
+	sig.Write(seed)
+	sig.Write(nonce)
+
+	return base64.URLEncoding.EncodeToString(sig.Sum(nil)), nil
+}

--- a/pkg/gds/admin/v2/csurf_test.go
+++ b/pkg/gds/admin/v2/csurf_test.go
@@ -1,0 +1,111 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/admin/v2"
+)
+
+func TestDoubleCookies(t *testing.T) {
+	// Test both the DoubleCookie middleware and the SetDoubleCookieTokens handler.
+	router := gin.New()
+
+	// Add login route that sets the cookies
+	router.GET("/login", func(c *gin.Context) {
+		err := admin.SetDoubleCookieTokens(c, time.Now().Add(time.Minute*10).Unix())
+		require.NoError(t, err)
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	// Add request route that requires double cookie submit
+	router.POST("/action", admin.DoubleCookie(), func(c *gin.Context) {
+		c.JSON(http.StatusCreated, gin.H{"success": true})
+	})
+
+	// Create an http client with a cookie jar
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := http.Client{
+		Jar: jar,
+	}
+
+	// Create the test server with the CSRF protected router
+	server := httptest.NewServer(router)
+
+	// Attempt to make a request to the server that is not CSRF protected
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/action", nil)
+	require.NoError(t, err)
+
+	// Ensure the request is Forbidden
+	rep, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, rep.StatusCode)
+
+	// Check the data in the response
+	data, err := readJSON(rep)
+	require.NoError(t, err)
+	require.Contains(t, data, "error")
+	require.Contains(t, data, "success")
+	require.Equal(t, admin.ErrCSRFVerification.Error(), data["error"].(string))
+	require.False(t, data["success"].(bool))
+
+	// Login and set the cookies
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/login", nil)
+	require.NoError(t, err)
+
+	// Ensure the request is Forbidden
+	rep, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rep.StatusCode)
+
+	cookies := rep.Cookies()
+	require.Len(t, cookies, 1)
+
+	// Check the data in the response
+	data, err = readJSON(rep)
+	require.NoError(t, err)
+	require.NotContains(t, data, "error")
+	require.Contains(t, data, "success")
+	require.True(t, data["success"].(bool))
+
+	// Check that we have access to the cookie now
+	ep, _ := url.Parse(server.URL)
+	cookies = client.Jar.Cookies(ep)
+	require.Len(t, cookies, 1)
+
+}
+
+func readJSON(rep *http.Response) (map[string]interface{}, error) {
+	defer rep.Body.Close()
+	body, err := ioutil.ReadAll(rep.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(map[string]interface{})
+	if err = json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func TestGenerateCSRFToken(t *testing.T) {
+	token1, err := admin.GenerateCSRFToken()
+	require.NoError(t, err)
+	require.Len(t, token1, 44)
+
+	token2, err := admin.GenerateCSRFToken()
+	require.NoError(t, err)
+
+	require.NotEqual(t, token1, token2)
+}

--- a/pkg/gds/admin/v2/errors.go
+++ b/pkg/gds/admin/v2/errors.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrInvalidResendAction = errors.New("invalid resend action")
 	ErrIDRequred           = errors.New("request requires a valid ID to determine endpoint")
+	ErrCSRFVerification    = errors.New("csrf verification failed for request")
 )
 
 var (

--- a/pkg/gds/secrets/token.go
+++ b/pkg/gds/secrets/token.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	chars        = []rune("ABCDEFGHIJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz1234567890")
-	specialChars = []rune("#$%&()*+-<=>?@[]^_{|}~")
+	specialChars = []rune("#%&()*+-<=>?@[]^_{}")
 )
 
 // CreateToken creates a variable length random token that can be used for passwords or API keys.
@@ -16,7 +16,7 @@ func CreateToken(length int) string {
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	var b strings.Builder
 	for i := 0; i < length; i++ {
-		if rand.Float64() <= 0.85 {
+		if random.Float64() <= 0.90 {
 			b.WriteRune(chars[random.Intn(len(chars))])
 		} else {
 			b.WriteRune(specialChars[random.Intn(len(specialChars))])


### PR DESCRIPTION
Implements the double cookie middleware for CSRF protection in the Admin
API. The CSRF protection relies on a cookie that is HttpOnly, e.g. one
that cannot be read in JavaScript and one that can be. The client
responsibility is to read the cookie that can be read and submit it in
an X-CSRF-TOKEN header with the request.

TODO:

- [x] Finish up tests (needs https test server for Secure cookies) 
- [x] Implement login and refresh stub endpoints that set the cookies 