### PR TITLE
Hotfix: Sectigo Batch Validation Error

### DIFF
--- a/pkg/gds/certs.go
+++ b/pkg/gds/certs.go
@@ -152,6 +152,7 @@ func (s *Service) submitCertificateRequest(r *models.CertificateRequest) (err er
 	if profile == sectigo.ProfileCipherTraceEndEntityCertificate || profile == sectigo.ProfileIDCipherTraceEndEntityCertificate {
 		// Default to TRISA Production locality since none has been provided.
 		// TODO: make this part of the certificate request.
+		params["organizationName"] = "TRISA Production"
 		params["localityName"] = "Menlo Park"
 		params["stateOrProvinceName"] = "California"
 		params["countryName"] = "US"
@@ -160,7 +161,7 @@ func (s *Service) submitCertificateRequest(r *models.CertificateRequest) (err er
 	// Step 3: submit the certificate
 	var rep *sectigo.BatchResponse
 
-	batchName := fmt.Sprintf("%s certificate request for %s (id: %s)", s.conf.DirectoryID, r.CommonName, r.Id)
+	batchName := fmt.Sprintf("%s-certreq-%s-%s)", s.conf.DirectoryID, r.CommonName, r.Id)
 	if rep, err = s.certs.CreateSingleCertBatch(authority, batchName, params); err != nil {
 		// Although the error may be logged again by the calling function, log the error
 		// here as well to provide debugging information about why the Sectigo request failed.


### PR DESCRIPTION
This PR implements a fix to the Batch Validation Error we were getting when attempting to issue the Hodlbum certificates. We've taken three actions:

1. Added extra logging to better diagnose Sectigo request issues
2. Added `organizationName` to the single batch certificate request params
3. Removed spaces and simplified the `batchName` parameter. 

It isn't clear which of 2 or 3 fixed the bug, but the new request successfully issued certs. 

Merging without review to get this hot-fixed ASAP. 