### PR TITLE
Implements Authentication and Reauthentication endpoints

### DIFF
--- a/containers/.env.template
+++ b/containers/.env.template
@@ -13,6 +13,11 @@ GDS_SERVICE_EMAIL="TRISA Directory Service <admin@trisatest.net>"
 GDS_ADMIN_EMAIL="Test Admin <test@example.com>"
 SENDGRID_API_KEY=SG.notarealapikey
 
+# Google Identity Services
+# These two environment variables should be identical
+GDS_ADMIN_AUDIENCE=""
+REACT_APP_GOOGLE_CLIENT_ID=""
+
 # Google Service Account - set these values to store data in Google Secret Manager
 # If GDS_SECRETS_TESTING=true then a mock in-memory secret manager is used; set to
 # false if using the Google service account.

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
       args:
         REACT_APP_GDS_API_ENDPOINT: http://localhost:4434/
         REACT_APP_GDS_IS_TESTNET: "true"
-        REACT_APP_GDS_CLIENT_ID: "TODO"
+        REACT_APP_GDS_CLIENT_ID: ${REACT_APP_GDS_CLIENT_ID}
     image: trisa/gds-admin-ui
     ports:
       - 3001:80

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       - GDS_ADMIN_ENABLED=true
       - GDS_ADMIN_BIND_ADDR=:4434
       - GDS_ADMIN_TOKEN_KEYS="1y9jUjVqRqRJaiKsNqrZmQkhTqe:/data/creds/current_token_key.pem,1y9jTDgrljWl0iVUOQBcCev7rBG:/data/creds/rotated_token_key.pem"
+      - GDS_ADMIN_AUDIENCE
       - GDS_REPLICA_ENABLED=false
       - GDS_REPLICA_BIND_ADDR=:4435
       - GDS_REPLICA_PID=8
@@ -82,6 +83,7 @@ services:
       args:
         REACT_APP_GDS_API_ENDPOINT: http://localhost:4434/
         REACT_APP_GDS_IS_TESTNET: "true"
+        REACT_APP_GDS_CLIENT_ID: "TODO"
     image: trisa/gds-admin-ui
     ports:
       - 3001:80

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       - GDS_ADMIN_BIND_ADDR=:4434
       - GDS_ADMIN_TOKEN_KEYS="1y9jUjVqRqRJaiKsNqrZmQkhTqe:/data/creds/current_token_key.pem,1y9jTDgrljWl0iVUOQBcCev7rBG:/data/creds/rotated_token_key.pem"
       - GDS_ADMIN_AUDIENCE
+      - GDS_ADMIN_AUTHORIZED_DOMAINS="trisa.io,rotational.io"
       - GDS_REPLICA_ENABLED=false
       - GDS_REPLICA_BIND_ADDR=:4435
       - GDS_REPLICA_PID=8

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -13,7 +13,9 @@ import (
 	ginzerolog "github.com/dn365/gin-zerolog"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/api/idtoken"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/trisacrypto/directory/pkg"
@@ -21,15 +23,22 @@ import (
 	"github.com/trisacrypto/directory/pkg/gds/config"
 	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	"github.com/trisacrypto/directory/pkg/gds/store"
+	"github.com/trisacrypto/directory/pkg/gds/tokens"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 )
 
 // NewAdmin creates a new GDS admin server derived from a parent Service.
 func NewAdmin(svc *Service) (a *Admin, err error) {
+	// Define the base admin server
 	a = &Admin{
 		svc:  svc,
 		conf: &svc.conf.Admin,
 		db:   svc.db,
+	}
+
+	// Create the token manager
+	if a.tokens, err = tokens.New(a.conf.TokenKeys); err != nil {
+		return nil, err
 	}
 
 	// Create the router
@@ -58,12 +67,13 @@ func NewAdmin(svc *Service) (a *Admin, err error) {
 // performing secure commands with authentication.
 type Admin struct {
 	sync.RWMutex
-	svc     *Service            // The parent Service the admin server uses to interact with other components
-	srv     *http.Server        // The HTTP server that listens on its own independent port
-	conf    *config.AdminConfig // The admin server specific configuration (alias to s.svc.conf.Admin)
-	db      store.Store         // Database connection for loading objects (alias to s.svc.db)
-	router  *gin.Engine         // The HTTP handler and associated middleware
-	healthy bool                // application state of the server
+	svc     *Service             // The parent Service the admin server uses to interact with other components
+	srv     *http.Server         // The HTTP server that listens on its own independent port
+	conf    *config.AdminConfig  // The admin server specific configuration (alias to s.svc.conf.Admin)
+	tokens  *tokens.TokenManager // A token manager that signs JWT tokens with RSA keys
+	db      store.Store          // Database connection for loading objects (alias to s.svc.db)
+	router  *gin.Engine          // The HTTP handler and associated middleware
+	healthy bool                 // application state of the server
 }
 
 // Serve GRPC requests on the specified address.
@@ -136,7 +146,8 @@ func (s *Admin) setupRoutes() (err error) {
 
 	// Add the v2 API routes
 	v2 := s.router.Group("/v2")
-	v2.POST("/authenticate", s.Authenticate)
+	v2.GET("/authenticate", s.ProtectAuthenticate)
+	v2.POST("/authenticate", admin.DoubleCookie(), s.Authenticate)
 	v2.POST("/reauthenticate", admin.DoubleCookie(), s.Reauthenticate)
 	v2.GET("/status", s.Status)
 	v2.GET("/summary", s.Summary)
@@ -149,22 +160,193 @@ func (s *Admin) setupRoutes() (err error) {
 	return nil
 }
 
-func (s *Admin) Authenticate(c *gin.Context) {
-	if err := admin.SetDoubleCookieTokens(c, time.Now().Add(time.Minute*10).Unix()); err != nil {
+// Set the maximum age of authentication protection cookies.
+const protectAuthenticateMaxAge = time.Minute * 10
+
+// ProtectAuthenticate prepares the front-end for submitting a login token by setting
+// the double cookie tokens for CSRF protection. The front-end should call this before
+// posting credentials from Google.
+func (s *Admin) ProtectAuthenticate(c *gin.Context) {
+	expiresAt := time.Now().Add(protectAuthenticateMaxAge).Unix()
+	if err := admin.SetDoubleCookieTokens(c, expiresAt); err != nil {
 		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not set cookies"))
 		return
 	}
-
-	c.JSON(http.StatusNotImplemented, admin.ErrorResponse("not implemented yet"))
+	c.JSON(http.StatusOK, &admin.Reply{Success: true})
 }
 
-func (s *Admin) Reauthenticate(c *gin.Context) {
-	if err := admin.SetDoubleCookieTokens(c, time.Now().Add(time.Minute*10).Unix()); err != nil {
+// Authenticate expects a Google OAuth JWT token that is verified by the server. Once
+// verified, the JWT claims are authenticated against the server. Provided valid claims,
+// the server will issue access and referesh tokens that the client should submit in the
+// Authorization header for all future requests. This method also resets the CSRF double
+// cookies to ensure that max-age matches the duration of the refresh tokens.
+func (s *Admin) Authenticate(c *gin.Context) {
+	var (
+		err          error
+		in           *admin.AuthRequest
+		out          *admin.AuthReply
+		claims       *idtoken.Payload
+		accessToken  *jwt.Token
+		refreshToken *jwt.Token
+	)
+
+	// Parse incoming JSON data from the client request
+	in = new(admin.AuthRequest)
+	if err = c.ShouldBind(&in); err != nil {
+		log.Warn().Err(err).Msg("could not bind request")
+		c.JSON(http.StatusBadRequest, admin.ErrorResponse(err))
+		return
+	}
+
+	// Check that a credential was posted
+	if in.Credential == "" {
+		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("invalid credentials"))
+		return
+	}
+
+	// Validate the credential with Google
+	if claims, err = idtoken.Validate(c.Request.Context(), in.Credential, s.conf.Audience); err != nil {
+		log.Warn().Err(err).Msg("invalid credentials used for authentication")
+		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("invalid credentials"))
+		return
+	}
+
+	// Create the access and refresh tokens from the claims
+	if accessToken, err = s.tokens.CreateAccessToken(claims); err != nil {
+		log.Error().Err(err).Msg("could not create access token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+
+	if refreshToken, err = s.tokens.CreateRefreshToken(accessToken); err != nil {
+		log.Error().Err(err).Msg("could not create refresh token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+
+	// Sign the tokens and return the response
+	out = new(admin.AuthReply)
+	if out.AccessToken, err = s.tokens.Sign(accessToken); err != nil {
+		log.Error().Err(err).Msg("could not sign access token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+	if out.RefreshToken, err = s.tokens.Sign(refreshToken); err != nil {
+		log.Error().Err(err).Msg("could not sign refresh token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+
+	// Refresh the double cookies for CSRF protection while using the access/refresh tokens
+	expiresAt := refreshToken.Claims.(tokens.Claims).ExpiresAt
+	if err := admin.SetDoubleCookieTokens(c, expiresAt); err != nil {
 		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not set cookies"))
 		return
 	}
 
-	c.JSON(http.StatusNotImplemented, admin.ErrorResponse("not implemented yet"))
+	// Return successful authentication!
+	c.JSON(http.StatusOK, out)
+}
+
+// Reauthenticate allows the submission of a refresh token to reauthenticate an expired
+// or expiring access token and issues a new token pair. The access token must still be
+// provided in the Authorization header as a Bearer token, even if it is expired since
+// the access token contains the claims that need to be reissued. The refresh token is
+// posted in the request body as the credential. This method also resets the CSRF double
+// cookies to ensure that the max-age matches the duration of the refresh tokens.
+func (s *Admin) Reauthenticate(c *gin.Context) {
+	var (
+		err           error
+		tks           string
+		in            *admin.AuthRequest
+		out           *admin.AuthReply
+		accessClaims  *tokens.Claims
+		refreshClaims *tokens.Claims
+		accessToken   *jwt.Token
+		refreshToken  *jwt.Token
+	)
+
+	// Get the Bearer token from the Authorization header (contains access token)
+	if tks, err = admin.GetAccessToken(c); err != nil {
+		log.Warn().Err(err).Msg("reauthenticate called without access token")
+		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("request is not authorized"))
+		return
+	}
+
+	// Parse the access token from the Authorization header without validating the
+	// claims, e.g. it doesn't matter if the access token is expired, but it should be
+	// signed correctly by the token server.
+	if accessClaims, err = s.tokens.Parse(tks); err != nil {
+		log.Warn().Err(err).Msg("reauthenticate called with invalid access token")
+		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("request is not authorized"))
+		return
+	}
+
+	// Parse incoming JSON data from the client request (contains refresh token)
+	in = new(admin.AuthRequest)
+	if err = c.ShouldBind(&in); err != nil {
+		log.Warn().Err(err).Msg("could not bind request")
+		c.JSON(http.StatusBadRequest, admin.ErrorResponse(err))
+		return
+	}
+
+	// Check that a credential was posted
+	if in.Credential == "" {
+		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("invalid credentials"))
+		return
+	}
+
+	// Validate the refresh token
+	if refreshClaims, err = s.tokens.Verify(in.Credential); err != nil {
+		log.Warn().Err(err).Msg("could not verify refresh token")
+		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("invalid credentials"))
+		return
+	}
+
+	// Ensure the refresh token and admin token match
+	// TODO: verify the in.Credential is a refresh token using the subject or audience
+	if accessClaims.Id != refreshClaims.Id {
+		log.Warn().Msg("mismatched access and refresh token pair")
+		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("invalid credentials"))
+		return
+	}
+
+	// At this point we've validated the reauthentication and are ready to reissue tokens
+	// Create the access and refresh tokens from the claims
+	if accessToken, err = s.tokens.CreateAccessToken(accessClaims); err != nil {
+		log.Error().Err(err).Msg("could not create access token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+
+	if refreshToken, err = s.tokens.CreateRefreshToken(accessToken); err != nil {
+		log.Error().Err(err).Msg("could not create refresh token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+
+	// Sign the tokens and return the response
+	out = new(admin.AuthReply)
+	if out.AccessToken, err = s.tokens.Sign(accessToken); err != nil {
+		log.Error().Err(err).Msg("could not sign access token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+	if out.RefreshToken, err = s.tokens.Sign(refreshToken); err != nil {
+		log.Error().Err(err).Msg("could not sign refresh token")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not authenticate with credentials"))
+		return
+	}
+
+	// Refresh the double cookies for CSRF protection while using the access/refresh tokens
+	expiresAt := refreshToken.Claims.(tokens.Claims).ExpiresAt
+	if err := admin.SetDoubleCookieTokens(c, expiresAt); err != nil {
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not set cookies"))
+		return
+	}
+
+	// Return successful reauthentication!
+	c.JSON(http.StatusOK, out)
 }
 
 // Summary provides aggregate statistics that describe the state of the GDS.

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -136,9 +136,9 @@ func (s *Admin) setupRoutes() (err error) {
 	// Add CORS configuration
 	// TODO: configure origins from the environment rather than hard-coding
 	s.router.Use(cors.New(cors.Config{
-		AllowAllOrigins:  true,
+		AllowOrigins:     []string{"http://localhost", "http://localhost:3000", "http://localhost:3001"},
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"},
-		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
+		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization", "X-CSRF-TOKEN"},
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour,
 	}))
@@ -245,7 +245,7 @@ func (s *Admin) Authenticate(c *gin.Context) {
 	}
 
 	// Refresh the double cookies for CSRF protection while using the access/refresh tokens
-	expiresAt := refreshToken.Claims.(tokens.Claims).ExpiresAt
+	expiresAt := refreshToken.Claims.(*tokens.Claims).ExpiresAt
 	if err := admin.SetDoubleCookieTokens(c, expiresAt); err != nil {
 		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not set cookies"))
 		return
@@ -370,7 +370,7 @@ func (s *Admin) Reauthenticate(c *gin.Context) {
 	}
 
 	// Refresh the double cookies for CSRF protection while using the access/refresh tokens
-	expiresAt := refreshToken.Claims.(tokens.Claims).ExpiresAt
+	expiresAt := refreshToken.Claims.(*tokens.Claims).ExpiresAt
 	if err := admin.SetDoubleCookieTokens(c, expiresAt); err != nil {
 		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not set cookies"))
 		return

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -12,6 +12,8 @@ import (
 // DirectoryAdministrationClient defines client-side interactions with the API.
 type DirectoryAdministrationClient interface {
 	Status(ctx context.Context) (out *StatusReply, err error)
+	Authenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error)
+	Reauthenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error)
 	Summary(ctx context.Context) (out *SummaryReply, err error)
 	Autocomplete(ctx context.Context) (out *AutocompleteReply, err error)
 	ListVASPs(ctx context.Context, params *ListVASPsParams) (out *ListVASPsReply, err error)
@@ -40,6 +42,23 @@ type StatusReply struct {
 //===========================================================================
 // Admin v2 API Requests and Responses
 //===========================================================================
+
+// AuthRequest is used by both the Authenticate and Reauthenticate API calls. In
+// Authenticate, the credential should be the OAuth2 JWT token supplied by the Identity
+// Service Provider. In Reauthenticate the credential should be the refresh token
+// returned by the Authenticate request.
+type AuthRequest struct {
+	Credential string `json:"credential"`
+}
+
+// AuthReply returns access and refresh tokens. The access token should be used as a
+// a Bearer token in the Authorization header for all authenticated requests including
+// Reauthentication. The refresh token is used in the Reauthenticate method to retrieve
+// new access tokens without requiring a new login.
+type AuthReply struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
 
 // SummaryReply provides aggregate statistics that describe the state of the GDS.
 type SummaryReply struct {

--- a/pkg/gds/admin/v2/auth.go
+++ b/pkg/gds/admin/v2/auth.go
@@ -1,0 +1,28 @@
+package admin
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	bearer        = "Bearer "
+	authorization = "Authorization"
+)
+
+// GetAccessToken retrieves the bearer token from the authorization header and parses
+// it to return only the access token. If the header is missing or the token is not
+// available an error is returned.
+func GetAccessToken(c *gin.Context) (tks string, err error) {
+	header := c.GetHeader(authorization)
+	if header != "" {
+		parts := strings.Split(header, bearer)
+		if len(parts) == 2 {
+			return strings.TrimSpace(parts[1]), nil
+		}
+		return "", errors.New("could not parser Bearer token from Authorization header")
+	}
+	return "", errors.New("no access token found in request")
+}

--- a/pkg/gds/admin/v2/auth_test.go
+++ b/pkg/gds/admin/v2/auth_test.go
@@ -1,0 +1,67 @@
+package admin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/admin/v2"
+)
+
+func TestGetAccessToken(t *testing.T) {
+	// Create a gin router that constructs a client from the context
+	router := gin.New()
+	router.GET("/", func(c *gin.Context) {
+		// Return whatever the GetAccessToken function returns
+		token, err := admin.GetAccessToken(c)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+
+		c.JSON(http.StatusOK, gin.H{"token": token, "err": errs})
+	})
+
+	// Create a test server from the router
+	server := httptest.NewServer(router)
+
+	// Test a request with no authorization header
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	require.NoError(t, err)
+	rep, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	data, err := readJSON(rep)
+	require.NoError(t, err)
+
+	require.Empty(t, data["token"])
+	require.Equal(t, "no access token found in request", data["err"])
+
+	// Test a request with no bearer token header
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	require.NoError(t, err)
+	req.Header.Add("Authorization", "notabearertoken")
+
+	rep, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	data, err = readJSON(rep)
+	require.NoError(t, err)
+
+	require.Empty(t, data["token"])
+	require.Equal(t, "could not parser Bearer token from Authorization header", data["err"])
+
+	// Test a request with a good bearer token header
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	require.NoError(t, err)
+	req.Header.Add("Authorization", "Bearer thisisyourtoken")
+
+	rep, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	data, err = readJSON(rep)
+	require.NoError(t, err)
+
+	require.Empty(t, data["err"])
+	require.Equal(t, "thisisyourtoken", data["token"])
+
+}

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -39,6 +39,41 @@ type APIv2 struct {
 // Ensure the API implments the Service interface.
 var _ DirectoryAdministrationClient = &APIv2{}
 
+// Authenticate the the client to the Server using the supplied credentials.
+// TODO: this method should prepare the APIv2 client to send and recv authenticated requests
+// TODO: does the client need to call the ProtectAuthenticate endpoint before auth?
+func (s APIv2) Authenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, "/v2/authenticate", in, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &AuthReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Reauthenticate the the client to the Server using the supplied credentials.
+// TODO: this method should prepare the APIv2 client to send and recv authenticated requests
+func (s APIv2) Reauthenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, "/v2/reauthenticate", in, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &AuthReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s APIv2) Status(ctx context.Context) (out *StatusReply, err error) {
 	//  Make the HTTP request
 	var req *http.Request

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -79,6 +79,82 @@ func TestClient(t *testing.T) {
 	require.EqualError(t, err, "[400] bad request")
 }
 
+func TestAuthenticate(t *testing.T) {
+	fixture := &admin.AuthReply{
+		AccessToken:  "",
+		RefreshToken: "",
+	}
+
+	req := &admin.AuthRequest{
+		Credential: "",
+	}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/authenticate", r.URL.Path)
+
+		// Must be able to deserialize the request
+		in := new(admin.AuthRequest)
+		err := json.NewDecoder(r.Body).Decode(in)
+		require.NoError(t, err)
+
+		require.Equal(t, req.Credential, in.Credential)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := admin.New(ts.URL)
+	require.NoError(t, err)
+
+	out, err := client.Authenticate(context.TODO(), req)
+	require.NoError(t, err)
+	require.Equal(t, fixture.AccessToken, out.AccessToken)
+	require.Equal(t, fixture.RefreshToken, out.RefreshToken)
+}
+
+func TestReuthenticate(t *testing.T) {
+	fixture := &admin.AuthReply{
+		AccessToken:  "",
+		RefreshToken: "",
+	}
+
+	req := &admin.AuthRequest{
+		Credential: "",
+	}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/reauthenticate", r.URL.Path)
+
+		// Must be able to deserialize the request
+		in := new(admin.AuthRequest)
+		err := json.NewDecoder(r.Body).Decode(in)
+		require.NoError(t, err)
+
+		require.Equal(t, req.Credential, in.Credential)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := admin.New(ts.URL)
+	require.NoError(t, err)
+
+	out, err := client.Reauthenticate(context.TODO(), req)
+	require.NoError(t, err)
+	require.Equal(t, fixture.AccessToken, out.AccessToken)
+	require.Equal(t, fixture.RefreshToken, out.RefreshToken)
+}
+
 func TestStatus(t *testing.T) {
 	fixture := &admin.StatusReply{
 		Status:    "ok",

--- a/pkg/gds/admin/v2/csurf.go
+++ b/pkg/gds/admin/v2/csurf.go
@@ -56,15 +56,15 @@ func DoubleCookie() gin.HandlerFunc {
 }
 
 // SetDoubleCookieTokens is a helper function to set cookies on a gin-request.
-func SetDoubleCookieTokens(c *gin.Context, nbf int64) error {
+func SetDoubleCookieTokens(c *gin.Context, exp int64) error {
 	// Generate the CSRF token
 	token, err := GenerateCSRFToken()
 	if err != nil {
 		return err
 	}
 
-	// Compute max age from the not before unix timestamp of the access token.
-	maxAge := int((time.Until(time.Unix(nbf, 0))).Seconds())
+	// Compute max age from the expires unix timestamp of the access token.
+	maxAge := int((time.Until(time.Unix(exp, 0))).Seconds())
 
 	// Set the reference cookie
 	c.SetCookie(CSRFReferenceCookie, token, maxAge, "/", "", true, true)

--- a/pkg/gds/admin/v2/csurf.go
+++ b/pkg/gds/admin/v2/csurf.go
@@ -56,6 +56,8 @@ func DoubleCookie() gin.HandlerFunc {
 }
 
 // SetDoubleCookieTokens is a helper function to set cookies on a gin-request.
+// The exp parameter is the Unix timestamp the cookie should be expired, which in most
+// cases is extracted from the exp field of the refresh token claims.
 func SetDoubleCookieTokens(c *gin.Context, exp int64) error {
 	// Generate the CSRF token
 	token, err := GenerateCSRFToken()
@@ -63,8 +65,8 @@ func SetDoubleCookieTokens(c *gin.Context, exp int64) error {
 		return err
 	}
 
-	// Compute max age from the expires unix timestamp of the access token.
-	maxAge := int((time.Until(time.Unix(exp, 0))).Seconds())
+	// Compute max age from the expires unix timestamp of the refresh token.
+	maxAge := int((time.Until(time.Unix(exp, 0))).Seconds()) + 1
 
 	// Set the reference cookie
 	c.SetCookie(CSRFReferenceCookie, token, maxAge, "/", "", true, true)

--- a/pkg/gds/config/config.go
+++ b/pkg/gds/config/config.go
@@ -38,19 +38,17 @@ type GDSConfig struct {
 }
 
 type AdminConfig struct {
-	Enabled  bool   `split_words:"true" default:"true"`
-	BindAddr string `split_words:"true" default:":4434"`
-	Mode     string `split_words:"true" default:"release"`
+	Enabled           bool     `split_words:"true" default:"true"`
+	BindAddr          string   `split_words:"true" default:":4434"`
+	Mode              string   `split_words:"true" default:"release"`
+	Audience          string   `split_words:"true"`
+	AuthorizedDomains []string `split_words:"true"`
 
 	// TokenKeys are the paths to RSA JWT signing keys in PEM encoded format. The
 	// environment variable should be a comma separated list of keyid:path/to/key.pem
 	// Multiple keys are used in order to rotate keys regularly; keyids therefore must
 	// be sortable; in general we prefer to use ksuid for key ids.
-	TokenKeys map[string]string `split_words:"true" required:"true"`
-
-	// Audience is the client ID from the credentials created in the Google Console to
-	// use the Sign-In with Google button. It is verified along with the token.
-	Audience string `split_words:"true" required:"true"`
+	TokenKeys map[string]string `split_words:"true"`
 }
 
 type ReplicaConfig struct {
@@ -136,6 +134,22 @@ func (c AdminConfig) Validate() error {
 	if c.Mode != gin.ReleaseMode && c.Mode != gin.DebugMode && c.Mode != gin.TestMode {
 		return fmt.Errorf("%q is not a valid gin mode", c.Mode)
 	}
+
+	if c.Enabled {
+		// Check configurations that are only required if the admin API is enabled
+		if c.Audience == "" {
+			return errors.New("invalid configuration: audience required for enabled admin")
+		}
+
+		if len(c.AuthorizedDomains) == 0 {
+			return errors.New("invalid configuration: authorized domains required for enabled admin")
+		}
+
+		if len(c.TokenKeys) == 0 {
+			return errors.New("invalid configuration: token keys required for enabled admin")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/gds/config/config.go
+++ b/pkg/gds/config/config.go
@@ -47,6 +47,10 @@ type AdminConfig struct {
 	// Multiple keys are used in order to rotate keys regularly; keyids therefore must
 	// be sortable; in general we prefer to use ksuid for key ids.
 	TokenKeys map[string]string `split_words:"true" required:"true"`
+
+	// Audience is the client ID from the credentials created in the Google Console to
+	// use the Sign-In with Google button. It is verified along with the token.
+	Audience string `split_words:"true" required:"true"`
 }
 
 type ReplicaConfig struct {

--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -22,6 +22,7 @@ var testEnv = map[string]string{
 	"GDS_ADMIN_BIND_ADDR":            ":444",
 	"GDS_ADMIN_MODE":                 "debug",
 	"GDS_ADMIN_TOKEN_KEYS":           "1y9fT85qWaIvAAORW7DKxtpz9FB:testdata/key1.pem,1y9fVjaUlsVdFFDUWlvRq2PLkw3:testdata/key2.pem",
+	"GDS_ADMIN_AUDIENCE":             "abc-1234.example.fakegoogleusercontent.com",
 	"GDS_REPLICA_ENABLED":            "true",
 	"GDS_REPLICA_BIND_ADDR":          ":445",
 	"GDS_REPLICA_PID":                "8",
@@ -79,6 +80,7 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, testEnv["GDS_ADMIN_MODE"], conf.Admin.Mode)
 	require.Equal(t, true, conf.Replica.Enabled)
 	require.Len(t, conf.Admin.TokenKeys, 2)
+	require.Equal(t, testEnv["GDS_ADMIN_AUDIENCE"], conf.Admin.Audience)
 	require.Equal(t, testEnv["GDS_REPLICA_BIND_ADDR"], conf.Replica.BindAddr)
 	require.Equal(t, uint64(8), conf.Replica.PID)
 	require.Equal(t, testEnv["GDS_REPLICA_NAME"], conf.Replica.Name)
@@ -110,6 +112,7 @@ func TestRequiredConfig(t *testing.T) {
 	required := []string{
 		"GDS_DATABASE_URL",
 		"GDS_SECRET_KEY",
+		"GDS_ADMIN_AUDIENCE",
 		"GDS_REPLICA_PID",
 		"GDS_REPLICA_REGION",
 		"GDS_ADMIN_TOKEN_KEYS",

--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -23,6 +23,7 @@ var testEnv = map[string]string{
 	"GDS_ADMIN_MODE":                 "debug",
 	"GDS_ADMIN_TOKEN_KEYS":           "1y9fT85qWaIvAAORW7DKxtpz9FB:testdata/key1.pem,1y9fVjaUlsVdFFDUWlvRq2PLkw3:testdata/key2.pem",
 	"GDS_ADMIN_AUDIENCE":             "abc-1234.example.fakegoogleusercontent.com",
+	"GDS_ADMIN_AUTHORIZED_DOMAINS":   "trisa.io,vaspdirectory.net,trisatest.net",
 	"GDS_REPLICA_ENABLED":            "true",
 	"GDS_REPLICA_BIND_ADDR":          ":445",
 	"GDS_REPLICA_PID":                "8",
@@ -81,6 +82,7 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, true, conf.Replica.Enabled)
 	require.Len(t, conf.Admin.TokenKeys, 2)
 	require.Equal(t, testEnv["GDS_ADMIN_AUDIENCE"], conf.Admin.Audience)
+	require.Len(t, conf.Admin.AuthorizedDomains, 3)
 	require.Equal(t, testEnv["GDS_REPLICA_BIND_ADDR"], conf.Replica.BindAddr)
 	require.Equal(t, uint64(8), conf.Replica.PID)
 	require.Equal(t, testEnv["GDS_REPLICA_NAME"], conf.Replica.Name)
@@ -113,9 +115,10 @@ func TestRequiredConfig(t *testing.T) {
 		"GDS_DATABASE_URL",
 		"GDS_SECRET_KEY",
 		"GDS_ADMIN_AUDIENCE",
+		"GDS_ADMIN_TOKEN_KEYS",
+		"GDS_ADMIN_AUTHORIZED_DOMAINS",
 		"GDS_REPLICA_PID",
 		"GDS_REPLICA_REGION",
-		"GDS_ADMIN_TOKEN_KEYS",
 	}
 
 	// Collect required environment variables and cleanup after
@@ -130,6 +133,9 @@ func TestRequiredConfig(t *testing.T) {
 		}
 	}
 	t.Cleanup(cleanup)
+
+	// Admin verification is predicated on it being enabled
+	setEnv("GDS_ADMIN_ENABLED", "true")
 
 	// Ensure that we've captured the complete set of required environment variables
 	setEnv(required...)
@@ -157,7 +163,10 @@ func TestRequiredConfig(t *testing.T) {
 	require.True(t, conf.Replica.Enabled)
 	require.Equal(t, uint64(8), conf.Replica.PID)
 	require.Equal(t, testEnv["GDS_REPLICA_REGION"], conf.Replica.Region)
+	require.Equal(t, testEnv["GDS_ADMIN_AUDIENCE"], conf.Admin.Audience)
 	require.Len(t, conf.Admin.TokenKeys, 2)
+	require.Len(t, conf.Admin.AuthorizedDomains, 3)
+
 }
 
 // Returns the current environment for the specified keys, or if no keys are specified

--- a/pkg/gds/tokens/tokens.go
+++ b/pkg/gds/tokens/tokens.go
@@ -106,6 +106,19 @@ func (tm *TokenManager) Verify(tks string) (claims *Claims, err error) {
 	return nil, fmt.Errorf("could not parse or verify GDS claims from %T", token.Claims)
 }
 
+// Parse an access or refresh token verifying its signature but without verifying its
+// claims. This ensures that valid JWT tokens are still accepted but claims can be
+// handled on a case-by-case basis; for example by validating an expired access token
+// during reauthentication.
+func (tm *TokenManager) Parse(tks string) (claims *Claims, err error) {
+	parser := &jwt.Parser{SkipClaimsValidation: true}
+	claims = &Claims{}
+	if _, err = parser.ParseWithClaims(tks, claims, tm.keyFunc); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
 // Sign an access or refresh token and return the token string.
 func (tm *TokenManager) Sign(token *jwt.Token) (tks string, err error) {
 	// Sanity check to prevent nil panics.

--- a/pkg/gds/tokens/tokens.go
+++ b/pkg/gds/tokens/tokens.go
@@ -153,7 +153,7 @@ func (tm *TokenManager) CreateAccessToken(creds interface{}) (_ *jwt.Token, err 
 
 	// Populate the claims from the credentials based on type.
 	switch t := creds.(type) {
-	case idtoken.Payload:
+	case *idtoken.Payload:
 		if err = claims.extractClaims(t.Claims); err != nil {
 			return nil, err
 		}

--- a/pkg/gds/tokens/tokens_test.go
+++ b/pkg/gds/tokens/tokens_test.go
@@ -195,6 +195,61 @@ func (s *TokenTestSuite) TestKeyRotation() {
 	require.Error(err)
 }
 
+// Test that a token can be parsed even if it is expired. This is necessary to parse
+// access tokens in order to use a refresh token to extract the claims.
+func (s *TokenTestSuite) TestParseExpiredToken() {
+	require := s.Require()
+	tm, err := tokens.New(s.testdata)
+	require.NoError(err, "could not initialize token manager")
+
+	// Default creds
+	creds := map[string]interface{}{
+		"hd":      "rotational.io",
+		"email":   "kate@rotational.io",
+		"name":    "Kate Holland",
+		"picture": "https://foo.googleusercontent.com/test!/Aoh14gJceTrUA",
+	}
+
+	accessToken, err := tm.CreateAccessToken(creds)
+	require.NoError(err, "could not create access token from claims")
+	require.IsType(&tokens.Claims{}, accessToken.Claims)
+
+	// Modify claims to be expired
+	claims := accessToken.Claims.(*tokens.Claims)
+	claims.IssuedAt = time.Unix(claims.IssuedAt, 0).Add(-24 * time.Hour).Unix()
+	claims.ExpiresAt = time.Unix(claims.ExpiresAt, 0).Add(-24 * time.Hour).Unix()
+	claims.NotBefore = time.Unix(claims.NotBefore, 0).Add(-24 * time.Hour).Unix()
+	accessToken.Claims = claims
+
+	// Create signed token
+	tks, err := tm.Sign(accessToken)
+	require.NoError(err, "could not create expired access token from cliams")
+
+	// Ensure that verification fails; claims are invalid.
+	pclaims, err := tm.Verify(tks)
+	require.Error(err, "expired token was somehow validated?")
+	require.Empty(pclaims, "verify returned claims even after error")
+
+	// Parse token without verifying claims but verifying the signature
+	pclaims, err = tm.Parse(tks)
+	require.NoError(err, "claims were validated in parse")
+	require.NotEmpty(pclaims, "parsing returned empty claims without error")
+
+	// Check claims
+	require.Equal(claims.Id, pclaims.Id)
+	require.Equal(claims.ExpiresAt, pclaims.ExpiresAt)
+	require.Equal(creds["hd"], claims.Domain)
+	require.Equal(creds["email"], claims.Email)
+	require.Equal(creds["name"], claims.Name)
+	require.Equal(creds["picture"], claims.Picture)
+
+	// Ensure signature is still validated on parse
+	tks += "abcdefg"
+	claims, err = tm.Parse(tks)
+	require.Error(err, "claims were parsed with bad signature")
+	require.Empty(claims, "bad signature token returned non-empty claims")
+}
+
 // Execute suite as a go test.
 func TestTokenTestSuite(t *testing.T) {
 	suite.Run(t, new(TokenTestSuite))

--- a/pkg/gds/tokens/tokens_test.go
+++ b/pkg/gds/tokens/tokens_test.go
@@ -223,7 +223,7 @@ func (s *TokenTestSuite) TestParseExpiredToken() {
 
 	// Create signed token
 	tks, err := tm.Sign(accessToken)
-	require.NoError(err, "could not create expired access token from cliams")
+	require.NoError(err, "could not create expired access token from claims")
 
 	// Ensure that verification fails; claims are invalid.
 	pclaims, err := tm.Verify(tks)

--- a/web/gds-admin-ui/src/pages/account/Login.js
+++ b/web/gds-admin-ui/src/pages/account/Login.js
@@ -8,6 +8,10 @@ import SignWithGoogle from '../../components/Auth/SignWithGoogle';
 import { loginUser } from '../../redux/auth/actions';
 import config from "../../config";
 
+// HACK: temporary code, do not commit!
+import { APICore } from "../../helpers/api/apiCore";
+const api = new APICore();
+
 
 const Login = (): React$Element<any> => {
     const dispatch = useDispatch();
@@ -18,7 +22,11 @@ const Login = (): React$Element<any> => {
 
     const handleCredentialResponse = (response) => {
         if (response.credential) {
-            dispatch(loginUser(response.credential))
+            // HACK: temporary code, do not commit!
+            console.log(response.credential);
+            const rep = api.create("/login", {credential: response.credential});
+            console.log(rep);
+            dispatch(loginUser(response.credential));
         }
     }
 

--- a/web/gds-admin-ui/src/pages/account/Login.js
+++ b/web/gds-admin-ui/src/pages/account/Login.js
@@ -8,10 +8,6 @@ import SignWithGoogle from '../../components/Auth/SignWithGoogle';
 import { loginUser } from '../../redux/auth/actions';
 import config from "../../config";
 
-// HACK: temporary code, do not commit!
-import { APICore } from "../../helpers/api/apiCore";
-const api = new APICore();
-
 
 const Login = (): React$Element<any> => {
     const dispatch = useDispatch();
@@ -22,11 +18,7 @@ const Login = (): React$Element<any> => {
 
     const handleCredentialResponse = (response) => {
         if (response.credential) {
-            // HACK: temporary code, do not commit!
-            console.log(response.credential);
-            const rep = api.create("/login", {credential: response.credential});
-            console.log(rep);
-            dispatch(loginUser(response.credential));
+            dispatch(loginUser(response.credential))
         }
     }
 


### PR DESCRIPTION
Implements Authentication and Reauthentication endpoints.

Authentication requires a Google Identity Services token, which is verified using the [`idtoken`](https://pkg.go.dev/google.golang.org/api/idtoken#Validate) package. If it is a valid Google token, then access and refresh tokens are issued. 

Reauthentication requires the access token in the header, even if it is expired and the refresh token submitted in the body. Once the access and refresh tokens are compared and verified new tokens are returned. 

Both Authentication and Reauthentication requires double cookie CSRF protection since they are POST endpoints that modify state on the server. Therefore I've also added a `GET /v2/authenticate` method that is handled by `ProtectAuthenticate` - this function sets the cookies on the front-end. The browser must do a GET request to this endpoint before rendering the login button component to set the cookies. It can then POST the client credentials. Note that this is because we're using a javascript callback; if we were using a Google Redirect, Google itself would POST double cookies for verification. See https://developers.google.com/identity/gsi/web/guides/verify-google-id-token for more. 

The authentication and reauthentication endpoints reset the double cookies to expire when the refresh token does. 

TODO: 
- [x] test to see if this actually works with Google credentials
- [ ] review audience and subject verification pieces
- [ ] not exactly sure how to write tests for this
- [x] perform authorized domains check  