### PR TITLE
sc-2163 test case for successful Admin API authentication

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -247,7 +247,7 @@ func (s *Admin) Authenticate(c *gin.Context) {
 	}
 
 	// Validate the credential with Google
-	if claims, err = idtoken.Validate(c.Request.Context(), in.Credential, s.conf.Oauth.GoogleAudience); err != nil {
+	if claims, err = s.tokens.Validate(c.Request.Context(), in.Credential, s.conf.Oauth.GoogleAudience); err != nil {
 		log.Warn().Err(err).Msg("invalid credentials used for authentication")
 		c.JSON(http.StatusUnauthorized, admin.ErrorResponse("invalid credentials"))
 		return

--- a/pkg/gds/mock.go
+++ b/pkg/gds/mock.go
@@ -88,7 +88,7 @@ func MockConfig() config.Config {
 			CookieDomain: "admin.gds.dev",
 			Audience:     "http://api.admin.gds.dev",
 			Oauth: config.OauthConfig{
-				GoogleAudience:         "4284607864536-notarealgoogleaudience.apps.googleusercontent.com",
+				GoogleAudience:         "http://localhost",
 				AuthorizedEmailDomains: []string{"gds.dev"},
 			},
 			TokenKeys: nil,

--- a/pkg/gds/tokens/mock.go
+++ b/pkg/gds/tokens/mock.go
@@ -1,10 +1,14 @@
 package tokens
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
+	"errors"
 
 	"github.com/segmentio/ksuid"
+	"google.golang.org/api/idtoken"
 )
 
 // MockTokenManager creates a new TokenManager with a randomly generated RSA key to be
@@ -14,6 +18,7 @@ func MockTokenManager() (tm *TokenManager, err error) {
 		audience: "http://localhost",
 		keys:     make(map[ksuid.KSUID]*rsa.PublicKey),
 	}
+	tm.validate = tm.mockValidate
 
 	var key *rsa.PrivateKey
 	if key, err = rsa.GenerateKey(rand.Reader, 1024); err != nil {
@@ -24,4 +29,41 @@ func MockTokenManager() (tm *TokenManager, err error) {
 	tm.currentKey = key
 	tm.keys[tm.currentKeyID] = &key.PublicKey
 	return tm, nil
+}
+
+// mockValidate is a mock for Google's token validation which enables authentication
+// testing by internally parsing the given token and injecting the claims into the
+// returned payload. This will only validate badly constructed tokens and tokens where
+// the supplied audience does not match the audience used to sign the token.
+func (tm *TokenManager) mockValidate(ctx context.Context, idToken string, audience string) (payload *idtoken.Payload, err error) {
+	var claims *Claims
+	if claims, err = tm.Parse(idToken); err != nil {
+		return nil, err
+	}
+
+	if claims.Audience != audience {
+		return nil, errors.New("audience in token does not match given audience")
+	}
+
+	payload = &idtoken.Payload{
+		Issuer:   claims.Issuer,
+		Audience: claims.Audience,
+		Expires:  claims.ExpiresAt,
+		IssuedAt: claims.IssuedAt,
+		Subject:  claims.Subject,
+		Claims:   make(map[string]interface{}),
+	}
+
+	// Marshal the claims to JSON
+	var data []byte
+	if data, err = json.Marshal(claims); err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the claims back into the payload
+	if err = json.Unmarshal(data, &payload.Claims); err != nil {
+		return nil, err
+	}
+
+	return payload, nil
 }


### PR DESCRIPTION
This adds the missing test cases for successful authentication on the Admin API `Authenticate` endpoint. The Admin API handler uses Google's `idtoken.Validate()` and is expecting a Google token. I got around this by adding a `validate` function to the token manager which must be configured when a new `TokenManager` is instantiated. When we're running the tests, the mocked `TokenManager` will be used which uses a mocked validation function instead of the Google one. The mocked function simply parses the token and injects the claims into the returned payload, bypassing all the checks that the Google handler is doing. This allows us to test that we are handling authentication properly assuming that we were passed a valid credential.