### PR TITLE
Trtl maintenance mode sc-2047

### DIFF
--- a/pkg/trtl/config/config.go
+++ b/pkg/trtl/config/config.go
@@ -10,6 +10,9 @@ import (
 	"github.com/trisacrypto/directory/pkg/utils/logger"
 )
 
+// Config defines the struct that is expected to initialize the trtl server
+// Note: because we need to validate the configuration, `config.New()`
+// must be called to ensure that the `processed` is correctly set
 type Config struct {
 	Maintenance bool                `split_words:"true" default:"false"`
 	BindAddr    string              `split_words:"true" default:":4435"`

--- a/pkg/trtl/interceptor.go
+++ b/pkg/trtl/interceptor.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
+	status "google.golang.org/grpc/status"
 )
 
 type ContextKey string
@@ -28,6 +30,12 @@ type PeerInfo struct {
 func (t *Server) interceptor(ctx context.Context, in interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
 	// Track how long the method takes to execute.
 	start := time.Now()
+
+	// Check if we're in maintenance mode
+	// TODO: update to consider the Status endpoint once that has been added
+	if t.conf.Maintenance {
+		return nil, status.Error(codes.Unavailable, "the trtl service is currently in maintenance mode")
+	}
 
 	// Fetch peer information from the TLS info.
 	var peer *PeerInfo

--- a/pkg/trtl/interceptor.go
+++ b/pkg/trtl/interceptor.go
@@ -32,7 +32,7 @@ func (t *Server) interceptor(ctx context.Context, in interface{}, info *grpc.Una
 	start := time.Now()
 
 	// Check if we're in maintenance mode
-	// TODO: update to consider the Status endpoint once that has been added
+	// TODO: update to consider the Status endpoint, once it has been added
 	if t.conf.Maintenance {
 		return nil, status.Error(codes.Unavailable, "the trtl service is currently in maintenance mode")
 	}

--- a/pkg/trtl/trtl.go
+++ b/pkg/trtl/trtl.go
@@ -162,3 +162,12 @@ func (t *Server) Shutdown() (err error) {
 	log.Debug().Msg("successful shutdown of trtl server")
 	return nil
 }
+
+//===========================================================================
+// Accessors - used primarily for testing
+//===========================================================================
+
+// GetDB returns the underlying Honu database used by all sub-services.
+func (t *Server) GetDB() *honu.DB {
+	return t.db
+}

--- a/pkg/trtl/trtl.go
+++ b/pkg/trtl/trtl.go
@@ -63,13 +63,22 @@ func New(conf config.Config) (s *Server, err error) {
 	s = &Server{
 		conf:  conf,
 		echan: make(chan error, 1),
-		srv:   grpc.NewServer(grpc.UnaryInterceptor(s.interceptor)),
 	}
 
-	// Everything that follows this comment assumes we're not in maintenance mode
-	// Open a connection to the Honu wrapped database
-	if s.db, err = honu.Open(conf.Database.URL, conf.GetHonuConfig()); err != nil {
-		return nil, fmt.Errorf("honu error: %v", err)
+	// NOTE: It appears this must happen outside the struct initialization of the Server
+	// or else the UnaryInterceptor doesn't capture conf when it when it creates the closure
+	s.srv = grpc.NewServer(grpc.UnaryInterceptor(s.interceptor))
+
+	// NOTE: if we are *not* in maintenance mode, we must open the database before we
+	// initialize the Honu and Peer mgmt services, else we'll get panics on nil dbs
+	// This is not the case for maintenance mode; which can proceed by initializing the
+	// the services, allowing them to respond "unavailable", but which will prevent the
+	// dbs in question from being engaged.
+	if !s.conf.Maintenance {
+		// Open a connection to the Honu wrapped database
+		if s.db, err = honu.Open(conf.Database.URL, conf.GetHonuConfig()); err != nil {
+			return nil, fmt.Errorf("honu error: %v", err)
+		}
 	}
 
 	// Initialize the Honu service
@@ -131,6 +140,7 @@ func (t *Server) Serve() (err error) {
 // be run in its own go routine and to allow tests to Run a bufconn server without
 // starting a live server with all of the various go routines and channels running.
 func (t *Server) Run(sock net.Listener) {
+
 	defer sock.Close()
 	if err := t.srv.Serve(sock); err != nil {
 		t.echan <- err

--- a/pkg/trtl/trtl.go
+++ b/pkg/trtl/trtl.go
@@ -66,14 +66,6 @@ func New(conf config.Config) (s *Server, err error) {
 		srv:   grpc.NewServer(grpc.UnaryInterceptor(s.interceptor)),
 	}
 
-	// TODO: check for maintenance mode
-
-	// Everything that follows this comment assumes we're not in maintenance mode
-	// Open a connection to the Honu wrapped database
-	if s.db, err = honu.Open(conf.Database.URL, conf.GetHonuConfig()); err != nil {
-		return nil, fmt.Errorf("honu error: %v", err)
-	}
-
 	// Initialize the Honu service
 	if s.honu, err = NewHonuService(s); err != nil {
 		return nil, err
@@ -87,6 +79,17 @@ func New(conf config.Config) (s *Server, err error) {
 	peers.RegisterPeerManagementServer(s.srv, s.peers)
 
 	// TODO: initialize the Replica service
+
+	// Stop configuration at this point for maintenance mode (no error)
+	if s.conf.Maintenance {
+		return s, nil
+	}
+
+	// Everything that follows this comment assumes we're not in maintenance mode
+	// Open a connection to the Honu wrapped database
+	if s.db, err = honu.Open(conf.Database.URL, conf.GetHonuConfig()); err != nil {
+		return nil, fmt.Errorf("honu error: %v", err)
+	}
 
 	return s, nil
 }

--- a/pkg/trtl/trtl_test.go
+++ b/pkg/trtl/trtl_test.go
@@ -150,6 +150,8 @@ func (s *trtlTestSuite) SetupSuite() {
 	os.Setenv("TRTL_DATABASE_URL", "leveldb:///"+s.db)
 	os.Setenv("TRTL_REPLICA_PID", fmt.Sprint(metaPID))
 	os.Setenv("TRTL_REPLICA_REGION", metaRegion)
+	os.Setenv("TRTL_MAINTENANCE", "false")
+
 	s.conf, err = config.New()
 	require.NoError(err)
 

--- a/pkg/trtl/trtl_test.go
+++ b/pkg/trtl/trtl_test.go
@@ -169,6 +169,7 @@ func (s *trtlTestSuite) SetupSuite() {
 
 func (s *trtlTestSuite) TearDownSuite() {
 	require := s.Require()
+	require.NoError(s.trtl.GetDB().Close())
 	err := os.RemoveAll(s.db)
 	require.NoError(err)
 	s.grpc.Release()
@@ -181,14 +182,13 @@ func TestTrtl(t *testing.T) {
 func (s *trtlTestSuite) TestMaintenance() {
 	require := s.Require()
 
-	var conf config.Config
+	conf, _ := config.New()
 	conf.Maintenance = true
 	conf.Database.URL = "test"
 	conf.Replica.Region = "tauceti"
 
-	var server *trtl.Server
 	server, err := trtl.New(conf)
-	require.Nil(server)
-	require.Error(err)
-	require.Equal(err.Error(), "honu error: resource temporarily unavailable")
+	require.NotEmpty(server, "no maintenance mode server was returned")
+	require.NoError(err, "starting the server in maintenance mode caused an error")
+	require.Nil(server.GetDB(), "maintenance mode database was not nil")
 }

--- a/pkg/trtl/trtl_test.go
+++ b/pkg/trtl/trtl_test.go
@@ -177,3 +177,18 @@ func (s *trtlTestSuite) TearDownSuite() {
 func TestTrtl(t *testing.T) {
 	suite.Run(t, new(trtlTestSuite))
 }
+
+func (s *trtlTestSuite) TestMaintenance() {
+	require := s.Require()
+
+	var conf config.Config
+	conf.Maintenance = true
+	conf.Database.URL = "test"
+	conf.Replica.Region = "tauceti"
+
+	var server *trtl.Server
+	server, err := trtl.New(conf)
+	require.Nil(server)
+	require.Error(err)
+	require.Equal(err.Error(), "honu error: resource temporarily unavailable")
+}


### PR DESCRIPTION
This PR introduces a maintenance mode for trtl that is similar to the maintenance mode we have for GDS; it allows the underlying trtl database to be accessible outside the context of normal operations (e.g. migrations, repairs, etc). 

One observation is that we may want to create another story for introducing a `Status` endpoint for trtl, since that is not currently defined in the protos; this is probably related to the work we'll do in sc-952.

