### PR TITLE
fix: modify logo on login and not-found screen according to environment

### DIFF
--- a/web/gds-admin-ui/src/layouts/LeftSidebar.js
+++ b/web/gds-admin-ui/src/layouts/LeftSidebar.js
@@ -4,14 +4,8 @@ import { Link } from 'react-router-dom';
 import SimpleBar from 'simplebar-react';
 import AppMenu from './Menu';
 import { getMenuItems } from '../helpers/menu';
+import { getDirectoryLogo, getDirectoryName, getDirectoryURL } from '../utils';
 
-import TrisatestLogo from '../assets/images/gds-trisatest-logo.png';
-import VaspDirectoryLogo from '../assets/images/gds-vaspdirectory-logo.png';
-import { getDirectoryName, getDirectoryURL, isTestNet } from '../utils';
-
-const getDirectoryLogo = () => {
-    return isTestNet() ? TrisatestLogo : VaspDirectoryLogo
-}
 
 const SideBarContent = ({ hideUserProfile }: SideBarContentProps) => {
     return (

--- a/web/gds-admin-ui/src/pages/account/AccountLayout.js
+++ b/web/gds-admin-ui/src/pages/account/AccountLayout.js
@@ -1,8 +1,7 @@
 // @flow
 import React, { useEffect } from 'react';
 import { Container, Row, Col, Card } from 'react-bootstrap';
-
-import Logo from '../../assets/images/gds-trisatest-logo.png';
+import { getDirectoryLogo } from '../../utils';
 
 type AccountLayoutProps = {
     bottomLinks?: React$Element<any>,
@@ -28,7 +27,7 @@ const AccountLayout = ({ bottomLinks, children }: AccountLayoutProps): React$Ele
                             <Card>
                                 <Card.Header className="pt-4 pb-4 text-center bg-primary" style={{ background: "linear-gradient(90deg,#24a9df,#1aebb4)" }}>
                                     <span>
-                                        <img src={Logo} alt="" height="38" />
+                                        <img src={getDirectoryLogo()} alt="" height="38" />
                                     </span>
                                 </Card.Header>
                                 <Card.Body className="p-4">{children}</Card.Body>

--- a/web/gds-admin-ui/src/pages/app/dashboard/Status.js
+++ b/web/gds-admin-ui/src/pages/app/dashboard/Status.js
@@ -5,7 +5,7 @@ import { capitalizeFirstLetter, getRatios } from '../../../utils';
 import { Status as STATUS } from '../../../constants';
 
 const Status = ({ statuses }) => {
-    const colors = ['#0acf97', '#727cf5', '#fa5c7c'];
+    const colors = ['#ffc107', '#dc3545', '#0d6efd'];
 
     const statusRatios = () => {
         if (statuses && typeof statuses === "object") {
@@ -15,7 +15,7 @@ const Status = ({ statuses }) => {
         return {}
     }
 
-    const getDonutChartData = () => Object.values(statusRatios())
+    const getDonutChartData = () => statuses ? Object.values(statuses) : []
     const statusPercents = () => Object.fromEntries(Object.entries(statusRatios()).map(([key, val]) => [key, val * 100.0]))
 
 
@@ -53,7 +53,7 @@ const Status = ({ statuses }) => {
     return (
         <Card>
             <Card.Body>
-                <h4 className="header-title mb-4">Review Speed</h4>
+                <h4 className="header-title mb-4">Registration Statuses</h4>
 
                 <div className="my-4 chartjs-chart" style={{ height: '202px' }}>
                     <Doughnut data={donutChartData} options={donutChartOpts} />

--- a/web/gds-admin-ui/src/pages/app/dashboard/Tasks.js
+++ b/web/gds-admin-ui/src/pages/app/dashboard/Tasks.js
@@ -32,7 +32,7 @@ const Tasks = ({ data }) => {
             <Card.Body>
                 <h4 className="header-title mb-3">Pending Reviews</h4>
 
-                <Table responsive className="table table-centered table-nowrap table-hover mb-0 z-index-2">
+                <Table className="table table-centered table-nowrap table-hover mb-0 z-index-2">
                     <tbody>
                         {
                             Array.isArray(data?.vasps) && data.vasps.map((vasp) => (

--- a/web/gds-admin-ui/src/pages/app/dashboard/TasksChart.js
+++ b/web/gds-admin-ui/src/pages/app/dashboard/TasksChart.js
@@ -60,17 +60,17 @@ const TasksChart = (): React$Element<any> => {
     }))
 
     const getWeeks = () => {
-        if (reviews && Array.isArray(reviews)) {
-            return reviews.map(review => review.week)
+        if (reviews && Array.isArray(reviews.weeks)) {
+            return reviews.weeks.map(review => review.week)
         }
 
         return []
     }
 
     const getData = (key = '') => {
-        if (reviews && Array.isArray(reviews)) {
-            return reviews.map(review => {
-                return review.registrations[key];
+        if (reviews && Array.isArray(reviews.weeks)) {
+            return reviews.weeks.map(week => {
+                return week.registrations[key];
             })
         }
 

--- a/web/gds-admin-ui/src/pages/app/dashboard/index.js
+++ b/web/gds-admin-ui/src/pages/app/dashboard/index.js
@@ -39,21 +39,20 @@ const ProjectDashboardPage = (): React$Element<React$FragmentType> => {
 
             <Statistics data={summary} />
 
-            <Row style={{ height: "500px" }}>
+            <Row>
                 <Col lg={4}>
                     <Status statuses={summary?.statuses} />
                 </Col>
-                <Col lg={8} style={{ overflowY: "scroll", height: "100%" }}>
+                <Col sm={12} lg={8} style={{ overflowY: "scroll", height: "100%" }}>
                     {!isVaspsLoading ? <Tasks data={vasps} /> : null}
                 </Col>
             </Row>
-            {
-                <Row>
-                    <Col>
-                        <TasksChart />
-                    </Col>
-                </Row>
-            }
+            <Row>
+                <Col>
+                    <TasksChart />
+                </Col>
+            </Row>
+
         </React.Fragment>
     );
 };

--- a/web/gds-admin-ui/src/pages/error/PageNotFound.js
+++ b/web/gds-admin-ui/src/pages/error/PageNotFound.js
@@ -3,8 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Row, Col, Card } from 'react-bootstrap';
 import { useLocation } from 'react-router-dom'
-
-import Logo from '../../assets/images/gds-trisatest-logo.png';
+import { getDirectoryLogo } from '../../utils';
 
 const ErrorPageNotFound = (): React$Element<React$FragmentType> => {
     const { state } = useLocation()
@@ -19,7 +18,7 @@ const ErrorPageNotFound = (): React$Element<React$FragmentType> => {
                                 <Card.Header className="pt-4 pb-4 text-center bg-primary" style={{ background: "linear-gradient(90deg,#24a9df,#1aebb4)" }}>
                                     <Link to="/">
                                         <span>
-                                            <img src={Logo} alt="" height="38" />
+                                            <img src={getDirectoryLogo()} alt="" height="38" />
                                         </span>
                                     </Link>
                                 </Card.Header>

--- a/web/gds-admin-ui/src/pages/error/PageNotFoundAlt.js
+++ b/web/gds-admin-ui/src/pages/error/PageNotFoundAlt.js
@@ -5,7 +5,6 @@ import { Row, Col } from 'react-bootstrap';
 
 const ErrorPageNotFoundAlt = (): React$Element<React$FragmentType> => {
     const { state } = useLocation()
-    console.log(state)
 
     return (
         <React.Fragment>

--- a/web/gds-admin-ui/src/pages/error/ServerError.js
+++ b/web/gds-admin-ui/src/pages/error/ServerError.js
@@ -2,11 +2,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Row, Col, Card } from 'react-bootstrap';
-
-// components
-import Logo from '../../assets/images/gds-trisatest-logo.png';
-
 import notFoundImg from '../../assets/images/startman.svg';
+import { getDirectoryLogo } from '../../utils';
 
 const ServerError = (): React$Element<React$FragmentType> => {
     return (
@@ -20,7 +17,7 @@ const ServerError = (): React$Element<React$FragmentType> => {
                                 <Card.Header className="pt-4 pb-4 text-center bg-primary">
                                     <Link to="/">
                                         <span>
-                                            <img src={Logo} alt="" height="18" />
+                                            <img src={getDirectoryLogo()} alt="" height="18" />
                                         </span>
                                     </Link>
                                 </Card.Header>

--- a/web/gds-admin-ui/src/utils/index.js
+++ b/web/gds-admin-ui/src/utils/index.js
@@ -1,6 +1,8 @@
 import config from '../config';
 import { ENVIRONMENT, Status } from '../constants';
 import { DIRECTORY } from '../constants';
+import TrisatestLogo from '../assets/images/gds-trisatest-logo.png';
+import VaspDirectoryLogo from '../assets/images/gds-vaspdirectory-logo.png';
 
 export * from './array';
 
@@ -97,4 +99,9 @@ function getDirectoryURL() {
     return isTestNet() ? "https://admin.vaspdirectory.net" : "https://admin.trisatest.net"
 }
 
-export { isTestNet, getDirectoryName, getDirectoryURL, getStatusClassName, formatDisplayedData, defaultEndpointPrefix, apiHost, getRatios, capitalizeFirstLetter, getCookie }
+const getDirectoryLogo = () => {
+    return isTestNet() ? TrisatestLogo : VaspDirectoryLogo
+}
+
+
+export { getDirectoryLogo, isTestNet, getDirectoryName, getDirectoryURL, getStatusClassName, formatDisplayedData, defaultEndpointPrefix, apiHost, getRatios, capitalizeFirstLetter, getCookie }


### PR DESCRIPTION
Fixes SC-1455
This is a fix to update the logo on login and not found screens based on `IS_TESTNET` variable. 
The purpose of this variable is to be able to know which logo should be appear on the screen either `VASP Directory` or `TESTNET`
Another story for that has been created by @bbengfort  `SC-1486` if you want to have his explanation