### PR TITLE
Authorization Middleware

### DIFF
--- a/pkg/gds/admin/v2/auth.go
+++ b/pkg/gds/admin/v2/auth.go
@@ -2,15 +2,53 @@ package admin
 
 import (
 	"errors"
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/directory/pkg/gds/tokens"
 )
 
 const (
 	bearer        = "Bearer "
 	authorization = "Authorization"
+	UserClaims    = "user_claims"
 )
+
+// Authorization middleware ensures that the request has a valid Bearer JWT in the
+// Authorization header of the request otherwise it returns a 401 unauthorized error.
+func Authorization(tm *tokens.TokenManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var (
+			err         error
+			accessToken string
+			claims      *tokens.Claims
+		)
+
+		// Get access token from the request and ensure it is supplied
+		if accessToken, err = GetAccessToken(c); err != nil {
+			log.Debug().Err(err).Msg("no access token requested with secure endpoint")
+			c.JSON(http.StatusUnauthorized, ErrorResponse("a valid authorization is required to access this endpoint"))
+			c.Abort()
+			return
+		}
+
+		// Verify that the access_token is valid and signed with server keys
+		if claims, err = tm.Verify(accessToken); err != nil {
+			log.Debug().Err(err).Msg("access token is invalid")
+			c.JSON(http.StatusUnauthorized, ErrorResponse("a valid authorization is required to access this endpoint"))
+			c.Abort()
+			return
+		}
+
+		// Add claims to context for use in downstream processing
+		c.Set(UserClaims, claims)
+
+		// Continue with middleware handling
+		c.Next()
+	}
+}
 
 // GetAccessToken retrieves the bearer token from the authorization header and parses
 // it to return only the access token. If the header is missing or the token is not

--- a/pkg/gds/admin/v2/auth_test.go
+++ b/pkg/gds/admin/v2/auth_test.go
@@ -8,7 +8,90 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/trisacrypto/directory/pkg/gds/admin/v2"
+	"github.com/trisacrypto/directory/pkg/gds/tokens"
 )
+
+func TestAuthorization(t *testing.T) {
+	// Test Authorization middleware
+	router := gin.New()
+	tm, err := tokens.MockTokenManager()
+	require.NoError(t, err)
+
+	// Create secure endpoint for testing purposes
+	router.GET("/", admin.Authorization(tm), func(c *gin.Context) {
+		claims, exists := c.Get(admin.UserClaims)
+		require.True(t, exists)
+		require.NotEmpty(t, claims)
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	// Create the test server with the authorized router
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	// Create a request to the server that is not authorized
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	require.NoError(t, err)
+
+	// Execute an unauthorized request and check a 401 response
+	rep, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, rep.StatusCode)
+
+	// Read the body of the response
+	data, err := readJSON(rep)
+	require.NoError(t, err)
+	require.Contains(t, data, "error")
+	require.Equal(t, "a valid authorization is required to access this endpoint", data["error"].(string))
+
+	// Create an access token to authorize the request
+	creds := map[string]interface{}{
+		"hd":      "rotational.io",
+		"email":   "kate@rotational.io",
+		"name":    "Kate Holland",
+		"picture": "https://foo.googleusercontent.com/test!/Aoh14gJceTrUA",
+	}
+
+	accessToken, err := tm.CreateAccessToken(creds)
+	require.NoError(t, err)
+
+	// Create signed token
+	tks, err := tm.Sign(accessToken)
+	require.NoError(t, err)
+
+	// Create a request to the server that is authorized
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	req.Header.Set("Authorization", "Bearer "+tks)
+	require.NoError(t, err)
+
+	// Execute an unauthorized request and check a 200 response
+	rep, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rep.StatusCode)
+
+	// Read the body of the response
+	data, err = readJSON(rep)
+	require.NoError(t, err)
+	require.NotContains(t, data, "error")
+	require.Contains(t, data, "success")
+
+	// Create a request to the server with an invalid access token by messing with its signature
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	req.Header.Set("Authorization", "Bearer "+tks+"scrambled")
+	require.NoError(t, err)
+
+	// Execute an unauthorized request and check a 401 response
+	rep, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, rep.StatusCode)
+
+	// Read the body of the response
+	data, err = readJSON(rep)
+	require.NoError(t, err)
+	require.Contains(t, data, "error")
+	require.Contains(t, data, "success")
+	require.Equal(t, "a valid authorization is required to access this endpoint", data["error"].(string))
+}
 
 func TestGetAccessToken(t *testing.T) {
 	// Create a gin router that constructs a client from the context
@@ -26,6 +109,7 @@ func TestGetAccessToken(t *testing.T) {
 
 	// Create a test server from the router
 	server := httptest.NewServer(router)
+	defer server.Close()
 
 	// Test a request with no authorization header
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/", nil)

--- a/pkg/gds/admin/v2/csurf_test.go
+++ b/pkg/gds/admin/v2/csurf_test.go
@@ -40,6 +40,7 @@ func TestDoubleCookies(t *testing.T) {
 
 	// Create the test server with the CSRF protected router
 	server := httptest.NewServer(router)
+	defer server.Close()
 
 	// Attempt to make a request to the server that is not CSRF protected
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/action", nil)

--- a/pkg/gds/tokens/mock.go
+++ b/pkg/gds/tokens/mock.go
@@ -1,0 +1,29 @@
+package tokens
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+
+	"github.com/segmentio/ksuid"
+)
+
+// MockTokenManager creates a new TokenManager with a randomly generated RSA key to be
+// used for testing external code that depends on the Token Manager.
+func MockTokenManager() (tm *TokenManager, err error) {
+	tm = &TokenManager{
+		audience: "http://localhost",
+		subject:  "testing",
+		issuer:   "http://localhost",
+		keys:     make(map[ksuid.KSUID]*rsa.PublicKey),
+	}
+
+	var key *rsa.PrivateKey
+	if key, err = rsa.GenerateKey(rand.Reader, 1024); err != nil {
+		return nil, err
+	}
+
+	tm.currentKeyID = ksuid.New()
+	tm.currentKey = key
+	tm.keys[tm.currentKeyID] = &key.PublicKey
+	return tm, nil
+}


### PR DESCRIPTION
Adds middleware that checks the Bearer JWT token from the Authorization
header before permitting the request to continue.

TODO:

- [x] Add middleware to all endpoints but the `authenticate` and `reauthenticate` endpoints 
- [x] Determine if authorization should happen before double cookie verification
- [x] Add claims to the context so that the request has access to the user email address for auditing
- [x] Create unit tests for the middleware 
- [ ] Verify the endpoints generally work (we'll need to work on integration tests in the next epic) 