### PR TITLE
sc-1343 verify emails sent in tests

### DIFF
--- a/pkg/gds/admin_test.go
+++ b/pkg/gds/admin_test.go
@@ -972,16 +972,6 @@ func (s *gdsTestSuite) TestResend() {
 	require.Equal(http.StatusOK, rep.StatusCode)
 	require.Equal(1, actual.Sent)
 	require.Contains(actual.Message, "contact verification emails resent")
-	// Email audit log should be updated
-	v, err := s.svc.GetStore().RetrieveVASP(vaspErrored)
-	require.NoError(err)
-	emails, err := models.GetEmailLog(v.Contacts.Billing)
-	require.NoError(err)
-	require.Len(emails, 1)
-	ts, err := time.Parse(time.RFC3339, emails[0].Timestamp)
-	require.NoError(err)
-	require.True(ts.Sub(sent) < time.Minute)
-	require.Equal("verify_contact", emails[0].Reason)
 
 	// ResendReview email
 	request.in = &admin.ResendRequest{
@@ -1016,23 +1006,45 @@ func (s *gdsTestSuite) TestResend() {
 	require.Equal(http.StatusOK, rep.StatusCode)
 	require.Equal(2, actual.Sent)
 	require.Contains(actual.Message, "rejection emails resent")
-	// Email audit logs should be updated
-	v, err = s.svc.GetStore().RetrieveVASP(vaspRejected)
+
+	// Verify that all emails were sent
+	errored, err := s.svc.GetStore().RetrieveVASP(vaspErrored)
 	require.NoError(err)
-	emails, err = models.GetEmailLog(v.Contacts.Administrative)
+	rejected, err := s.svc.GetStore().RetrieveVASP(vaspRejected)
 	require.NoError(err)
-	require.Len(emails, 1)
-	ts, err = time.Parse(time.RFC3339, emails[0].Timestamp)
-	require.NoError(err)
-	require.True(ts.Sub(sent) < time.Minute)
-	require.Equal("rejection", emails[0].Reason)
-	emails, err = models.GetEmailLog(v.Contacts.Legal)
-	require.NoError(err)
-	require.Len(emails, 1)
-	ts, err = time.Parse(time.RFC3339, emails[0].Timestamp)
-	require.NoError(err)
-	require.True(ts.Sub(sent) < time.Minute)
-	require.Equal("rejection", emails[0].Reason)
+	messages := []*emailMeta{
+		{
+			contact:   errored.Contacts.Billing,
+			to:        errored.Contacts.Billing.Email,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.VerifyContactRE,
+			reason:    "verify_contact",
+			timestamp: sent,
+		},
+		{
+			to:        s.svc.GetConf().Email.AdminEmail,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.ReviewRequestRE,
+			timestamp: sent,
+		},
+		{
+			contact:   rejected.Contacts.Administrative,
+			to:        rejected.Contacts.Administrative.Email,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.RejectRegistrationRE,
+			reason:    "rejection",
+			timestamp: sent,
+		},
+		{
+			contact:   rejected.Contacts.Legal,
+			to:        rejected.Contacts.Legal.Email,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.RejectRegistrationRE,
+			reason:    "rejection",
+			timestamp: sent,
+		},
+	}
+	s.CheckEmails(messages)
 }
 
 // Test the ReviewTimeline endpoint.

--- a/pkg/gds/emails/mock.go
+++ b/pkg/gds/emails/mock.go
@@ -169,3 +169,13 @@ func (c *mockSendGridClient) Send(msg *sgmail.SGMailV3) (rep *rest.Response, err
 
 	return &rest.Response{StatusCode: http.StatusOK}, nil
 }
+
+func GetRecipient(msg *sgmail.SGMailV3) (recipient string, err error) {
+	for _, p := range msg.Personalizations {
+		for _, t := range p.To {
+			recipient = t.Address
+			return recipient, nil
+		}
+	}
+	return "", errors.New("no recipient found for email")
+}

--- a/pkg/gds/gds_test.go
+++ b/pkg/gds/gds_test.go
@@ -67,6 +67,7 @@ func (s *gdsTestSuite) TestRegister() {
 
 	// Successful VASP registration
 	request.Entity = refVASP.Entity
+	sent := time.Now()
 	reply, err := client.Register(ctx, request)
 	require.NoError(err)
 	require.NotNil(reply)
@@ -81,19 +82,6 @@ func (s *gdsTestSuite) TestRegister() {
 	require.NoError(err)
 	require.Equal(reply.Id, v.Id)
 	require.Equal(pb.VerificationState_SUBMITTED, v.VerificationStatus)
-	// Emails should be sent to the contacts
-	emails, err := models.GetEmailLog(v.Contacts.Administrative)
-	require.NoError(err)
-	require.Len(emails, 1)
-	emails, err = models.GetEmailLog(v.Contacts.Billing)
-	require.NoError(err)
-	require.Len(emails, 1)
-	emails, err = models.GetEmailLog(v.Contacts.Legal)
-	require.NoError(err)
-	require.Len(emails, 1)
-	emails, err = models.GetEmailLog(v.Contacts.Technical)
-	require.NoError(err)
-	require.Len(emails, 1)
 	// Certificate request should be created
 	ids, err := models.GetCertReqIDs(v)
 	require.NoError(err)
@@ -113,6 +101,43 @@ func (s *gdsTestSuite) TestRegister() {
 	// Should not be able to register an identical VASP
 	_, err = client.Register(ctx, request)
 	require.Error(err)
+
+	// Emails should be sent to the contacts
+	messages := []*emailMeta{
+		{
+			contact:   v.Contacts.Administrative,
+			to:        v.Contacts.Administrative.Email,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.VerifyContactRE,
+			reason:    "verify_contact",
+			timestamp: sent,
+		},
+		{
+			contact:   v.Contacts.Billing,
+			to:        v.Contacts.Billing.Email,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.VerifyContactRE,
+			reason:    "verify_contact",
+			timestamp: sent,
+		},
+		{
+			contact:   v.Contacts.Legal,
+			to:        v.Contacts.Legal.Email,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.VerifyContactRE,
+			reason:    "verify_contact",
+			timestamp: sent,
+		},
+		{
+			contact:   v.Contacts.Technical,
+			to:        v.Contacts.Technical.Email,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.VerifyContactRE,
+			reason:    "verify_contact",
+			timestamp: sent,
+		},
+	}
+	s.CheckEmails(messages)
 }
 
 // TestLookup test that the Lookup RPC correctly returns details for a VASP.
@@ -302,6 +327,7 @@ func (s *gdsTestSuite) TestVerifyContact() {
 
 	// Successful verification
 	request.Token = ""
+	sent := time.Now()
 	reply, err := client.VerifyContact(ctx, request)
 	require.NoError(err)
 	require.Nil(reply.Error)
@@ -316,9 +342,6 @@ func (s *gdsTestSuite) TestVerifyContact() {
 	require.NoError(err)
 	require.NotEmpty(token)
 
-	// Email should be sent to the admins
-	require.Len(emails.MockEmails, 1)
-
 	// Audit log should contain new entries for contact verifications, EMAIL_VERIFIED,
 	// PENDING_REVIEW, along with the intitial SUBMITTED.
 	log, err := models.GetAuditLog(vasp)
@@ -332,6 +355,17 @@ func (s *gdsTestSuite) TestVerifyContact() {
 	require.Equal(vasp.Contacts.Administrative.Email, log[2].Source)
 	require.Equal(pb.VerificationState_EMAIL_VERIFIED, log[5].CurrentState)
 	require.Equal(pb.VerificationState_PENDING_REVIEW, log[6].CurrentState)
+
+	// Email should be sent to the admins
+	messages := []*emailMeta{
+		{
+			to:        s.svc.GetConf().Email.AdminEmail,
+			from:      s.svc.GetConf().Email.ServiceEmail,
+			subject:   emails.ReviewRequestRE,
+			timestamp: sent,
+		},
+	}
+	s.CheckEmails(messages)
 }
 
 // TestVerification tests that the Verification RPC returns the correct status


### PR DESCRIPTION
This adds an assert helper which hopefully makes it easier to verify which emails are sent in the tests, by checking against both the audit log and the email mock.