### PR TITLE
[WIP] Review notes endpoints

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -318,6 +318,86 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:     "admin:notes",
+			Usage:    "list notes associated with a VASP",
+			Category: "admin",
+			Action:   adminListNotes,
+			Before:   initClient,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "the uuid of the VASP",
+				},
+			},
+		},
+		{
+			Name:     "admin:notes-create",
+			Usage:    "create a new note associated with a VASP",
+			Category: "admin",
+			Action:   adminCreateNote,
+			Before:   initClient,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "the uuid of the VASP to associate the note with",
+				},
+				cli.StringFlag{
+					Name:  "n, name",
+					Usage: "the name of the new note or existing note",
+				},
+				cli.StringFlag{
+					Name:  "t, text",
+					Usage: "the text to include in the note",
+				},
+				cli.StringFlag{
+					Name:  "f, file",
+					Usage: "read note text from file",
+				},
+			},
+		},
+		{
+			Name:     "admin:notes-update",
+			Usage:    "update an existing VASP note",
+			Category: "admin",
+			Action:   adminUpdateNote,
+			Before:   initClient,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "the uuid of the VASP the note is associated with",
+				},
+				cli.StringFlag{
+					Name:  "n, name",
+					Usage: "the name of the note to update",
+				},
+				cli.StringFlag{
+					Name:  "t, text",
+					Usage: "the text to include in the note",
+				},
+				cli.StringFlag{
+					Name:  "f, file",
+					Usage: "read note text from file",
+				},
+			},
+		},
+		{
+			Name:     "admin:notes-delete",
+			Usage:    "delete an existing VASP note",
+			Category: "admin",
+			Action:   adminDeleteNote,
+			Before:   initClient,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "i, id",
+					Usage: "the uuid of the VASP the note is associated with",
+				},
+				cli.StringFlag{
+					Name:  "n, name",
+					Usage: "the name of the note to delete",
+				},
+			},
+		},
 	}
 
 	app.Run(os.Args)
@@ -678,6 +758,137 @@ func adminRetrieveVASPs(c *cli.Context) (err error) {
 
 	var rep *admin.RetrieveVASPReply
 	if rep, err = adminClient.RetrieveVASP(ctx, c.String("id")); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminListNotes(c *cli.Context) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	vaspID := c.String("id")
+	if vaspID == "" {
+		cli.NewExitError("must specify VASP ID (--id)", 1)
+	}
+
+	var rep *admin.ListReviewNotesReply
+	if rep, err = adminClient.ListReviewNotes(ctx, vaspID); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminCreateNote(c *cli.Context) (err error) {
+	var (
+		params *admin.ModifyReviewNoteRequest
+		text   string
+		file   string
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	params = &admin.ModifyReviewNoteRequest{
+		VASP: c.String("id"),
+		Note: c.String("name"),
+	}
+
+	if params.VASP == "" {
+		cli.NewExitError("must specify VASP ID (--id)", 1)
+	}
+
+	// Get the note text
+	text = c.String("text")
+	file = c.String("file")
+	if text == "" && file == "" {
+		return cli.NewExitError("must specify either --text or --file", 1)
+	} else if text != "" && file != "" {
+		return cli.NewExitError("cannot specify both --text and --file", 1)
+	} else if text != "" {
+		params.Text = text
+	} else {
+		var data []byte
+		if data, err = os.ReadFile(file); err != nil {
+			return cli.NewExitError(err, 1)
+		}
+		params.Text = string(data)
+	}
+
+	var rep *admin.CreateReviewNoteReply
+	if rep, err = adminClient.CreateReviewNote(ctx, params); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminUpdateNote(c *cli.Context) (err error) {
+	var (
+		params *admin.ModifyReviewNoteRequest
+		text   string
+		file   string
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	params = &admin.ModifyReviewNoteRequest{
+		VASP: c.String("id"),
+		Note: c.String("name"),
+	}
+
+	if params.VASP == "" {
+		cli.NewExitError("must specify VASP ID (--id)", 1)
+	}
+
+	if params.Note == "" {
+		return cli.NewExitError("must specify note name (--name)", 1)
+	}
+
+	// Get the note text
+	text = c.String("text")
+	file = c.String("file")
+	if text == "" && file == "" {
+		return cli.NewExitError("must specify either --text or --file", 1)
+	} else if text != "" && file != "" {
+		return cli.NewExitError("cannot specify both --text and --file", 1)
+	} else if text != "" {
+		params.Text = text
+	} else {
+		var data []byte
+		if data, err = os.ReadFile(file); err != nil {
+			return cli.NewExitError(err, 1)
+		}
+		params.Text = string(data)
+	}
+
+	var rep *admin.Reply
+	if rep, err = adminClient.UpdateReviewNote(ctx, params); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminDeleteNote(c *cli.Context) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	vaspID := c.String("id")
+	if vaspID == "" {
+		return cli.NewExitError("must specify VASP ID (--id)", 1)
+	}
+
+	noteID := c.String("name")
+	if noteID == "" {
+		return cli.NewExitError("must specify note name (--name)", 1)
+	}
+
+	var rep *admin.Reply
+	if rep, err = adminClient.DeleteReviewNote(ctx, vaspID, noteID); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -19,6 +19,10 @@ type DirectoryAdministrationClient interface {
 	Autocomplete(ctx context.Context) (out *AutocompleteReply, err error)
 	ListVASPs(ctx context.Context, params *ListVASPsParams) (out *ListVASPsReply, err error)
 	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
+	CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *CreateReviewNoteReply, err error)
+	ListReviewNotes(ctx context.Context, id string) (out *ListReviewNotesReply, err error)
+	UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *Reply, err error)
+	DeleteReviewNote(ctx context.Context, vaspID string, noteID string) (out *Reply, err error)
 	Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error)
 	Resend(ctx context.Context, in *ResendRequest) (out *ResendReply, err error)
 }
@@ -118,6 +122,45 @@ type RetrieveVASPReply struct {
 	VASP             map[string]interface{} `json:"vasp"`
 	VerifiedContacts map[string]string      `json:"verified_contacts"`
 	Traveler         bool                   `json:"traveler"`
+}
+
+// ModifyReviewNoteRequest is a request-like struct for creating or updateing notes.
+type ModifyReviewNoteRequest struct {
+	// The ID of the VASP (optional - is part of the URL).
+	VASP string `json:"vasp,omitempty"`
+
+	// The ID of the note to create (optional - can be automatically generated).
+	Note string `json:"note,omitempty"`
+
+	// Actual text of the new note.
+	Text string `json:"text"`
+}
+
+// CreateReviewNoteReply contains information about the newly created note.
+type CreateReviewNoteReply struct {
+	// The ID of the new note.
+	ID string `json:"id"`
+}
+
+// ListReviewNotesReply contains information about a group of notes.
+type ListReviewNotesReply struct {
+	Notes []ReviewNote `json:"notes"`
+}
+
+type ReviewNote struct {
+	// The ID of the note.
+	ID string `json:"id"`
+
+	// Created, modified timestamps.
+	Created  string `json:"created"`
+	Modified string `json:"modified"`
+
+	// Author, last editor of the note.
+	Author string `json:"author"`
+	Editor string `json:"editor"`
+
+	// Actual text of the note.
+	Text string `json:"text"`
 }
 
 //===========================================================================

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -267,6 +267,102 @@ func (s *APIv2) RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPR
 	return out, nil
 }
 
+func (s *APIv2) CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *CreateReviewNoteReply, err error) {
+	// vaspID is required for the endpoint
+	if in.VASP == "" {
+		return nil, ErrIDRequred
+	}
+
+	// Determine the path from the request
+	path := fmt.Sprintf("/v2/vasps/%s/notes", in.VASP)
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, path, in, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &CreateReviewNoteReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (s *APIv2) ListReviewNotes(ctx context.Context, id string) (out *ListReviewNotesReply, err error) {
+	// vaspID is required for the endpoint
+	if id == "" {
+		return nil, ErrIDRequred
+	}
+
+	// Determine the path from the request
+	path := fmt.Sprintf("/v2/vasps/%s/notes", id)
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, path, nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &ListReviewNotesReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (s *APIv2) UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *Reply, err error) {
+	// vaspID and noteID are required for the endpoint
+	if in.VASP == "" || in.Note == "" {
+		return nil, ErrIDRequred
+	}
+
+	// Determine the path from the request
+	path := fmt.Sprintf("/v2/vasps/%s/notes/%s", in.VASP, in.Note)
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPut, path, in, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &Reply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (s *APIv2) DeleteReviewNote(ctx context.Context, vaspID string, noteID string) (out *Reply, err error) {
+	// vaspID and noteID are required for the endpoint
+	if vaspID == "" || noteID == "" {
+		return nil, ErrIDRequred
+	}
+
+	// Determine the path from the request
+	path := fmt.Sprintf("/v2/vasps/%s/notes/%s", vaspID, noteID)
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodDelete, path, nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &Reply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func (s *APIv2) Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error) {
 	// The ID is required for the review request to determine the endpoint
 	if in.ID == "" {

--- a/pkg/gds/models/v1/models.go
+++ b/pkg/gds/models/v1/models.go
@@ -10,6 +10,11 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+var (
+	ErrorAlreadyExists = errors.New("Already exists")
+	ErrorNotFound      = errors.New("Not found")
+)
+
 // GetAdminVerificationToken from the extra data on the VASP record.
 func GetAdminVerificationToken(vasp *pb.VASP) (_ string, err error) {
 	// If the extra data is nil, return empty string with no error
@@ -183,7 +188,7 @@ func CreateReviewNote(vasp *pb.VASP, id string, author string, text string) (err
 	}
 
 	if _, exists := extra.ReviewNotes[id]; exists {
-		return fmt.Errorf("a note already exists with id: %s", id)
+		return ErrorAlreadyExists
 	}
 
 	// Create the new note.
@@ -224,7 +229,7 @@ func UpdateReviewNote(vasp *pb.VASP, id string, editor string, text string) (err
 	var note *ReviewNote
 	var exists bool
 	if note, exists = extra.ReviewNotes[id]; !exists {
-		return fmt.Errorf("could not find note with id: %s", id)
+		return ErrorNotFound
 	}
 
 	// Update the note.
@@ -259,7 +264,7 @@ func DeleteReviewNote(vasp *pb.VASP, id string) (err error) {
 	}
 
 	if _, exists := extra.ReviewNotes[id]; !exists {
-		return fmt.Errorf("could not find note with id: %s", id)
+		return ErrorNotFound
 	}
 
 	// Delete the note


### PR DESCRIPTION
This implements endpoints and service functions for the review notes feature. Specifically, there are four review note routes implemented:

- `GET /v2/:vaspID/notes` retrieve all notes for a VASP
- `POST /v2/:vaspID/notes` create a new note in the the VASP
- `PUT /v2/:vaspID/notes/:noteID` update a note in the VASP
- `DELETE /v2/:vaspID/notes/:noteID` delete a note from a VASP

TODO

- [ ] Add client tests