### PR TITLE
Load locale data for GDS-UI to avoid plural error msg

### DIFF
--- a/web/gds-ui/src/contexts/LanguageContext.js
+++ b/web/gds-ui/src/contexts/LanguageContext.js
@@ -5,7 +5,8 @@ import { messages as messagesEn } from '../locales/en/messages';
 import { messages as messagesDe } from '../locales/de/messages';
 import { messages as messagesFr } from '../locales/fr/messages';
 import { messages as messagesZh } from '../locales/zh/messages';
-import { en, de, fr, zh } from 'make-plural/plurals'
+import { messages as messagesJa } from '../locales/ja/messages';
+import { en, de, fr, zh, ja } from 'make-plural/plurals'
 
 
 const Context = React.createContext();
@@ -17,12 +18,14 @@ export const LanguageStore = ({ children }) => {
       de: messagesDe,
       fr: messagesFr,
       zh: messagesZh,
+      ja: messagesJa,
     });
     i18n.loadLocaleData({
       en: { plurals: en },
       de: { plurals: de },
       fr: { plurals: fr },
-      zh: { plurals: zh }
+      zh: { plurals: zh },
+      ja: { plurals: ja}
     })
     i18n.activate('en');
   }, []);

--- a/web/gds-ui/src/contexts/LanguageContext.js
+++ b/web/gds-ui/src/contexts/LanguageContext.js
@@ -5,6 +5,7 @@ import { messages as messagesEn } from '../locales/en/messages';
 import { messages as messagesDe } from '../locales/de/messages';
 import { messages as messagesFr } from '../locales/fr/messages';
 import { messages as messagesZh } from '../locales/zh/messages';
+import { en, de, fr, zh } from 'make-plural/plurals'
 
 
 const Context = React.createContext();
@@ -17,6 +18,12 @@ export const LanguageStore = ({ children }) => {
       fr: messagesFr,
       zh: messagesZh,
     });
+    i18n.loadLocaleData({
+      en: { plurals: en },
+      de: { plurals: de },
+      fr: { plurals: fr },
+      zh: { plurals: zh }
+    })
     i18n.activate('en');
   }, []);
 


### PR DESCRIPTION
This PR adds the `loadLocaleData` function to avoid this error message:

```
index.js:1 Plurals for locale en aren't loaded. Use i18n.loadLocaleData method to load plurals for specific locale. Using other plural rule as a fallback.
```