### PR TITLE
GDS Containers Update

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.env
+.git
+.github
+.vscode
+fixtures
+.DS_Store
+LICENSE
+README.md

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -76,6 +76,7 @@ REPO=$(realpath "$DIR/..")
 
 # Build the primary backend images
 docker build -t trisa/gds:$TAG -f $DIR/gds/Dockerfile $REPO
+docker build -t trisa/trtl:$TAG -f $DIR/trtl/Dockerfile $REPO
 docker build -t trisa/grpc-proxy:$TAG -f $DIR/grpc-proxy/Dockerfile $REPO
 
 # Build the UI images for trisatest.net and vaspdirectory.net
@@ -110,14 +111,16 @@ docker build \
 
 # Retag the images to push to gcr.io
 docker tag trisa/gds:$TAG gcr.io/trisa-gds/gds:$TAG
-docker tag trisa/gds-ui:$TAG gcr.io/trisa-gds/gds-ui:$TAG
+docker tag trisa/trtl:$TAG gcr.io/trisa-gds/trtl:$TAG
 docker tag trisa/grpc-proxy:$TAG gcr.io/trisa-gds/grpc-proxy:$TAG
+docker tag trisa/gds-ui:$TAG gcr.io/trisa-gds/gds-ui:$TAG
 docker tag trisa/gds-testnet-ui:$TAG gcr.io/trisa-gds/gds-testnet-ui:$TAG
 docker tag trisa/gds-admin-ui:$TAG gcr.io/trisa-gds/gds-admin-ui:$TAG
 docker tag trisa/gds-testnet-admin-ui:$TAG gcr.io/trisa-gds/gds-testnet-admin-ui:$TAG
 
 # Push to DockerHub
 docker push trisa/gds:$TAG
+docker push trisa/trtl:$TAG
 docker push trisa/grpc-proxy:$TAG
 docker push trisa/gds-ui:$TAG
 docker push trisa/gds-testnet-ui:$TAG
@@ -126,6 +129,7 @@ docker push trisa/gds-testnet-admin-ui:$TAG
 
 # Push to GCR
 docker push gcr.io/trisa-gds/gds:$TAG
+docker push gcr.io/trisa-gds/trtl:$TAG
 docker push gcr.io/trisa-gds/grpc-proxy:$TAG
 docker push gcr.io/trisa-gds/gds-ui:$TAG
 docker push gcr.io/trisa-gds/gds-testnet-ui:$TAG

--- a/containers/trtl/Dockerfile
+++ b/containers/trtl/Dockerfile
@@ -28,15 +28,14 @@ COPY proto ./proto
 RUN go test -timeout 30s -v ./...
 
 # Build binaries
-RUN go build -v -o /go/bin/gds ./cmd/gds
-RUN go build -v -o /go/bin/sectigo ./cmd/sectigo
+RUN go build -v -o /go/bin/trtl ./cmd/trtl
 RUN go build -v -o /go/bin/gdsutil ./cmd/gdsutil
 
 # Final Stage
 FROM ${FINAL_IMAGE} AS final
 
 LABEL maintainer="TRISA <info@trisa.io>"
-LABEL description="Global TRISA Directory Service"
+LABEL description="GDS Replicated Data Backend (TRTL)"
 
 # Ensure ca-certificates are up to date
 RUN set -x && apt-get update && \
@@ -44,8 +43,7 @@ RUN set -x && apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /go/bin/gds /usr/local/bin/gds
-COPY --from=builder /go/bin/sectigo /usr/local/bin/sectigo
+COPY --from=builder /go/bin/trtl /usr/local/bin/trtl
 COPY --from=builder /go/bin/gdsutil /usr/local/bin/gdsutil
 
-CMD [ "/usr/local/bin/gds", "serve" ]
+CMD [ "/usr/local/bin/trtl", "serve" ]


### PR DESCRIPTION
This PR adds the TRTL Dockerfile and updates the GDS Dockerfile to be a
bit lighter-weight and share cache with the TRTL Dockerfile in order to
reduce build times. The GDS container has decreased from 175MB to 132MB
as a result of these changes.