### PR TITLE
Hotfix: Handle Sectigo COLLECTED batch detail status

### DIFF
--- a/cmd/sectigo/main.go
+++ b/cmd/sectigo/main.go
@@ -119,8 +119,12 @@ func main() {
 					Usage: "if specified get detail for batch with id",
 				},
 				cli.BoolFlag{
+					Name:  "I, info",
+					Usage: "get batch processing info",
+				},
+				cli.BoolFlag{
 					Name:  "s, status",
-					Usage: "get batch processing status",
+					Usage: "get batch processing status (text description)",
 				},
 			},
 		},
@@ -346,13 +350,23 @@ func batches(c *cli.Context) (err error) {
 	id := c.Int("id")
 	if id != 0 {
 		// Perform batch detail lookup
-		if c.Bool("status") {
+		if c.Bool("info") {
 			var rep *sectigo.ProcessingInfoResponse
 			if rep, err = api.ProcessingInfo(id); err != nil {
 				return cli.NewExitError(err, 1)
 			}
 
 			printJSON(rep)
+			return nil
+		}
+
+		// Perform text status lookup
+		if c.Bool("status") {
+			var status string
+			if status, err = api.BatchStatus(id); err != nil {
+				return cli.NewExitError(err, 1)
+			}
+			fmt.Println(status)
 			return nil
 		}
 

--- a/pkg/sectigo/mock/mock.go
+++ b/pkg/sectigo/mock/mock.go
@@ -123,6 +123,7 @@ func (s *Server) setupHandlers() {
 	s.handle(sectigo.CreateSingleCertBatchEP, http.MethodPut, s.createSingleCertBatch)
 	s.handle(sectigo.UploadCSREP, http.MethodPost, s.uploadCSR)
 	s.handle(sectigo.BatchDetailEP, http.MethodGet, s.batchDetail)
+	s.handle(sectigo.BatchStatusEP, http.MethodGet, s.batchStatus)
 	s.handle(sectigo.BatchProcessingInfoEP, http.MethodGet, s.batchProcessingInfo)
 	s.handle(sectigo.DownloadEP, http.MethodGet, s.download)
 	s.handle(sectigo.DevicesEP, http.MethodGet, s.devices)
@@ -262,6 +263,17 @@ func (s *Server) batchDetail(c *gin.Context) {
 		Status:       "completed",
 		Active:       false,
 	})
+}
+
+func (s *Server) batchStatus(c *gin.Context) {
+	s.calls[sectigo.BatchStatusEP]++
+	id := c.Param("param0")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, "missing batch id")
+		return
+	}
+
+	c.String(http.StatusOK, "Ready for download")
 }
 
 func (s *Server) batchProcessingInfo(c *gin.Context) {

--- a/pkg/sectigo/sectigo_test.go
+++ b/pkg/sectigo/sectigo_test.go
@@ -71,6 +71,7 @@ func (s *SectigoTestSuite) TestSuccessfulCalls() {
 		{name: CreateSingleCertBatchEP, f: s.createSingleCertBatch},
 		{name: UploadCSREP, f: s.uploadCSRBatch},
 		{name: BatchDetailEP, f: s.batchDetail},
+		{name: BatchStatusEP, f: s.batchStatus},
 		{name: BatchProcessingInfoEP, f: s.processingInfo},
 		{name: DownloadEP, f: s.download},
 		{name: DevicesEP, f: s.licensesUsed},
@@ -118,6 +119,13 @@ func (s *SectigoTestSuite) batchDetail(t *testing.T) {
 	rep, err := s.api.BatchDetail(42)
 	require.NoError(t, err)
 	require.NotNil(t, rep)
+}
+
+func (s *SectigoTestSuite) batchStatus(t *testing.T) {
+	rep, err := s.api.BatchStatus(42)
+	require.NoError(t, err)
+	require.NotEmpty(t, rep)
+	require.Equal(t, "READY_FOR_DOWNLOAD", rep)
 }
 
 func (s *SectigoTestSuite) processingInfo(t *testing.T) {

--- a/pkg/sectigo/serializers.go
+++ b/pkg/sectigo/serializers.go
@@ -12,6 +12,7 @@ const (
 	BatchStatusProcessing       = "PROCESSING"
 	BatchStatusNotAcceptable    = "NOT_ACCEPTABLE"
 	BatchStatusReadyForDownload = "READY_FOR_DOWNLOAD"
+	BatchStatusCollected        = "COLLECTED"
 )
 
 // AuthenticationRequest to POST data to the authenticateEP


### PR DESCRIPTION
This PR implements the batch status Sectigo API endpoint. If the batch
detail for a certificate request comes back with an unknown status then
the certificate manager attempts to lookup the batch status directly.
Logging for this error is improved.

Fixes SC-2353