### PR TITLE
Change Chinese language dropdown label

### DIFF
--- a/web/gds-ui/src/components/select/LanguageSelect.js
+++ b/web/gds-ui/src/components/select/LanguageSelect.js
@@ -18,7 +18,7 @@ const languages = {
   },
   zh: {
     flag: "🇨🇳",
-    title: "中国人",
+    title: "中文",
   },
 }
 


### PR DESCRIPTION
Change the “中国人” here into “中文“. What we now have is “Chinese people” but better change it into the “Chinese language”, which is “中文“
![Screen Shot 2021-11-01 at 9 56 12 PM](https://user-images.githubusercontent.com/15382905/139780875-bfe9d794-85bf-4996-bf56-aeccbe3d79bf.png)


