### PR TITLE
sc-1864 return note from update endpoint

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -1000,7 +1000,7 @@ func adminUpdateNote(c *cli.Context) (err error) {
 		params.Text = string(data)
 	}
 
-	var rep *admin.Reply
+	var rep *admin.ReviewNote
 	if rep, err = adminClient.UpdateReviewNote(ctx, params); err != nil {
 		return cli.Exit(err, 1)
 	}

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -873,6 +873,7 @@ func (s *Admin) UpdateReviewNote(c *gin.Context) {
 	var (
 		err    error
 		in     *admin.ModifyReviewNoteRequest
+		note   *models.ReviewNote
 		vasp   *pb.VASP
 		claims *tokens.Claims
 		vaspID string
@@ -920,7 +921,7 @@ func (s *Admin) UpdateReviewNote(c *gin.Context) {
 	}
 
 	// Update the note
-	if err = models.UpdateReviewNote(vasp, noteID, claims.Email, in.Text); err != nil {
+	if note, err = models.UpdateReviewNote(vasp, noteID, claims.Email, in.Text); err != nil {
 		log.Warn().Err(err).Msg("error updating review note")
 		if err == models.ErrorNotFound {
 			c.JSON(http.StatusNotFound, admin.ErrorResponse("review note not found"))
@@ -936,7 +937,14 @@ func (s *Admin) UpdateReviewNote(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not update VASP record"))
 	}
 
-	c.JSON(http.StatusOK, &admin.Reply{Success: true})
+	c.JSON(http.StatusOK, &admin.ReviewNote{
+		ID:       note.Id,
+		Created:  note.Created,
+		Modified: note.Modified,
+		Author:   note.Author,
+		Editor:   note.Editor,
+		Text:     note.Text,
+	})
 }
 
 // DeleteReviewNote deletes a review note given vaspID and noteID params.

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -23,7 +23,7 @@ type DirectoryAdministrationClient interface {
 	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
 	CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error)
 	ListReviewNotes(ctx context.Context, id string) (out *ListReviewNotesReply, err error)
-	UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *Reply, err error)
+	UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error)
 	DeleteReviewNote(ctx context.Context, vaspID string, noteID string) (out *Reply, err error)
 	Review(ctx context.Context, in *ReviewRequest) (out *ReviewReply, err error)
 	Resend(ctx context.Context, in *ResendRequest) (out *ResendReply, err error)

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -352,7 +352,7 @@ func (s *APIv2) ListReviewNotes(ctx context.Context, id string) (out *ListReview
 	return out, nil
 }
 
-func (s *APIv2) UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *Reply, err error) {
+func (s *APIv2) UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error) {
 	// vaspID and noteID are required for the endpoint
 	if in.VASP == "" || in.NoteID == "" {
 		return nil, ErrIDRequred
@@ -373,7 +373,7 @@ func (s *APIv2) UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteReques
 	}
 
 	// Execute the request and get a response
-	out = &Reply{}
+	out = &ReviewNote{}
 	if _, err = s.Do(req, out, true); err != nil {
 		return nil, err
 	}

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -505,7 +505,14 @@ func TestListReviewNotes(t *testing.T) {
 }
 
 func UpdateReviewNote(t *testing.T) {
-	fixture := &admin.Reply{Success: true}
+	fixture := &admin.ReviewNote{
+		ID:       "af367d27-b0e7-48b5-8987-e48a0712a826",
+		Created:  time.Now().Format(time.RFC3339),
+		Modified: time.Now().Add(time.Hour).Format(time.RFC3339),
+		Author:   "alice@example.com",
+		Editor:   "bob@example.com",
+		Text:     "updated note text",
+	}
 
 	req := &admin.ModifyReviewNoteRequest{
 		VASP:   "83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5",

--- a/pkg/gds/models/v1/models.go
+++ b/pkg/gds/models/v1/models.go
@@ -209,28 +209,27 @@ func CreateReviewNote(vasp *pb.VASP, id string, author string, text string) (not
 }
 
 // UpdateReviewNote updates a specified note on the VASP.
-func UpdateReviewNote(vasp *pb.VASP, id string, editor string, text string) (err error) {
+func UpdateReviewNote(vasp *pb.VASP, id string, editor string, text string) (note *ReviewNote, err error) {
 	// Validate note id.
 	if id == "" {
-		return errors.New("must specify a valid note id")
+		return nil, errors.New("must specify a valid note id")
 	}
 
 	// Update is invalid if the extra data doesn't exist.
 	if vasp.Extra == nil {
-		return errors.New("extra does not exist")
+		return nil, errors.New("extra does not exist")
 	}
 
 	// Unmarshal previous extra data.
 	extra := &GDSExtraData{}
 	if err = vasp.Extra.UnmarshalTo(extra); err != nil {
-		return fmt.Errorf("could not deserialize previous extra: %s", err)
+		return nil, fmt.Errorf("could not deserialize previous extra: %s", err)
 	}
 
 	// Get the specified note.
-	var note *ReviewNote
 	var exists bool
 	if note, exists = extra.ReviewNotes[id]; !exists {
-		return ErrorNotFound
+		return nil, ErrorNotFound
 	}
 
 	// Update the note.
@@ -240,10 +239,10 @@ func UpdateReviewNote(vasp *pb.VASP, id string, editor string, text string) (err
 
 	// Serialize the extra data back to the VASP.
 	if vasp.Extra, err = anypb.New(extra); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return note, nil
 }
 
 // DeleteReviewNote deletes a specified note on the VASP.

--- a/pkg/gds/models/v1/models_test.go
+++ b/pkg/gds/models/v1/models_test.go
@@ -180,7 +180,7 @@ func TestReviewNotes(t *testing.T) {
 	require.Len(t, notes, 0)
 
 	// Attempt to update a note from an empty map
-	err = UpdateReviewNote(vasp, "boats", "pontoon@boatz.com", "boats are cool")
+	_, err = UpdateReviewNote(vasp, "boats", "pontoon@boatz.com", "boats are cool")
 	require.Error(t, err)
 
 	// Attempt to update a note from an empty map
@@ -206,7 +206,7 @@ func TestReviewNotes(t *testing.T) {
 	require.Equal(t, "boats are cool", notes["boats"].Text)
 
 	// Attempt to update a note that doesn't exist
-	err = UpdateReviewNote(vasp, "jetskis", "admin@example.com", "jetskis are fun")
+	_, err = UpdateReviewNote(vasp, "jetskis", "admin@example.com", "jetskis are fun")
 	require.Error(t, err)
 
 	// Attempt to delete a note that doesn't exist
@@ -226,8 +226,15 @@ func TestReviewNotes(t *testing.T) {
 
 	// Update an existing note
 	expectedTime := time.Now()
-	err = UpdateReviewNote(vasp, "jetskis", "pontoon@boatz.com", "jetskis are loud")
+	note, err = UpdateReviewNote(vasp, "jetskis", "pontoon@boatz.com", "jetskis are loud")
 	require.NoError(t, err)
+	require.Equal(t, "jetskis", note.Id)
+	require.Equal(t, "jetskis are loud", note.Text)
+	require.Equal(t, "admin@example.com", note.Author)
+	require.Equal(t, "pontoon@boatz.com", note.Editor)
+	modifiedTime, err := time.Parse(time.RFC3339, note.Modified)
+	require.NoError(t, err)
+	require.LessOrEqual(t, modifiedTime.Sub(expectedTime), time.Minute)
 
 	// Editor and modified should be updated
 	notes, err = GetReviewNotes(vasp)
@@ -236,8 +243,6 @@ func TestReviewNotes(t *testing.T) {
 	require.Equal(t, "boats are cool", notes["boats"].Text)
 	require.Equal(t, "jetskis are loud", notes["jetskis"].Text)
 	require.Equal(t, "pontoon@boatz.com", notes["jetskis"].Editor)
-	modifiedTime, err := time.Parse(time.RFC3339, notes["jetskis"].Created)
-	require.NoError(t, err)
 	require.LessOrEqual(t, modifiedTime.Sub(expectedTime), time.Minute)
 
 	// Delete an existing note


### PR DESCRIPTION
This makes a change to the `UpdateReviewNote` endpoint so that it returns the updated note rather than an empty success reply, similar to the change that was just made for the `CreateReviewNote` endpoint.