### PR TITLE
sc-2354 add contact email to audit log on GDS RPCs

### DIFF
--- a/pkg/gds/gds.go
+++ b/pkg/gds/gds.go
@@ -139,7 +139,7 @@ func (s *GDS) Register(ctx context.Context, in *api.RegisterRequest) (out *api.R
 	// Retrieve email address from one of the supplied contacts.
 	var email string
 	if email = getContactEmail(vasp); email == "" {
-		log.Warn().Msg("no contact email address found")
+		log.Error().Err(errors.New("no contact email address found")).Msg("incorrect access on validated VASP")
 		return nil, status.Error(codes.InvalidArgument, "no email address in supplied VASP contacts")
 	}
 


### PR DESCRIPTION
This makes some changes to the GDS RPCs to add the contact email as the "source" for the audit logs. Also, new audit log entries are created for verified contacts.