### PR TITLE
sc-1804 return note from CreateNote endpoint

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -952,7 +952,7 @@ func adminCreateNote(c *cli.Context) (err error) {
 		params.Text = string(data)
 	}
 
-	var rep *admin.CreateReviewNoteReply
+	var rep *admin.ReviewNote
 	if rep, err = adminClient.CreateReviewNote(ctx, params); err != nil {
 		return cli.Exit(err, 1)
 	}

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -736,6 +736,7 @@ func (s *Admin) CreateReviewNote(c *gin.Context) {
 	var (
 		err    error
 		in     *admin.ModifyReviewNoteRequest
+		note   *models.ReviewNote
 		vasp   *pb.VASP
 		claims *tokens.Claims
 		vaspID string
@@ -795,7 +796,7 @@ func (s *Admin) CreateReviewNote(c *gin.Context) {
 	}
 
 	// Create the note
-	if err = models.CreateReviewNote(vasp, noteID, claims.Email, in.Text); err != nil {
+	if note, err = models.CreateReviewNote(vasp, noteID, claims.Email, in.Text); err != nil {
 		log.Warn().Err(err).Msg("error creating review note")
 		if err == models.ErrorAlreadyExists {
 			c.JSON(http.StatusBadRequest, admin.ErrorResponse("note already exists"))
@@ -811,7 +812,14 @@ func (s *Admin) CreateReviewNote(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not update VASP record"))
 	}
 
-	c.JSON(http.StatusCreated, &admin.CreateReviewNoteReply{ID: noteID})
+	c.JSON(http.StatusCreated, &admin.ReviewNote{
+		ID:       note.Id,
+		Created:  note.Created,
+		Modified: note.Modified,
+		Author:   note.Author,
+		Editor:   note.Editor,
+		Text:     note.Text,
+	})
 }
 
 // ListReviewNotes returns a list of review notes given a vaspID param.

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -21,7 +21,7 @@ type DirectoryAdministrationClient interface {
 	Autocomplete(ctx context.Context) (out *AutocompleteReply, err error)
 	ListVASPs(ctx context.Context, params *ListVASPsParams) (out *ListVASPsReply, err error)
 	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
-	CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *CreateReviewNoteReply, err error)
+	CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error)
 	ListReviewNotes(ctx context.Context, id string) (out *ListReviewNotesReply, err error)
 	UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *Reply, err error)
 	DeleteReviewNote(ctx context.Context, vaspID string, noteID string) (out *Reply, err error)
@@ -142,12 +142,6 @@ type ModifyReviewNoteRequest struct {
 
 	// Actual text of the note.
 	Text string `json:"text"`
-}
-
-// CreateReviewNoteReply contains information about the newly created note.
-type CreateReviewNoteReply struct {
-	// The ID of the new note.
-	ID string `json:"id"`
 }
 
 // ListReviewNotesReply contains information about a group of notes.

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -294,7 +294,7 @@ func (s *APIv2) RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPR
 	return out, nil
 }
 
-func (s *APIv2) CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *CreateReviewNoteReply, err error) {
+func (s *APIv2) CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error) {
 	// vaspID is required for the endpoint
 	if in.VASP == "" {
 		return nil, ErrIDRequred
@@ -315,7 +315,7 @@ func (s *APIv2) CreateReviewNote(ctx context.Context, in *ModifyReviewNoteReques
 	}
 
 	// Execute the request and get a response
-	out = &CreateReviewNoteReply{}
+	out = &ReviewNote{}
 	if _, err = s.Do(req, out, true); err != nil {
 		return nil, err
 	}

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -412,7 +412,7 @@ func TestRetrieveVASP(t *testing.T) {
 }
 
 func TestCreateReviewNote(t *testing.T) {
-	fixture := &admin.CreateReviewNoteReply{
+	fixture := &admin.ReviewNote{
 		ID: "af367d27-b0e7-48b5-8987-e48a0712a826",
 	}
 

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -412,13 +412,16 @@ func TestRetrieveVASP(t *testing.T) {
 }
 
 func TestCreateReviewNote(t *testing.T) {
-	fixture := &admin.ReviewNote{
-		ID: "af367d27-b0e7-48b5-8987-e48a0712a826",
-	}
-
 	req := &admin.ModifyReviewNoteRequest{
 		VASP: "83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5",
 		Text: "note text",
+	}
+
+	fixture := &admin.ReviewNote{
+		ID:      "af367d27-b0e7-48b5-8987-e48a0712a826",
+		Created: time.Now().Format(time.RFC3339),
+		Author:  "alice@example.com",
+		Text:    req.Text,
 	}
 
 	// Create a Test Server

--- a/pkg/gds/models/v1/models_test.go
+++ b/pkg/gds/models/v1/models_test.go
@@ -46,8 +46,13 @@ func TestVASPExtra(t *testing.T) {
 	require.True(t, proto.Equal(entry, auditLog[0]))
 
 	// Attempt to create a review note
-	err = CreateReviewNote(vasp, "boats", "pontoon@boatz.com", "boats are cool")
+	note, err := CreateReviewNote(vasp, "boats", "pontoon@boatz.com", "boats are cool")
 	require.NoError(t, err)
+	require.Equal(t, "boats", note.Id)
+	require.Equal(t, "", note.Modified)
+	require.Equal(t, "pontoon@boatz.com", note.Author)
+	require.Equal(t, "", note.Editor)
+	require.Equal(t, "boats are cool", note.Text)
 
 	// Should be able to fetch the note
 	notes, err := GetReviewNotes(vasp)
@@ -183,8 +188,13 @@ func TestReviewNotes(t *testing.T) {
 	require.Error(t, err)
 
 	// Create a new note
-	err = CreateReviewNote(vasp, "boats", "pontoon@boatz.com", "boats are cool")
+	note, err := CreateReviewNote(vasp, "boats", "pontoon@boatz.com", "boats are cool")
 	require.NoError(t, err)
+	require.Equal(t, "boats", note.Id)
+	require.Equal(t, "", note.Modified)
+	require.Equal(t, "pontoon@boatz.com", note.Author)
+	require.Equal(t, "", note.Editor)
+	require.Equal(t, "boats are cool", note.Text)
 
 	notes, err = GetReviewNotes(vasp)
 	require.NoError(t, err)
@@ -204,8 +214,9 @@ func TestReviewNotes(t *testing.T) {
 	require.Error(t, err)
 
 	// Create a new note
-	err = CreateReviewNote(vasp, "jetskis", "admin@example.com", "jetskis are fun")
+	note, err = CreateReviewNote(vasp, "jetskis", "admin@example.com", "jetskis are fun")
 	require.NoError(t, err)
+	require.Equal(t, "jetskis are fun", note.Text)
 
 	notes, err = GetReviewNotes(vasp)
 	require.NoError(t, err)


### PR DESCRIPTION
This changes the `CreateReviewNote` endpoint a bit so that it returns the newly created note instead of just the ID slug, which makes the review note handling on the front end a bit easier.