### PR TITLE
fix uninitialized pointer

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -836,7 +836,9 @@ func (s *Admin) ListReviewNotes(c *gin.Context) {
 	}
 
 	// Compose the JSON response
-	out.Notes = make([]admin.ReviewNote, len(notes))
+	out = &admin.ListReviewNotesReply{
+		Notes: make([]admin.ReviewNote, len(notes)),
+	}
 	for _, n := range notes {
 		out.Notes = append(out.Notes, admin.ReviewNote{
 			ID:       n.Id,


### PR DESCRIPTION
This fixes an uninitialized pointer in `ListReviewNotes` which is the actual bug that @elysee15 is getting the 500 error from when calling the notes endpoint.