### PR TITLE
[WIP] Admin timeline API

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -261,6 +261,14 @@ func main() {
 			},
 		},
 		{
+			Name:     "admin:timeline",
+			Usage:    "request a timeline of VASP state changes",
+			Category: "admin",
+			Action:   adminTimeline,
+			Before:   initClient,
+			Flags:    []cli.Flag{},
+		},
+		{
 			Name:     "admin:status",
 			Usage:    "perform a health check against the admin API",
 			Category: "admin",
@@ -612,6 +620,18 @@ func resend(c *cli.Context) (err error) {
 
 	var rep *admin.ResendReply
 	if rep, err = adminClient.Resend(ctx, req); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminTimeline(c *cli.Context) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var rep *admin.TimelineReply
+	if rep, err = adminClient.Timeline(ctx); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -1020,14 +1020,17 @@ func (s *Admin) Timeline(c *gin.Context) {
 		}
 
 		// Get VASP audit log
-		if auditLog, err := models.GetAuditLog(vasp); err != nil {
+		var auditLog []*models.AuditLogEntry
+		var err error
+		if auditLog, err = models.GetAuditLog(vasp); err != nil {
 			log.Warn().Err(err).Msg("could not retrieve audit log for vasp")
 			continue
 		}
 
 		// Iterate over VASP audit log and count registrations
 		for _, entry := range auditLog {
-			if timestamp, err := time.Parse(time.RFC3339, entry.Timestamp); err != nil {
+			var timestamp time.Time
+			if timestamp, err = time.Parse(time.RFC3339, entry.Timestamp); err != nil {
 				log.Warn().Err(err).Msg("could not parse timestamp in audit log entry")
 				continue
 			}

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -162,6 +163,7 @@ func (s *Admin) setupRoutes() (err error) {
 		// Information routes (must be authenticated)
 		v2.GET("/summary", authorize, s.Summary)
 		v2.GET("/autocomplete", authorize, s.Autocomplete)
+		v2.GET("/timeline", authorize, s.Timeline)
 
 		// VASP routes all must be authenticated (some CSRF protection required)
 		vasps := v2.Group("/vasps", authorize)
@@ -973,6 +975,99 @@ func (s *Admin) Resend(c *gin.Context) {
 	}
 
 	log.Info().Str("id", vasp.Id).Int("sent", out.Sent).Str("resend_type", string(in.Action)).Msg("resend request complete")
+	c.JSON(http.StatusOK, out)
+}
+
+// Timeline returns a list of time series records containing registration state counts by week.
+func (s *Admin) Timeline(c *gin.Context) {
+	const timeFormat = "YYYY-MM-DD"
+	// TODO: Make start date configurable in the request
+	startTime := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.Local)
+	endTime := time.Now()
+	if startTime.After(endTime) {
+		log.Warn().Err(fmt.Errorf("start date after end date")).Msg("invalid timeline request: start date can't be after current date")
+		c.JSON(http.StatusBadRequest, admin.ErrorResponse(fmt.Errorf("invalid start date: %s", startTime.Format(time.RFC3339))))
+	}
+
+	// Initialize the record structs
+	type weekRecord struct {
+		VASPs         map[string]bool
+		Registrations map[string]int
+	}
+	numWeeks := int(endTime.Sub(startTime).Hours()/24/7) + 1
+	weeks := make([]*weekRecord, 0, numWeeks)
+	for i := 0; i < numWeeks; i++ {
+		record := &weekRecord{
+			VASPs:         make(map[string]bool),
+			Registrations: make(map[string]int),
+		}
+		var s int32
+		for s = 0; s <= int32(pb.VerificationState_ERRORED); s++ {
+			record.Registrations[pb.VerificationState_name[s]] = 0
+		}
+		weeks[i] = record
+	}
+
+	// Iterate over the VASPs and count registrations
+	iter := s.db.ListVASPs()
+	defer iter.Release()
+	for iter.Next() {
+		// Fetch VASP from the database
+		var vasp *pb.VASP
+		if vasp = iter.VASP(); vasp == nil {
+			// VASP could not be parsed; error logged in VASP() method continue iteration
+			continue
+		}
+
+		// Get VASP audit log
+		if auditLog, err := models.GetAuditLog(vasp); err != nil {
+			log.Warn().Err(err).Msg("could not retrieve audit log for vasp")
+			continue
+		}
+
+		// Iterate over VASP audit log and count registrations
+		for _, entry := range auditLog {
+			if timestamp, err := time.Parse(time.RFC3339, entry.Timestamp); err != nil {
+				log.Warn().Err(err).Msg("could not parse timestamp in audit log entry")
+				continue
+			}
+			weekNum := int(timestamp.Sub(startTime).Hours() / 24 / 7)
+
+			// Mark VASP if we haven't seen it before
+			if _, exists := weeks[weekNum].VASPs[vasp.Id]; !exists {
+				weeks[weekNum].VASPs[vasp.Id] = true
+			}
+			weeks[weekNum].Registrations[vasp.VerificationStatus.String()]++
+		}
+	}
+
+	if err := iter.Error(); err != nil {
+		log.Warn().Err(err).Msg("could not iterate over vasps in store")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse(err))
+		return
+	}
+
+	// Construct timeline reply
+	out := &admin.TimelineReply{
+		Weeks: make([]admin.TimelineRecord, 0, numWeeks),
+	}
+	weekTime := startTime
+	for i := 0; i < numWeeks; i++ {
+		weekDate := weekTime.Format(timeFormat)
+		out.Weeks = append(out.Weeks, admin.TimelineRecord{
+			Week:          weekDate,
+			VASPsCount:    len(weeks[i].VASPs),
+			Registrations: weeks[i].Registrations,
+		})
+		weekTime = weekTime.Add(time.Hour * 24 * 7)
+	}
+
+	// Sort output by week
+	sort.Slice(out.Weeks, func(i, j int) bool {
+		first, _ := time.Parse(timeFormat, out.Weeks[i].Week)
+		second, _ := time.Parse(timeFormat, out.Weeks[j].Week)
+		return first.Before(second)
+	})
 	c.JSON(http.StatusOK, out)
 }
 

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -20,6 +20,7 @@ type DirectoryAdministrationClient interface {
 	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
 	Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error)
 	Resend(ctx context.Context, in *ResendRequest) (out *ResendReply, err error)
+	Timeline(ctx context.Context) (out *TimelineReply, err error)
 }
 
 //===========================================================================
@@ -176,4 +177,16 @@ type ResendRequest struct {
 type ResendReply struct {
 	Sent    int    `json:"sent"`
 	Message string `json:"message"`
+}
+
+// TimelineRecord contains counts of VASP registration states over a single week.
+type TimelineRecord struct {
+	Week          string         `json:"week"`
+	VASPsCount    int            `json:"vasps_count"`
+	Registrations map[string]int `json:"registrations"`
+}
+
+// TimelineReply returns a list of time series records containing registration counts.
+type TimelineReply struct {
+	Weeks []TimelineRecord `json:"weeks"`
 }

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -224,6 +224,21 @@ func (s APIv2) Resend(ctx context.Context, in *ResendRequest) (out *ResendReply,
 	return out, nil
 }
 
+func (s APIv2) Timeline(ctx context.Context) (out *TimelineReply, err error) {
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v2/timeline", nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &TimelineReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 const (
 	userAgent    = "GDS Admin API Client/v2"
 	accept       = "application/json"


### PR DESCRIPTION
This implements an endpoint for the Admin API which returns time series data in the form of JSON which contains a record for each week. Each record contains the week in YYYY-MM-DD format, the total number of VASPs, and counts of the VerificationState changes broken down by status. The value of this endpoint is that it can be used to render time series graphs on the frontend.

TODO

- [ ] Make start/end date configurable in the request
- [ ] Figure out what the route should be called, right now it's /v2/timeline
- [ ] The VASP count is not always going to be correct (e.g., if the state of a VASP doesn't change for a week then it won't be counted)...should we just remove it from the output?