### PR TITLE
Simple CLI Authentication

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -307,7 +307,7 @@ func main() {
 		},
 		{
 			Name:     "admin:detail",
-			Usage:    "retrieve a VASP detail recrod by id",
+			Usage:    "retrieve a VASP detail record by id",
 			Category: "admin",
 			Action:   adminRetrieveVASPs,
 			Before:   initAdminClient,

--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -89,7 +89,7 @@ func main() {
 			Usage:    "submit a VASP registration review response",
 			Category: "admin",
 			Action:   review,
-			Before:   initClient,
+			Before:   initAdminClient,
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "i, id",
@@ -232,7 +232,7 @@ func main() {
 			Usage:    "request emails be resent in case of delivery errors",
 			Category: "admin",
 			Action:   resend,
-			Before:   initClient,
+			Before:   initAdminClient,
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "i, id",
@@ -265,7 +265,7 @@ func main() {
 			Usage:    "perform a health check against the admin API",
 			Category: "admin",
 			Action:   adminStatus,
-			Before:   initClient,
+			Before:   initAdminClient,
 			Flags:    []cli.Flag{},
 		},
 		{
@@ -273,7 +273,7 @@ func main() {
 			Usage:    "collect aggregate information about current GDS status",
 			Category: "admin",
 			Action:   adminSummary,
-			Before:   initClient,
+			Before:   initAdminClient,
 			Flags:    []cli.Flag{},
 		},
 		{
@@ -281,7 +281,7 @@ func main() {
 			Usage:    "get autocomplete names for the admin searchbar",
 			Category: "admin",
 			Action:   adminAutocomplete,
-			Before:   initClient,
+			Before:   initAdminClient,
 			Flags:    []cli.Flag{},
 		},
 		{
@@ -289,7 +289,7 @@ func main() {
 			Usage:    "list all VASPs summary detail",
 			Category: "admin",
 			Action:   adminListVASPs,
-			Before:   initClient,
+			Before:   initAdminClient,
 			Flags: []cli.Flag{
 				cli.IntFlag{
 					Name:  "p, page",
@@ -310,7 +310,7 @@ func main() {
 			Usage:    "retrieve a VASP detail recrod by id",
 			Category: "admin",
 			Action:   adminRetrieveVASPs,
-			Before:   initClient,
+			Before:   initAdminClient,
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "i, id",
@@ -704,9 +704,17 @@ func initClient(c *cli.Context) (err error) {
 		return cli.NewExitError(err, 1)
 	}
 	client = api.NewTRISADirectoryClient(cc)
+	return nil
+}
 
+func initAdminClient(c *cli.Context) (err error) {
 	// Connect the admin client
 	if adminClient, err = admin.New(c.GlobalString("admin-endpoint")); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	// Attempt to login the admin client
+	if err = adminClient.Login(context.Background()); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	return nil

--- a/cmd/gdsutil/main.go
+++ b/cmd/gdsutil/main.go
@@ -1183,8 +1183,11 @@ func registerReissue(c *cli.Context) (err error) {
 		Id:         uuid.New().String(),
 		Vasp:       vasp.Id,
 		CommonName: vasp.CommonName,
-		Status:     models.CertificateRequestState_READY_TO_SUBMIT,
 		Created:    time.Now().Format(time.RFC3339),
+	}
+
+	if err = models.UpdateCertificateRequestStatus(certreq, models.CertificateRequestState_READY_TO_SUBMIT, "reissue certificates", email); err != nil {
+		return cli.NewExitError(err, 1)
 	}
 
 	// Make a new secret of type "password"

--- a/cmd/gdsutil/main.go
+++ b/cmd/gdsutil/main.go
@@ -1183,7 +1183,7 @@ func registerReissue(c *cli.Context) (err error) {
 		Id:         uuid.New().String(),
 		Vasp:       vasp.Id,
 		CommonName: vasp.CommonName,
-		Status:     models.CertificateRequestState_INITIALIZED,
+		Status:     models.CertificateRequestState_READY_TO_SUBMIT,
 		Created:    time.Now().Format(time.RFC3339),
 	}
 

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -83,7 +83,7 @@ services:
       context: ../
       dockerfile: ./containers/gds-admin-ui/Dockerfile
       args:
-        REACT_APP_GDS_API_ENDPOINT: http://localhost:4434/
+        REACT_APP_GDS_API_ENDPOINT: http://localhost:4434/v2
         REACT_APP_GDS_IS_TESTNET: "true"
         REACT_APP_GDS_CLIENT_ID: ${REACT_APP_GDS_CLIENT_ID}
     image: trisa/gds-admin-ui

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -270,11 +270,11 @@ func (s *Admin) checkAuthorizedDomain(claims *idtoken.Payload) error {
 		return fmt.Errorf("claim type %T unparseable", domain)
 	}
 
+	// Process the HD domain for string comparison purposes
 	domains = strings.ToLower(strings.TrimSpace(domains))
 
 	// Search the authorized domains, if found return nil
 	for _, authorized := range s.conf.AuthorizedDomains {
-		authorized = strings.ToLower(strings.Trim(strings.TrimSpace(authorized), "\"'"))
 		if domains == authorized {
 			// Found an authorized domain!
 			return nil

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -11,6 +11,7 @@ import (
 
 // DirectoryAdministrationClient defines client-side interactions with the API.
 type DirectoryAdministrationClient interface {
+	Login(ctx context.Context) (err error)
 	Status(ctx context.Context) (out *StatusReply, err error)
 	Authenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error)
 	Reauthenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error)

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -441,7 +441,7 @@ func (s *APIv2) Credentials() (creds *AuthReply, err error) {
 	return nil, errors.New("no credentials are available")
 }
 
-// DeleteCredentials removed cached access and refresh tokens
+// DeleteCredentials removes cached access and refresh tokens
 func (s *APIv2) DeleteCredentials() (err error) {
 	folder := cfgd.QueryFolderContainsFile(credentials)
 	if folder != nil && folder.Exists(credentials) {
@@ -456,7 +456,7 @@ type ClientConfig struct {
 	TokenKeys map[string]string `envconfig:"GDS_ADMIN_TOKEN_KEYS"`
 }
 
-// GenerateCredentials creates a token manager generate and save credentials
+// GenerateCredentials creates a token manager to generate and save credentials
 func (s *APIv2) GenerateCredentials() (err error) {
 	var conf ClientConfig
 	if err = envconfig.Process("gds", &conf); err != nil {

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -8,10 +8,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-querystring/query"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/shibukawa/configdir"
+	"github.com/trisacrypto/directory/pkg/gds/tokens"
 )
 
 // New creates a new admin.v2 API client that implements the Service interface.
@@ -20,10 +27,15 @@ func New(endpoint string) (_ DirectoryAdministrationClient, err error) {
 		client: &http.Client{
 			Transport:     nil,
 			CheckRedirect: nil,
-			Jar:           nil,
 			Timeout:       30 * time.Second,
 		},
 	}
+
+	// Create cookie jar
+	if c.client.Jar, err = cookiejar.New(nil); err != nil {
+		return nil, fmt.Errorf("could not create cookiejar: %s", err)
+	}
+
 	if c.endpoint, err = url.Parse(endpoint); err != nil {
 		return nil, fmt.Errorf("could not parse endpoint: %s", err)
 	}
@@ -32,17 +44,93 @@ func New(endpoint string) (_ DirectoryAdministrationClient, err error) {
 
 // APIv2 implements the Service interface.
 type APIv2 struct {
-	endpoint *url.URL
-	client   *http.Client
+	endpoint    *url.URL
+	client      *http.Client
+	accessToken string
+	csrfToken   string
 }
 
 // Ensure the API implments the Service interface.
 var _ DirectoryAdministrationClient = &APIv2{}
 
+// Login prepares the client for authorized requests. It first looks for a stored token
+// on disk; if it finds none then it uses either a token manager or redirects the client
+// to the browser to authenticate with the server. If the access token is expired, it
+// uses the refresh token to reauthenticate and saves the resulting tokens back to disk.
+func (s *APIv2) Login(ctx context.Context) (err error) {
+	var creds *AuthReply
+	if creds, err = s.Credentials(); err != nil {
+		// No credentials were found begin login process
+		// TODO: refactor this section to allow either local token generation or online login
+		return s.GenerateCredentials()
+	}
+	s.accessToken = creds.AccessToken
+
+	// If we've successfully loaded the credentials check the access token to make sure it's still valid
+	parser := &jwt.Parser{}
+	claims := &tokens.Claims{}
+	if _, _, err = parser.ParseUnverified(creds.AccessToken, claims); err != nil {
+		s.DeleteCredentials()
+		return errors.New("access tokens unparseable, cached credentials have been deleted, please try again")
+	}
+
+	if err = claims.Valid(); err == nil {
+		return nil
+	}
+
+	// Access token is invalid attempt to reauthenticate
+	if creds, err = s.Reauthenticate(ctx, &AuthRequest{Credential: creds.RefreshToken}); err != nil {
+		s.DeleteCredentials()
+		return fmt.Errorf("could not reauthenticate (%s), cached credentials have been deleted, please try again", err)
+	}
+
+	// Save refreshed creds to disk
+	s.accessToken = creds.AccessToken
+
+	var data []byte
+	if data, err = json.Marshal(creds); err != nil {
+		return err
+	}
+
+	folders := cfgd.QueryFolders(configdir.Global)
+	folders[0].WriteFile(credentials, data)
+
+	return nil
+}
+
+//===========================================================================
+// Client Methods
+//===========================================================================
+
+// ProtectAuthenticate sets cookies for CSRF protection (not necessary in the API but good for testing)
+func (s *APIv2) ProtectAuthenticate(ctx context.Context) (err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v2/authenticate", nil, nil); err != nil {
+		return err
+	}
+
+	// Execute the request and get a response
+	if _, err = s.Do(req, nil, true); err != nil {
+		return err
+	}
+
+	// NOTE: this will only work over HTTPS, not for local debugging
+	cookies := s.client.Jar.Cookies(s.endpoint)
+	for _, cookie := range cookies {
+		if cookie.Name == CSRFCookie {
+			s.csrfToken = cookie.Value
+		}
+	}
+	return nil
+}
+
 // Authenticate the the client to the Server using the supplied credentials.
-// TODO: this method should prepare the APIv2 client to send and recv authenticated requests
-// TODO: does the client need to call the ProtectAuthenticate endpoint before auth?
-func (s APIv2) Authenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error) {
+func (s *APIv2) Authenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error) {
+	if err = s.ProtectAuthenticate(ctx); err != nil {
+		return nil, fmt.Errorf("could not protect authenticate from CSRF: %s", err)
+	}
+
 	//  Make the HTTP request
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v2/authenticate", in, nil); err != nil {
@@ -58,8 +146,11 @@ func (s APIv2) Authenticate(ctx context.Context, in *AuthRequest) (out *AuthRepl
 }
 
 // Reauthenticate the the client to the Server using the supplied credentials.
-// TODO: this method should prepare the APIv2 client to send and recv authenticated requests
-func (s APIv2) Reauthenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error) {
+func (s *APIv2) Reauthenticate(ctx context.Context, in *AuthRequest) (out *AuthReply, err error) {
+	if err = s.ProtectAuthenticate(ctx); err != nil {
+		return nil, fmt.Errorf("could not protect reauthenticate from CSRF: %s", err)
+	}
+
 	//  Make the HTTP request
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v2/reauthenticate", in, nil); err != nil {
@@ -74,7 +165,7 @@ func (s APIv2) Reauthenticate(ctx context.Context, in *AuthRequest) (out *AuthRe
 	return out, nil
 }
 
-func (s APIv2) Status(ctx context.Context) (out *StatusReply, err error) {
+func (s *APIv2) Status(ctx context.Context) (out *StatusReply, err error) {
 	//  Make the HTTP request
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodGet, "/v2/status", nil, nil); err != nil {
@@ -102,7 +193,7 @@ func (s APIv2) Status(ctx context.Context) (out *StatusReply, err error) {
 	return out, nil
 }
 
-func (s APIv2) Summary(ctx context.Context) (out *SummaryReply, err error) {
+func (s *APIv2) Summary(ctx context.Context) (out *SummaryReply, err error) {
 	//  Make the HTTP request
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodGet, "/v2/summary", nil, nil); err != nil {
@@ -117,7 +208,7 @@ func (s APIv2) Summary(ctx context.Context) (out *SummaryReply, err error) {
 	return out, nil
 }
 
-func (s APIv2) Autocomplete(ctx context.Context) (out *AutocompleteReply, err error) {
+func (s *APIv2) Autocomplete(ctx context.Context) (out *AutocompleteReply, err error) {
 	//  Make the HTTP request
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodGet, "/v2/autocomplete", nil, nil); err != nil {
@@ -132,7 +223,7 @@ func (s APIv2) Autocomplete(ctx context.Context) (out *AutocompleteReply, err er
 	return out, nil
 }
 
-func (s APIv2) ListVASPs(ctx context.Context, in *ListVASPsParams) (out *ListVASPsReply, err error) {
+func (s *APIv2) ListVASPs(ctx context.Context, in *ListVASPsParams) (out *ListVASPsReply, err error) {
 	// Create the query params from the input
 	var params url.Values
 	if params, err = query.Values(in); err != nil {
@@ -154,7 +245,7 @@ func (s APIv2) ListVASPs(ctx context.Context, in *ListVASPsParams) (out *ListVAS
 	return out, nil
 }
 
-func (s APIv2) RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error) {
+func (s *APIv2) RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error) {
 	// Compute the path based on the id
 	if id == "" {
 		return nil, errors.New("id is required to compute the URL for the VASP")
@@ -176,10 +267,14 @@ func (s APIv2) RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPRe
 	return out, nil
 }
 
-func (s APIv2) Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error) {
+func (s *APIv2) Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error) {
 	// The ID is required for the review request to determine the endpoint
 	if in.ID == "" {
 		return nil, ErrIDRequred
+	}
+
+	if err = s.ProtectAuthenticate(ctx); err != nil {
+		return nil, fmt.Errorf("could not protect review from CSRF: %s", err)
 	}
 
 	// Determine the path from the request
@@ -200,10 +295,14 @@ func (s APIv2) Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply,
 	return out, nil
 }
 
-func (s APIv2) Resend(ctx context.Context, in *ResendRequest) (out *ResendReply, err error) {
+func (s *APIv2) Resend(ctx context.Context, in *ResendRequest) (out *ResendReply, err error) {
 	// The ID is required for the review request to determine the endpoint
 	if in.ID == "" {
 		return nil, ErrIDRequred
+	}
+
+	if err = s.ProtectAuthenticate(ctx); err != nil {
+		return nil, fmt.Errorf("could not protect resend from CSRF: %s", err)
 	}
 
 	// Determine the path from the request
@@ -224,6 +323,10 @@ func (s APIv2) Resend(ctx context.Context, in *ResendRequest) (out *ResendReply,
 	return out, nil
 }
 
+//===========================================================================
+// Helper Methods
+//===========================================================================
+
 const (
 	userAgent    = "GDS Admin API Client/v2"
 	accept       = "application/json"
@@ -235,7 +338,7 @@ const (
 // NewRequest creates an http.Request with the specified context and method, resolving
 // the path to the root endpoint of the API (e.g. /v2) and serializes the data to JSON.
 // This method also sets the default headers of all GDS Admin API v2 client requests.
-func (s APIv2) NewRequest(ctx context.Context, method, path string, data interface{}, params *url.Values) (req *http.Request, err error) {
+func (s *APIv2) NewRequest(ctx context.Context, method, path string, data interface{}, params *url.Values) (req *http.Request, err error) {
 	// Resolve the URL reference from the path
 	endpoint := s.endpoint.ResolveReference(&url.URL{Path: path})
 	if params != nil && len(*params) > 0 {
@@ -264,12 +367,20 @@ func (s APIv2) NewRequest(ctx context.Context, method, path string, data interfa
 	req.Header.Add("Accept-Encoding", acceptEncode)
 	req.Header.Add("Content-Type", contentType)
 
+	// Set authorizatoin and csrf protection if available
+	if s.accessToken != "" {
+		req.Header.Add("Authorization", "Bearer "+s.accessToken)
+	}
+	if s.csrfToken != "" {
+		req.Header.Add(CSRFHeader, s.csrfToken)
+	}
+
 	return req, nil
 }
 
 // Do executes an http request against the server, performs error checking, and
 // deserializes the response data into the specified struct if requested.
-func (s APIv2) Do(req *http.Request, data interface{}, checkStatus bool) (rep *http.Response, err error) {
+func (s *APIv2) Do(req *http.Request, data interface{}, checkStatus bool) (rep *http.Response, err error) {
 	if rep, err = s.client.Do(req); err != nil {
 		return rep, fmt.Errorf("could not execute request: %s", err)
 	}
@@ -303,4 +414,100 @@ func (s APIv2) Do(req *http.Request, data interface{}, checkStatus bool) (rep *h
 	}
 
 	return rep, nil
+}
+
+var cfgd = configdir.New("rotational", "gds")
+
+const (
+	credentials = "credentials.json"
+)
+
+// Credentials returns the cached access and refresh tokens from disk.
+func (s *APIv2) Credentials() (creds *AuthReply, err error) {
+	folder := cfgd.QueryFolderContainsFile(credentials)
+	if folder != nil {
+		var data []byte
+		if data, err = folder.ReadFile(credentials); err != nil {
+			return nil, err
+		}
+
+		creds = &AuthReply{}
+		if err = json.Unmarshal(data, creds); err != nil {
+			return nil, err
+		}
+
+		return creds, nil
+	}
+	return nil, errors.New("no credentials are available")
+}
+
+// DeleteCredentials removed cached access and refresh tokens
+func (s *APIv2) DeleteCredentials() (err error) {
+	folder := cfgd.QueryFolderContainsFile(credentials)
+	if folder != nil && folder.Exists(credentials) {
+		return os.Remove(filepath.Join(folder.Path, credentials))
+	}
+
+	return nil
+}
+
+// TODO: do better than this when we have client profiles
+type ClientConfig struct {
+	TokenKeys map[string]string `envconfig:"GDS_ADMIN_TOKEN_KEYS"`
+}
+
+// GenerateCredentials creates a token manager generate and save credentials
+func (s *APIv2) GenerateCredentials() (err error) {
+	var conf ClientConfig
+	if err = envconfig.Process("gds", &conf); err != nil {
+		return err
+	}
+
+	if len(conf.TokenKeys) == 0 {
+		return errors.New("invalid configuration: token keys are required for local key generation")
+	}
+
+	var tm *tokens.TokenManager
+	if tm, err = tokens.New(conf.TokenKeys); err != nil {
+		return err
+	}
+
+	var accessToken, refreshToken *jwt.Token
+
+	claims := map[string]interface{}{
+		"hd":      "rotational.io",
+		"email":   "admin@rotational.io",
+		"name":    "GDS Admin CLI",
+		"picture": "",
+	}
+
+	// Create the access and refresh tokens from the claims
+	if accessToken, err = tm.CreateAccessToken(claims); err != nil {
+		return err
+	}
+
+	if refreshToken, err = tm.CreateRefreshToken(accessToken); err != nil {
+		return err
+	}
+
+	// Sign the tokens and return the response
+	creds := new(AuthReply)
+	if creds.AccessToken, err = tm.Sign(accessToken); err != nil {
+		return err
+	}
+	if creds.RefreshToken, err = tm.Sign(refreshToken); err != nil {
+		return err
+	}
+
+	// Save the credentials to disk
+	var data []byte
+	if data, err = json.Marshal(creds); err != nil {
+		return err
+	}
+
+	folders := cfgd.QueryFolders(configdir.Global)
+	folders[0].WriteFile(credentials, data)
+
+	s.accessToken = creds.AccessToken
+	return nil
 }

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -91,6 +91,15 @@ func TestAuthenticate(t *testing.T) {
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Double cookie protect GET request w/o middleware
+		// The client must a call to GET /v2/authenticate before authentication
+		// TODO: enhance this test to ensure client makes this call before POST
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/authenticate" {
+			w.Header().Add("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v2/authenticate", r.URL.Path)
 
@@ -129,6 +138,14 @@ func TestReuthenticate(t *testing.T) {
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Double cookie protect GET request w/o middleware
+		// The client must a call to GET /v2/authenticate before authentication
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/authenticate" {
+			w.Header().Add("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v2/reauthenticate", r.URL.Path)
 
@@ -378,6 +395,14 @@ func TestReview(t *testing.T) {
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Double cookie protect GET request w/o middleware
+		// The client must a call to GET /v2/authenticate before authentication
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/authenticate" {
+			w.Header().Add("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v2/vasps/1234/review", r.URL.Path)
 
@@ -420,6 +445,14 @@ func TestResend(t *testing.T) {
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Double cookie protect GET request w/o middleware
+		// The client must a call to GET /v2/authenticate before authentication
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/authenticate" {
+			w.Header().Add("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v2/vasps/1234/resend", r.URL.Path)
 

--- a/pkg/gds/config/config.go
+++ b/pkg/gds/config/config.go
@@ -119,6 +119,11 @@ func New() (_ Config, err error) {
 		return Config{}, err
 	}
 
+	// Preprocess authorized domains
+	for i, domain := range conf.Admin.AuthorizedDomains {
+		conf.Admin.AuthorizedDomains[i] = strings.ToLower(strings.Trim(strings.TrimSpace(domain), "\"'"))
+	}
+
 	conf.processed = true
 	return conf, nil
 }

--- a/pkg/gds/tokens/tokens.go
+++ b/pkg/gds/tokens/tokens.go
@@ -161,15 +161,11 @@ func (tm *TokenManager) CreateAccessToken(creds interface{}) (_ *jwt.Token, err 
 		if err = claims.extractClaims(t.(map[string]interface{})); err != nil {
 			return nil, err
 		}
-	case jwt.Token:
-		cc, ok := t.Claims.(*Claims)
-		if !ok {
-			return nil, errors.New("token does not have associated GDS claims")
-		}
-		claims.Domain = cc.Domain
-		claims.Email = cc.Email
-		claims.Name = cc.Name
-		claims.Picture = cc.Picture
+	case *Claims:
+		claims.Domain = t.Domain
+		claims.Email = t.Email
+		claims.Name = t.Name
+		claims.Picture = t.Picture
 	default:
 		return nil, fmt.Errorf("cannot create access token from %T", t)
 	}


### PR DESCRIPTION
To ensure the CLI still works on the MVP release, this PR adds private
key based authentication to the CLI to avoid having to go through the
OAuth2 workflow. This mechanism will be replaced in the future but is a
stop gap for now.