### PR TITLE
GDS: Fuzzy Search Fix

### DIFF
--- a/pkg/gds/gds.go
+++ b/pkg/gds/gds.go
@@ -274,7 +274,11 @@ func (s *GDS) Lookup(ctx context.Context, in *api.LookupRequest) (out *api.Looku
 		}
 
 		if len(vasps) != 1 {
-			log.Warn().Str("common_name", in.CommonName).Int("nresults", len(vasps)).Msg("wrong number of VASPs returned from search")
+			// Don't warn when common name is not found, just when multiple results are returned
+			if len(vasps) > 1 {
+				log.Warn().Str("common_name", in.CommonName).Int("nresults", len(vasps)).Msg("multiple VASPs returned from common name search in lookup")
+			}
+			log.Debug().Msg("could not lookup VASP by common name")
 			return nil, status.Error(codes.NotFound, "could not find VASP by common name")
 		}
 
@@ -374,7 +378,11 @@ func (s *GDS) Verification(ctx context.Context, in *api.VerificationRequest) (ou
 		}
 
 		if len(vasps) != 1 {
-			log.Warn().Str("common_name", in.CommonName).Int("nresults", len(vasps)).Msg("wrong number of VASPs returned from search")
+			if len(vasps) > 1 {
+				// Don't warn when common name is not found, just when multiple results are returned
+				log.Warn().Str("common_name", in.CommonName).Int("nresults", len(vasps)).Msg("multiple VASPs returned from common name search in verification")
+			}
+			log.Debug().Msg("could not lookup VASP by common name")
 			return nil, status.Error(codes.NotFound, "could not find VASP by common name")
 		}
 

--- a/pkg/gds/gds.go
+++ b/pkg/gds/gds.go
@@ -352,7 +352,6 @@ func (s *GDS) Search(ctx context.Context, in *api.SearchRequest) (out *api.Searc
 		Strs("categories", categories).
 		Int("results", len(out.Results)).
 		Msg("search succeeded")
-
 	return out, nil
 }
 

--- a/pkg/gds/gds_test.go
+++ b/pkg/gds/gds_test.go
@@ -215,6 +215,22 @@ func (s *gdsTestSuite) TestSearch() {
 	require.Equal(charlieVASP.CommonName, reply.Results[0].CommonName)
 	require.Equal(charlieVASP.TrisaEndpoint, reply.Results[0].Endpoint)
 
+	// Fuzzy search by case-insensitive prefix
+	request.Name = []string{"nov"}
+	reply, err = client.Search(ctx, request)
+	require.NoError(err)
+	require.Empty(reply.Error)
+	require.Len(reply.Results, 1)
+	bobVASP := s.fixtures[vasps]["novembercash"].(*pb.VASP)
+	require.Equal(bobVASP.Id, reply.Results[0].Id)
+
+	// Prefix search must have at least three characters
+	request.Name = []string{"Ch"}
+	reply, err = client.Search(ctx, request)
+	require.NoError(err)
+	require.Empty(reply.Error)
+	require.Len(reply.Results, 0)
+
 	// Multiple results
 	request.Name = []string{"CharlieBank", "Delta Assets"}
 	reply, err = client.Search(ctx, request)

--- a/pkg/gds/gds_test.go
+++ b/pkg/gds/gds_test.go
@@ -216,7 +216,7 @@ func (s *gdsTestSuite) TestSearch() {
 	require.Equal(charlieVASP.TrisaEndpoint, reply.Results[0].Endpoint)
 
 	// Fuzzy search by case-insensitive prefix
-	request.Name = []string{"nov"}
+	request.Name = []string{"NOV"}
 	reply, err = client.Search(ctx, request)
 	require.NoError(err)
 	require.Empty(reply.Error)
@@ -225,7 +225,7 @@ func (s *gdsTestSuite) TestSearch() {
 	require.Equal(bobVASP.Id, reply.Results[0].Id)
 
 	// Prefix search must have at least three characters
-	request.Name = []string{"Ch"}
+	request.Name = []string{"ch"}
 	reply, err = client.Search(ctx, request)
 	require.NoError(err)
 	require.Empty(reply.Error)

--- a/pkg/gds/store/leveldb/leveldb.go
+++ b/pkg/gds/store/leveldb/leveldb.go
@@ -69,6 +69,8 @@ var (
 	preCertReqs      = []byte("certreqs::")
 )
 
+const searchPrefixMinLength = 3
+
 // Store implements store.Store for some basic LevelDB operations and simple protocol
 // buffer storage in a key/value database.
 type Store struct {
@@ -286,7 +288,7 @@ func (s *Store) SearchVASPs(query map[string]interface{}) (vasps []*pb.VASP, err
 			if id := s.names[name]; id != "" {
 				// exact match
 				records[id] = struct{}{}
-			} else if len(name) > 2 {
+			} else if len(name) >= searchPrefixMinLength {
 				// prefix match
 				for vasp, id := range s.names {
 					if strings.HasPrefix(vasp, name) {


### PR DESCRIPTION
Modifies the VASP search to allow for prefix searches if the query > 3 characters. For example the query `"alice"` will match "AliceCoin" bu the query `"al"` will not. The search remains case-insensitive. Note that searches such as `"trisa-"` or `"trisa."` now return far more results since the common name field is also included. 