### PR TITLE
sc-2187 GDS register test

### DIFF
--- a/pkg/gds/gds_test.go
+++ b/pkg/gds/gds_test.go
@@ -4,8 +4,106 @@ import (
 	"context"
 	"time"
 
+	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	api "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
+	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 )
+
+// TestRegister tests that the Register RPC correcty registers a new VASP with GDS.
+func (s *gdsTestSuite) TestRegister() {
+	s.LoadEmptyFixtures()
+	defer s.ResetEmptyFixtures()
+	require := s.Require()
+	ctx := context.Background()
+	refVASP := s.fixtures[vasps]["d9da630e-41aa-11ec-9d29-acde48001122"].(*pb.VASP)
+
+	// Start the gRPC client
+	require.NoError(s.grpc.Connect())
+	defer s.grpc.Close()
+	client := api.NewTRISADirectoryClient(s.grpc.Conn)
+
+	// Emails need to be filled in for a valid VASP registration. Need to make copies
+	// of the contacts here to avoid modifying the fixtures for other tests.
+	contacts := *refVASP.Contacts
+	admin := *refVASP.Contacts.Administrative
+	contacts.Administrative = &admin
+	contacts.Administrative.Email = "admin@example.com"
+	billing := *refVASP.Contacts.Billing
+	contacts.Billing = &billing
+	contacts.Billing.Email = "billing@example.com"
+	legal := *refVASP.Contacts.Legal
+	contacts.Legal = &legal
+	contacts.Legal.Email = "legal@example.com"
+	technical := *refVASP.Contacts.Technical
+	contacts.Technical = &technical
+	contacts.Technical.Email = "technical@example.com"
+
+	// Common name is not parseable from the endpoint
+	request := &api.RegisterRequest{
+		Entity:           refVASP.Entity,
+		Contacts:         &contacts,
+		Website:          refVASP.Website,
+		BusinessCategory: refVASP.BusinessCategory,
+		VaspCategories:   refVASP.VaspCategories,
+		EstablishedOn:    refVASP.EstablishedOn,
+		Trixo:            refVASP.Trixo,
+		TrisaEndpoint:    ":3000",
+	}
+	_, err := client.Register(ctx, request)
+	require.Error(err)
+	request.TrisaEndpoint = "trisatest.net"
+	_, err = client.Register(ctx, request)
+	require.Error(err)
+
+	// VASP request is incomplete
+	request.TrisaEndpoint = "trisatest.net:3000"
+	request.Entity = nil
+	_, err = client.Register(ctx, request)
+	require.Error(err)
+
+	// Successful VASP registration
+	request.Entity = refVASP.Entity
+	reply, err := client.Register(ctx, request)
+	require.NoError(err)
+	require.NotNil(reply)
+	require.NotEmpty(reply.Id)
+	require.Equal(s.svc.GetConf().DirectoryID, reply.RegisteredDirectory)
+	require.Equal("trisatest.net", reply.CommonName)
+	require.Equal(pb.VerificationState_SUBMITTED, reply.Status)
+	require.Contains(reply.Message, "verification code has been sent")
+	require.NotEmpty(reply.Pkcs12Password)
+	// VASP should be in the database
+	v, err := s.svc.GetStore().RetrieveVASP(reply.Id)
+	require.NoError(err)
+	require.Equal(reply.Id, v.Id)
+	require.Equal(pb.VerificationState_SUBMITTED, v.VerificationStatus)
+	// Emails should be sent to the contacts
+	emails, err := models.GetEmailLog(v.Contacts.Administrative)
+	require.NoError(err)
+	require.Len(emails, 1)
+	emails, err = models.GetEmailLog(v.Contacts.Billing)
+	require.NoError(err)
+	require.Len(emails, 1)
+	emails, err = models.GetEmailLog(v.Contacts.Legal)
+	require.NoError(err)
+	require.Len(emails, 1)
+	emails, err = models.GetEmailLog(v.Contacts.Technical)
+	require.NoError(err)
+	require.Len(emails, 1)
+	// Certificate request should be created
+	ids, err := models.GetCertReqIDs(v)
+	require.NoError(err)
+	require.Len(ids, 1)
+	certReq, err := s.svc.GetStore().RetrieveCertReq(ids[0])
+	require.NoError(err)
+	require.Equal(v.Id, certReq.Vasp)
+	require.Equal(v.CommonName, certReq.CommonName)
+	require.Equal(models.CertificateRequestState_INITIALIZED, certReq.Status)
+
+	// Should not be able to register an identical VASP
+	_, err = client.Register(ctx, request)
+	require.Error(err)
+}
 
 // TestStatus tests that the Status RPC returns the correct status response.
 func (s *gdsTestSuite) TestStatus() {

--- a/pkg/gds/mock.go
+++ b/pkg/gds/mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/trisacrypto/directory/pkg/gds/config"
 	"github.com/trisacrypto/directory/pkg/gds/emails"
+	"github.com/trisacrypto/directory/pkg/gds/secrets"
 	"github.com/trisacrypto/directory/pkg/gds/store"
 	"github.com/trisacrypto/directory/pkg/gds/tokens"
 	"github.com/trisacrypto/directory/pkg/utils/logger"
@@ -34,6 +35,9 @@ func NewMock(conf config.Config) (s *Service, err error) {
 		conf: conf,
 	}
 	if svc.email, err = emails.New(conf.Email); err != nil {
+		return nil, err
+	}
+	if svc.secret, err = secrets.NewMock(conf.Secrets); err != nil {
 		return nil, err
 	}
 	if svc.db, err = store.Open(conf.Database); err != nil {

--- a/pkg/gds/service_test.go
+++ b/pkg/gds/service_test.go
@@ -229,8 +229,6 @@ func (s *gdsTestSuite) CompareFixture(namespace, key string, obj interface{}, re
 			a.Contacts.Billing.Extra, b.Contacts.Billing.Extra = nil, nil
 		}
 
-		fmt.Println(a)
-		fmt.Println(b)
 		require.True(proto.Equal(a, b), "vasps are not the same")
 
 	case certreqs:


### PR DESCRIPTION
This adds a test for the GDS Register RPC. The test itself is pretty straightforward, but I did have to add the mocked secret manager to the mocked service to get the password code to work, and change up how we're starting/stopping the bufconn listener due to a bug I encountered.