### PR TITLE
feat: certificate details issuer and subject accordions

### DIFF
--- a/web/gds-admin-ui/src/__tests__/certificate-details.js
+++ b/web/gds-admin-ui/src/__tests__/certificate-details.js
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import CertificateDetails, { IdentityCertificateDropDown } from "pages/app/details/CertificateDetails"
+import CertificateDetails from "pages/app/details/CertificateDetails"
 
 
 describe('CertificateDetails', () => {

--- a/web/gds-admin-ui/src/assets/scss/app-creative.scss
+++ b/web/gds-admin-ui/src/assets/scss/app-creative.scss
@@ -107,3 +107,12 @@ a[disabled] {
 .cursor-pointer{
     cursor: pointer;
 }
+
+.accordion-flush .accordion-item .accordion-button{
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+}
+
+.accordion-flush .accordion-item .accordion-button[aria-expanded=false]{
+    border-radius: 5px;
+}

--- a/web/gds-admin-ui/src/pages/app/details/CertificateDetails.js
+++ b/web/gds-admin-ui/src/pages/app/details/CertificateDetails.js
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import FileInformationCard from 'components/FileInformationCard';
 import PropTypes from 'prop-types'

--- a/web/gds-admin-ui/src/pages/app/details/CertificateDetails/Detail.js
+++ b/web/gds-admin-ui/src/pages/app/details/CertificateDetails/Detail.js
@@ -1,0 +1,61 @@
+
+import React from 'react'
+import countryCodeEmoji, { getCountryName } from 'utils/country'
+
+function Detail({ data, title }) {
+    const formatToReadableString = (data) => {
+        if (Array.isArray(data)) {
+            return !data.length ? 'N/A' : data.toString().split(',').join(', ')
+        }
+    }
+
+    return (
+        <>
+            <p className='m-0'><span className='fw-bold'>Common name:</span> {data?.common_name}</p>
+            <p className='m-0'>
+                <span className='fw-bold'>Country: </span>
+                {
+                    formatToReadableString(data?.country.map(c => `${countryCodeEmoji(c)} ${getCountryName(c)}`))
+                }
+            </p>
+            <p className='m-0'>
+                <span className='fw-bold'>Locality: </span>
+                {
+                    formatToReadableString(data?.locality)
+                }
+            </p>
+            <p className='m-0'>
+                <span className='fw-bold'>Organisation: </span>
+                {
+                    formatToReadableString(data?.organization)
+                }
+            </p>
+            <p className='m-0'>
+                <span className='fw-bold'>Organisational unit: </span>
+                {
+                    formatToReadableString(data?.organizational_unit)
+                }
+            </p>
+            <p className='m-0'>
+                <span className='fw-bold'>Postal code: </span>
+                {
+                    formatToReadableString(data?.postal_code)
+                }
+            </p>
+            <p className='m-0'>
+                <span className='fw-bold'>Province: </span>
+                {
+                    formatToReadableString(data?.province)
+                }
+            </p>
+            <p className='m-0'>
+                <span className='fw-bold'>Serial number: </span>{data?.serial_number ? data?.serial_number : 'N/A'}
+            </p>
+            <p className='m-0'>
+                <span className='fw-bold'>Street address: </span>{data?.serial_number ? data?.serial_number : 'N/A'}
+            </p>
+        </>
+    )
+}
+
+export default Detail

--- a/web/gds-admin-ui/src/pages/app/details/CertificateDetails/Details.js
+++ b/web/gds-admin-ui/src/pages/app/details/CertificateDetails/Details.js
@@ -1,0 +1,33 @@
+
+import React from 'react'
+import { Accordion } from 'react-bootstrap'
+import Detail from './Detail'
+
+function Details({ data }) {
+    return (
+        <Accordion flush>
+            <Accordion.Item eventKey="0" className='border rounded-2 mb-1'>
+                <Accordion.Header className='m-0 p-0 outline-none'>
+                    <h5 className="text-muted font-weight-bold m-0">
+                        Issuer details
+                    </h5>
+                </Accordion.Header>
+                <Accordion.Body style={{ marginBottom: 10, lineHeight: 1.75 }}>
+                    <Detail data={data.issuer} />
+                </Accordion.Body>
+            </Accordion.Item>
+            <Accordion.Item eventKey="1" className='border rounded-2 mb-1'>
+                <Accordion.Header className='m-0 p-0 outline-none'>
+                    <h5 className="text-muted font-weight-bold m-0">
+                        Subject details
+                    </h5>
+                </Accordion.Header>
+                <Accordion.Body style={{ marginBottom: 10, lineHeight: 1.75 }}>
+                    <Detail data={data.subject} />
+                </Accordion.Body>
+            </Accordion.Item>
+        </Accordion>
+    )
+}
+
+export default Details

--- a/web/gds-admin-ui/src/pages/app/details/CertificateDetails/index.js
+++ b/web/gds-admin-ui/src/pages/app/details/CertificateDetails/index.js
@@ -6,10 +6,11 @@ import { copyToClipboard, formatDisplayedData } from 'utils';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { downloadFile } from 'helpers/api/utils';
+import Details from './Details';
 dayjs.extend(relativeTime)
 
 
-export const IdentityCertificateDropDown = ({ handleCopySignatureClick, handleCopySerialNumberClick, handleViewDetailsClick }) => {
+export const IdentityCertificateDropDown = ({ handleCopySignatureClick, handleCopySerialNumberClick }) => {
 
     return (
         <Dropdown className="float-end" align="end">
@@ -26,9 +27,6 @@ export const IdentityCertificateDropDown = ({ handleCopySignatureClick, handleCo
                 </Dropdown.Item>
                 <Dropdown.Item data-testid="copy-serial-number" onClick={handleCopySerialNumberClick}>
                     <i className="mdi mdi-content-copy me-1"></i>Copy serial number
-                </Dropdown.Item>
-                <Dropdown.Item onClick={handleViewDetailsClick}>
-                    <i className="mdi mdi-information-outline me-1"></i>View details
                 </Dropdown.Item>
             </Dropdown.Menu>
         </Dropdown>
@@ -133,9 +131,12 @@ function CertificateDetails({ data }) {
                         <p className='mb-1'><span className='fw-bold'>Subject: </span>{data?.subject?.common_name}</p>
 
                         <Row>
-                            <Col>
+                            <Col sm={12}>
                                 <FileInformationCard file={data?.data} name="Public Identity Key" ext=".PEM" onDownload={() => handlePublicIdentityKeyDownloadClick(data?.data)} />
                                 <FileInformationCard file={data?.chain} name="TRISA Trust Chain (CA)" ext=".GZ" onDownload={() => handleTrustChainDownloadClick(data?.chain)} />
+                            </Col>
+                            <Col>
+                                <Details data={data} />
                             </Col>
                         </Row>
                     </Card.Body>


### PR DESCRIPTION
I preferred to use the accordion because for me it’s easier for the user experience
<img width="916" alt="Screen Shot 2021-12-09 at 15 36 23" src="https://user-images.githubusercontent.com/54010836/145426786-3152601e-ab12-4706-beba-45746df0e385.png">
<img width="916" alt="Screen Shot 2021-12-09 at 15 36 55" src="https://user-images.githubusercontent.com/54010836/145426882-e5067f8d-7c07-4840-85d0-d2694f69d699.png">

