### PR TITLE
sc-2059 allow multiple status filters

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -364,8 +364,8 @@ func main() {
 						Aliases: []string{"s"},
 						Usage:   "specify the number of items per page",
 					},
-					&cli.StringFlag{
-						Name:    "status",
+					&cli.StringSliceFlag{
+						Name:    "status-filters",
 						Aliases: []string{"S"},
 						Usage:   "filter by verification status",
 					},

--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -874,9 +874,9 @@ func adminListVASPs(c *cli.Context) (err error) {
 	defer cancel()
 
 	params := &admin.ListVASPsParams{
-		Page:     c.Int("page"),
-		PageSize: c.Int("page-size"),
-		Status:   c.String("status"),
+		Page:          c.Int("page"),
+		PageSize:      c.Int("page-size"),
+		StatusFilters: c.StringSlice("status-filters"),
 	}
 
 	var rep *admin.ListVASPsReply

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -570,16 +570,18 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 	}
 
 	// Determine status filter
-	var status pb.VerificationState
-	if in.Status != "" {
-		in.Status = strings.ToUpper(strings.ReplaceAll(in.Status, " ", "_"))
-		sn, ok := pb.VerificationState_value[in.Status]
-		if !ok {
-			log.Warn().Str("status", in.Status).Msg("unknown verification status")
-			c.JSON(http.StatusBadRequest, admin.ErrorResponse(fmt.Errorf("unknown verification status %q", in.Status)))
-			return
+	filters := make(map[pb.VerificationState]struct{})
+	if in.StatusFilters != nil {
+		for i, s := range in.StatusFilters {
+			in.StatusFilters[i] = strings.ToUpper(strings.ReplaceAll(s, " ", "_"))
+			sn, ok := pb.VerificationState_value[in.StatusFilters[i]]
+			if !ok {
+				log.Warn().Str("status", in.StatusFilters[i]).Msg("unknown verification status")
+				c.JSON(http.StatusBadRequest, admin.ErrorResponse(fmt.Errorf("unknown verification status %q", in.StatusFilters[i])))
+				return
+			}
+			filters[pb.VerificationState(sn)] = struct{}{}
 		}
-		status = pb.VerificationState(sn)
 	}
 
 	// Set pagination defaults if not specified in query
@@ -604,8 +606,7 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 	// Query the list of VASPs from the data store
 	iter := s.db.ListVASPs()
 	defer iter.Release()
-	for iter.Next() {
-		out.Count++
+	for out.Count = 0; iter.Next(); out.Count++ {
 		if out.Count >= minIndex && out.Count < maxIndex {
 			// In the page range so add to the list reply
 			// Fetch VASP from the database
@@ -615,8 +616,8 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 				continue
 			}
 
-			// Check the status before continuing
-			if status != pb.VerificationState_NO_VERIFICATION && vasp.VerificationStatus != status {
+			// Check against the status filters before continuing
+			if _, ok := filters[vasp.VerificationStatus]; len(filters) > 0 && !ok {
 				continue
 			}
 

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -613,11 +613,13 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 			var vasp *pb.VASP
 			if vasp = iter.VASP(); vasp == nil {
 				// VASP could not be parsed; error logged in VASP() method continue iteration
+				out.Count--
 				continue
 			}
 
 			// Check against the status filters before continuing
 			if _, ok := filters[vasp.VerificationStatus]; len(filters) > 0 && !ok {
+				out.Count--
 				continue
 			}
 

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -87,9 +87,9 @@ type AutocompleteReply struct {
 // ListVASPsParams is a request-like struct that passes query params to the ListVASPs
 // GET request. All query params are optional and modify how and what data is retrieved.
 type ListVASPsParams struct {
-	Status   string `url:"status,omitempty" form:"status"`
-	Page     int    `url:"page,omitempty" form:"page" default:"1"`             // defaults to page 1 if not included
-	PageSize int    `url:"page_size,omitempty" form:"page_size" default:"100"` // defaults to 100 if not included
+	StatusFilters []string `url:"status_filters,omitempty" form:"status_filters"`
+	Page          int      `url:"page,omitempty" form:"page" default:"1"`             // defaults to page 1 if not included
+	PageSize      int      `url:"page_size,omitempty" form:"page_size" default:"100"` // defaults to 100 if not included
 }
 
 // ListVASPsReply contains a summary data structure of all VASPs managed by the directory.

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -87,7 +87,7 @@ type AutocompleteReply struct {
 // ListVASPsParams is a request-like struct that passes query params to the ListVASPs
 // GET request. All query params are optional and modify how and what data is retrieved.
 type ListVASPsParams struct {
-	StatusFilters []string `url:"status_filters,omitempty" form:"status_filters"`
+	StatusFilters []string `url:"status,omitempty" form:"status"`
 	Page          int      `url:"page,omitempty" form:"page" default:"1"`             // defaults to page 1 if not included
 	PageSize      int      `url:"page_size,omitempty" form:"page_size" default:"100"` // defaults to 100 if not included
 }

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -355,7 +355,7 @@ func TestListVASPs(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/v2/vasps", r.URL.Path)
-		require.Equal(t, "page=2&page_size=10&status_filters=pending_review&status_filters=verified", r.URL.RawQuery)
+		require.Equal(t, "page=2&page_size=10&status=pending_review&status=verified", r.URL.RawQuery)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -330,6 +330,15 @@ func TestListVASPs(t *testing.T) {
 				Traveler:           false,
 				VerifiedContacts:   map[string]bool{"billing": false, "technical": true},
 			},
+			{
+				ID:                 "5b180719-62c4-4674-ab2a-279ddb0e487a",
+				Name:               "Charlie VASP",
+				CommonName:         "trisa.charlie.co.uk",
+				VerificationStatus: "submitted",
+				LastUpdated:        "2021-09-21T22:02:39Z",
+				Traveler:           false,
+				VerifiedContacts:   map[string]bool{"administrative": false, "billing": true},
+			},
 		},
 		Page:     2,
 		PageSize: 10,
@@ -337,16 +346,16 @@ func TestListVASPs(t *testing.T) {
 	}
 
 	params := &admin.ListVASPsParams{
-		Status:   "pending_review",
-		Page:     2,
-		PageSize: 10,
+		StatusFilters: []string{"pending_review", "verified"},
+		Page:          2,
+		PageSize:      10,
 	}
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/v2/vasps", r.URL.Path)
-		require.Equal(t, "page=2&page_size=10&status=pending_review", r.URL.RawQuery)
+		require.Equal(t, "page=2&page_size=10&status_filters=pending_review&status_filters=verified", r.URL.RawQuery)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This allows multiple status filters to be passed into the `ListVASPs` endpoint in the GET params. The GET requests end up looking like this:

`/v2/vasps?status_filters=pending_review&status_filters=verified`

I also included the pagination bug fix here, since I was in the area anyway.