### PR TITLE
Bugfix: Contact Sanitization nil Error

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -408,10 +408,18 @@ func (s *Admin) RetrieveVASP(c *gin.Context) {
 	// Must be done after verified contacts is computed
 	// This is safe because nothing is saved back to the database
 	vasp.Extra = nil
-	vasp.Contacts.Administrative.Extra = nil
-	vasp.Contacts.Legal.Extra = nil
-	vasp.Contacts.Technical.Extra = nil
-	vasp.Contacts.Billing.Extra = nil
+	if vasp.Contacts.Administrative != nil {
+		vasp.Contacts.Administrative.Extra = nil
+	}
+	if vasp.Contacts.Legal != nil {
+		vasp.Contacts.Legal.Extra = nil
+	}
+	if vasp.Contacts.Technical != nil {
+		vasp.Contacts.Technical.Extra = nil
+	}
+	if vasp.Contacts.Billing != nil {
+		vasp.Contacts.Billing.Extra = nil
+	}
 
 	// Serialize the VASP from protojson
 	jsonpb := protojson.MarshalOptions{


### PR DESCRIPTION
An error occurred when the contact was nil and the Extra data was being
sanitized. This PR "fixes" it by performing a nil check on the contact
first. However, it is likely we should simply have "sanitize"
functionality for contacts in the future.