### PR TITLE
sc-2346 CSV load test

### DIFF
--- a/pkg/gds/store/load_test.go
+++ b/pkg/gds/store/load_test.go
@@ -1,0 +1,72 @@
+package store_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/store"
+	"github.com/trisacrypto/directory/pkg/gds/store/mockdb"
+)
+
+// Test that the Load functions fails to load improperly formatted files.
+func TestLoadInvalid(t *testing.T) {
+	db := mockdb.GetStore()
+
+	// Invalid path
+	require.Error(t, store.Load(db, filepath.Join("testdata", "invalid", "invalid.csv")))
+
+	// Invalid CSV file
+	require.Error(t, store.Load(db, filepath.Join("testdata", "bad_format.csv")))
+
+	// Invalid country code
+	require.Error(t, store.Load(db, filepath.Join("testdata", "invalid_country.csv")))
+
+	// Invalid url
+	require.Error(t, store.Load(db, filepath.Join("testdata", "invalid_url.csv")))
+
+	// No records, should not error
+	require.NoError(t, store.Load(db, filepath.Join("testdata", "empty.csv")))
+
+	// No store calls
+	require.False(t, mockdb.GetState().CreateVASPInvoked, "CreateVASP should not have been invoked")
+	require.False(t, mockdb.GetState().RetrieveVASPInvoked, "RetrieveVASP should not have been invoked")
+}
+
+// Test that the Load function correctly loads VASPs from a valid CSV file.
+func TestLoad(t *testing.T) {
+	db := mockdb.GetStore()
+
+	// Load a valid CSV file
+	require.Nil(t, store.Load(db, filepath.Join("testdata", "vasps.csv")))
+	state := mockdb.GetState()
+	require.True(t, state.CreateVASPInvoked, "CreateVASP should have been invoked")
+	require.True(t, state.RetrieveVASPInvoked, "RetrieveVASP should have been invoked")
+
+	// Should be new VASPs in the store
+	// Echo Funds should be skipped because there is no url provided
+	require.Len(t, state.VASPs, 2)
+	require.Len(t, state.Keys, 2)
+
+	// Check that the VASPs were correctly loaded into the store
+	charlieVASP, err := db.RetrieveVASP(state.Keys[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, charlieVASP.Id)
+	require.Equal(t, "CharlieBank", charlieVASP.Entity.Name.NameIdentifiers[0].LegalPersonName)
+	require.Equal(t, "2140 Carson Mission Apt. 731", charlieVASP.Entity.GeographicAddresses[0].AddressLine[0])
+	require.Equal(t, "https://trisa.charliebank.io", charlieVASP.Website)
+	require.Equal(t, "CA", charlieVASP.Entity.CountryOfRegistration)
+	require.Equal(t, "CA", charlieVASP.Entity.GeographicAddresses[0].Country)
+	require.Equal(t, "trisa.charliebank.io", charlieVASP.CommonName)
+
+	deltaVASP, err := db.RetrieveVASP(state.Keys[1])
+	require.NoError(t, err)
+	require.NotEmpty(t, deltaVASP.Id)
+	require.NotEqual(t, charlieVASP.Id, deltaVASP.Id, "VASP IDs should be unique")
+	require.Equal(t, "Delta Assets", deltaVASP.Entity.Name.NameIdentifiers[0].LegalPersonName)
+	require.Equal(t, "0806 Neal Coves Suite 610", deltaVASP.Entity.GeographicAddresses[0].AddressLine[0])
+	require.Equal(t, "http://trisa.delta.io", deltaVASP.Website)
+	require.Equal(t, "XX", deltaVASP.Entity.CountryOfRegistration)
+	require.Equal(t, "XX", deltaVASP.Entity.GeographicAddresses[0].Country)
+	require.Equal(t, "trisa.delta.io", deltaVASP.CommonName)
+}

--- a/pkg/gds/store/load_test.go
+++ b/pkg/gds/store/load_test.go
@@ -36,6 +36,7 @@ func TestLoadInvalid(t *testing.T) {
 // Test that the Load function correctly loads VASPs from a valid CSV file.
 func TestLoad(t *testing.T) {
 	db := mockdb.GetStore()
+	defer mockdb.ResetState()
 
 	// Load a valid CSV file
 	require.Nil(t, store.Load(db, filepath.Join("testdata", "vasps.csv")))

--- a/pkg/gds/store/mockdb/mockdb.go
+++ b/pkg/gds/store/mockdb/mockdb.go
@@ -1,125 +1,159 @@
 package mockdb
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	"github.com/trisacrypto/directory/pkg/gds/store"
 	"github.com/trisacrypto/directory/pkg/gds/store/iterator"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 )
 
-var _ store.Store = &MockDB{}
+var db store.Store = &MockDB{}
+var state = &MockState{
+	VASPs: make(map[string]pb.VASP),
+	Keys:  []string{},
+}
+
+// MockState contains the current state of the MockDB for test verification.
+type MockState struct {
+	// in-memory database store
+	VASPs map[string]pb.VASP
+	Keys  []string
+
+	// keep track of store interface calls
+	CloseInvoked           bool
+	CreateVASPInvoked      bool
+	RetrieveVASPInvoked    bool
+	UpdateVASPInvoked      bool
+	DeleteVASPInvoked      bool
+	ListVASPsInvoked       bool
+	SearchVASPsInvoked     bool
+	ListCertReqsInvoked    bool
+	CreateCertReqInvoked   bool
+	RetrieveCertReqInvoked bool
+	UpdateCertReqInvoked   bool
+	DeleteCertReqInvoked   bool
+	ReindexInvoked         bool
+	BackupInvoked          bool
+}
+
+func GetState() *MockState {
+	return state
+}
+
+func ResetState() {
+	state = &MockState{
+		VASPs: make(map[string]pb.VASP),
+		Keys:  []string{},
+	}
+}
 
 // MockDB fulfills the store interface for testing.
 type MockDB struct {
-	OnClose      func() error
-	CloseInvoked bool
-
+	OnClose           func() error
 	OnCreateVASP      func(v *pb.VASP) (string, error)
-	CreateVASPInvoked bool
-
-	OnRetrieveVASP      func(id string) (*pb.VASP, error)
-	RetrieveVASPInvoked bool
-
+	OnRetrieveVASP    func(id string) (*pb.VASP, error)
 	OnUpdateVASP      func(v *pb.VASP) error
-	UpdateVASPInvoked bool
-
 	OnDeleteVASP      func(id string) error
-	DeleteVASPInvoked bool
+	OnListVASPs       func() iterator.DirectoryIterator
+	OnSearchVASPs     func(query map[string]interface{}) ([]*pb.VASP, error)
+	OnListCertReqs    func() iterator.CertificateIterator
+	OnCreateCertReq   func(r *models.CertificateRequest) (string, error)
+	OnRetrieveCertReq func(id string) (*models.CertificateRequest, error)
+	OnUpdateCertReq   func(r *models.CertificateRequest) error
+	OnDeleteCertReq   func(id string) error
+	OnReindex         func() error
+	OnBackup          func(string) error
+}
 
-	OnListVASPs      func() iterator.DirectoryIterator
-	ListVASPsInvoked bool
-
-	OnSearchVASPs      func(query map[string]interface{}) ([]*pb.VASP, error)
-	SearchVASPsInvoked bool
-
-	OnListCertReqs      func() iterator.CertificateIterator
-	ListCertReqsInvoked bool
-
-	OnCreateCertReq      func(r *models.CertificateRequest) (string, error)
-	CreateCertReqInvoked bool
-
-	OnRetrieveCertReq      func(id string) (*models.CertificateRequest, error)
-	RetrieveCertReqInvoked bool
-
-	OnUpdateCertReq      func(r *models.CertificateRequest) error
-	UpdateCertReqInvoked bool
-
-	OnDeleteCertReq      func(id string) error
-	DeleteCertReqInvoked bool
-
-	OnReindex      func() error
-	ReindexInvoked bool
-
-	OnBackup      func(string) error
-	BackupInvoked bool
+func GetStore() store.Store {
+	return db
 }
 
 func (m *MockDB) Close() error {
-	m.CloseInvoked = true
+	state.CloseInvoked = true
 	return m.OnClose()
 }
 
 func (m *MockDB) CreateVASP(v *pb.VASP) (string, error) {
-	m.CreateVASPInvoked = true
-	return m.OnCreateVASP(v)
+	state.CreateVASPInvoked = true
+	if v.Id == "" {
+		return "", errors.New("VASP must contain an ID")
+	}
+	if _, ok := state.VASPs[v.Id]; ok {
+		return "", fmt.Errorf("VASP with ID %s already exists", v.Id)
+	}
+	state.VASPs[v.Id] = *v
+	state.Keys = append(state.Keys, v.Id)
+	return v.Id, nil
 }
 
 func (m *MockDB) RetrieveVASP(id string) (*pb.VASP, error) {
-	m.RetrieveVASPInvoked = true
-	return m.OnRetrieveVASP(id)
+	state.RetrieveVASPInvoked = true
+	if id == "" {
+		return nil, errors.New("missing VASP ID")
+	}
+	var v pb.VASP
+	var ok bool
+	if v, ok = state.VASPs[id]; !ok {
+		return nil, fmt.Errorf("VASP with ID %s not found", id)
+	}
+	return &v, nil
 }
 
 func (m *MockDB) UpdateVASP(v *pb.VASP) error {
-	m.UpdateVASPInvoked = true
+	state.UpdateVASPInvoked = true
 	return m.OnUpdateVASP(v)
 }
 
 func (m *MockDB) DeleteVASP(id string) error {
-	m.DeleteVASPInvoked = true
+	state.DeleteVASPInvoked = true
 	return m.OnDeleteVASP(id)
 }
 
 func (m *MockDB) ListVASPs() iterator.DirectoryIterator {
-	m.ListVASPsInvoked = true
+	state.ListVASPsInvoked = true
 	return m.OnListVASPs()
 }
 
 func (m *MockDB) SearchVASPs(query map[string]interface{}) ([]*pb.VASP, error) {
-	m.SearchVASPsInvoked = true
+	state.SearchVASPsInvoked = true
 	return m.OnSearchVASPs(query)
 }
 
 func (m *MockDB) ListCertReqs() iterator.CertificateIterator {
-	m.ListCertReqsInvoked = true
+	state.ListCertReqsInvoked = true
 	return m.OnListCertReqs()
 }
 
 func (m *MockDB) CreateCertReq(r *models.CertificateRequest) (string, error) {
-	m.CreateCertReqInvoked = true
+	state.CreateCertReqInvoked = true
 	return m.OnCreateCertReq(r)
 }
 
 func (m *MockDB) RetrieveCertReq(id string) (*models.CertificateRequest, error) {
-	m.RetrieveCertReqInvoked = true
+	state.RetrieveCertReqInvoked = true
 	return m.OnRetrieveCertReq(id)
 }
 
 func (m *MockDB) UpdateCertReq(r *models.CertificateRequest) error {
-	m.UpdateCertReqInvoked = true
+	state.UpdateCertReqInvoked = true
 	return m.OnUpdateCertReq(r)
 }
 
 func (m *MockDB) DeleteCertReq(id string) error {
-	m.DeleteCertReqInvoked = true
+	state.DeleteCertReqInvoked = true
 	return m.OnDeleteCertReq(id)
 }
 
 func (m *MockDB) Reindex() error {
-	m.ReindexInvoked = true
+	state.ReindexInvoked = true
 	return m.OnReindex()
 }
 
 func (m *MockDB) Backup(path string) error {
-	m.BackupInvoked = true
+	state.BackupInvoked = true
 	return m.OnBackup(path)
 }

--- a/pkg/gds/store/testdata/bad_format.csv
+++ b/pkg/gds/store/testdata/bad_format.csv
@@ -1,0 +1,2 @@
+this,is,a,badly
+formatted,csv,file

--- a/pkg/gds/store/testdata/empty.csv
+++ b/pkg/gds/store/testdata/empty.csv
@@ -1,0 +1,1 @@
+entity name,country,category,url,address

--- a/pkg/gds/store/testdata/invalid_country.csv
+++ b/pkg/gds/store/testdata/invalid_country.csv
@@ -1,0 +1,2 @@
+entity name,country,category,url,address
+CharlieBank,XX,P2P,https://trisa.charliebank.io,2140 Carson Mission Apt. 731

--- a/pkg/gds/store/testdata/invalid_url.csv
+++ b/pkg/gds/store/testdata/invalid_url.csv
@@ -1,0 +1,2 @@
+entity name,country,category,url,address
+CharlieBank,CA,P2P,not a url,2140 Carson Mission Apt. 731

--- a/pkg/gds/store/testdata/vasps.csv
+++ b/pkg/gds/store/testdata/vasps.csv
@@ -1,0 +1,4 @@
+entity name,country,category,url,address
+CharlieBank,CA,P2P,https://trisa.charliebank.io,2140 Carson Mission Apt. 731
+Delta Assets,#N/A,Miner,trisa.delta.io,0806 Neal Coves Suite 610
+Echo Funds,GY,Custodian,,683 Hebert Ridges


### PR DESCRIPTION
This adds some tests for `store.Load` which loads VASPs from a CSV file. In order to make the testing easier I changed the `mockdb` struct a bit, although I don't think we were using it before so it shouldn't affect anything.