### PR TITLE
fix routing and nil map

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -180,7 +180,7 @@ func (s *Admin) setupRoutes() (err error) {
 			vasps.POST("/:vaspID/review", csrf, s.Review)
 			vasps.POST("/:vaspID/resend", csrf, s.Resend)
 
-			notes := v2.Group("/:vaspID/notes")
+			notes := vasps.Group("/:vaspID/notes")
 			{
 				notes.GET("", s.ListReviewNotes)
 				notes.POST("", csrf, s.CreateReviewNote)

--- a/pkg/gds/models/v1/models.go
+++ b/pkg/gds/models/v1/models.go
@@ -155,9 +155,9 @@ func UpdateCertificateRequestStatus(request *CertificateRequest, state Certifica
 
 // GetReviewNotes returns all of the review notes for a VASP as a map.
 func GetReviewNotes(vasp *pb.VASP) (_ map[string]*ReviewNote, err error) {
-	// If the extra data is nil, return nil (no review notes).
+	// If the extra data is nil, return an empty map (no review notes).
 	if vasp.Extra == nil {
-		return nil, nil
+		return map[string]*ReviewNote{}, nil
 	}
 
 	// Unmarshal the extra data field on the VASP.


### PR DESCRIPTION
This fixes two issues @elysee15 discovered with the review notes endpoint.

1. The notes endpoint was configured at `v2/:vaspID/notes`, it should be `v2/vasps/:vaspID/notes`.
2. The review notes handlers run into a nil exception when a VASP contains no review notes.