### PR TITLE
sc-2167 authentication middleware test

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -130,11 +130,6 @@ func (s *Admin) Shutdown() (err error) {
 	return nil
 }
 
-// Routes returns the Admin API router for testing purposes.
-func (s *Admin) Routes() http.Handler {
-	return s.router
-}
-
 func (s *Admin) setupRoutes() (err error) {
 	// Application Middleware
 	s.router.Use(ginzerolog.Logger("gin"))
@@ -1490,4 +1485,9 @@ func (s *Admin) Available() gin.HandlerFunc {
 // GetTokenManager returns the underlying token manager for testing.
 func (s *Admin) GetTokenManager() *tokens.TokenManager {
 	return s.tokens
+}
+
+// Routes returns the Admin API router for testing purposes.
+func (s *Admin) Routes() http.Handler {
+	return s.router
 }

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -1487,7 +1487,7 @@ func (s *Admin) GetTokenManager() *tokens.TokenManager {
 	return s.tokens
 }
 
-// Routes returns the Admin API router for testing purposes.
-func (s *Admin) Routes() http.Handler {
+// GetRouter returns the Admin API router for testing purposes.
+func (s *Admin) GetRouter() http.Handler {
 	return s.router
 }

--- a/pkg/gds/mock.go
+++ b/pkg/gds/mock.go
@@ -46,6 +46,11 @@ func NewMock(conf config.Config) (s *Service, err error) {
 	if admin.tokens, err = tokens.MockTokenManager(); err != nil {
 		return nil, err
 	}
+	gin.SetMode(admin.conf.Mode)
+	admin.router = gin.New()
+	if err = admin.setupRoutes(); err != nil {
+		return nil, err
+	}
 	svc.admin = admin
 	return svc, nil
 }


### PR DESCRIPTION
This adds a table test to make sure that the admin API routes do not accept unauthenticated requests.