### PR TITLE
Implements trtl delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.4
 	github.com/golang-jwt/jwt/v4 v4.0.0
+	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.2.0
 	github.com/googleapis/gax-go v1.0.3


### PR DESCRIPTION
This PR implements trtl's Delete method, with some preliminary tests and an (untested) prototype CLI command. 

I've opened several follow on issues to deal with the honu issue we uncovered whilst working on this PR (doesn't currently handle namespaces) and the test fixtures (bypassing honu loading results in unexpected metadata).