### PR TITLE
Edit client profiles from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,44 @@ Finally, to run the services:
 ```
 $ docker compose -f ./containers/docker-compose.yaml --profile=all up
 ```
+
+## Configuration
+
+Server side configuration is done with the environment. Please see the instructions in the .env.template file for creating a local .env file to get started with development.
+
+### Profiles
+
+Client-side configuration is setup using profiles. A profile is a set of related configurations for both development and production. For example, the default environments are "production" to connect to vaspdirectory.net, "testnet" to connect to trisatest.net, and "localhost" to connect to locally running development servers. The profiles are configured in a YAML file that is stored in an OS-specific configuration directory.
+
+To get started with profiles, install them using the `gds profiles`, `gdsutil profiles` or `trtl profiles` commands that are found in the `./cmd` directory.
+
+```
+$ gds profiles --install
+```
+
+This will create the YAML file in the OS-specific configuration directory. To view the path of the configuration file:
+
+```
+$ gds profiles --path
+```
+
+Basic usage is as follows:
+
+1. `gds profiles` - show the configuration of the currently active profile
+2. `gds profiles --list` - show a list of available profiles
+3. `gds profiles --activate [name]` - activate the specified profile and use it
+4. `gds profiles --edit` - edit the profiles using a command line editor
+
+The easiest way to edit the profiles is to use `gds profiles --edit`, which will use the editor specified in the environment variable `$EDITOR`, or search for an editor in your `PATH` if none is specified. You must use a command line editor, e.g. `vim`, `emacs`, or `nano` so that the profile editor can verify the contents of the profiles before saving it.
+
+If you would like to specify a different editor on the command line but do not want to set the `$EDITOR` environment variable, you can use a command-specific environment:
+
+```
+$ EDITOR=nano gds profiles --edit
+```
+
+If you would like to edit the profiles using VSCode or a GUI based editor, use the following command (note there will be no verification of correctness using this method):
+
+```
+$ code "$(gds profiles --path)"
+```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,41 @@ Finally, to run the services:
 $ docker compose -f ./containers/docker-compose.yaml --profile=all up
 ```
 
+## CLI Tools
+
+There are several CLI helper tools within the repository designed to make it easier to test out the RPCs and experiment locally. The code for these CLI tools is contained in the `cmd` folder. (*Note: CLI tools are not maintained to the same degree as the rest of the codebase; if you notice any odd behavior, don't hesitate to ask.)
+
+### GDS CLI
+
+This program will allow you to interact with the TRISA global directory service (GDS) and some GDS Admin RPCs experimentally (e.g. looking up a VASP, reviewing a certificate request).
+
+To install the GDS CLI, run this from the project root:
+
+```bash
+go install ./cmd/gds
+```
+
+### GDS Utils CLI
+
+This program provides utilities for operating the GDS service and database.
+
+To install the GDS Utils CLI, run this from the project root:
+
+```bash
+go install ./cmd/gdsutil
+```
+
+### Trtl CLI
+
+This program provides tools for interacting with the Trtl data replication service.
+
+To install the Trtl CLI, run this from the project root:
+
+```bash
+go install ./cmd/trtl
+```
+
+
 ## Configuration
 
 Server side configuration is done with the environment. Please see the instructions in the .env.template file for creating a local .env file to get started with development.
@@ -71,13 +106,16 @@ Server side configuration is done with the environment. Please see the instructi
 
 Client-side configuration is setup using profiles. A profile is a set of related configurations for both development and production. For example, the default environments are "production" to connect to vaspdirectory.net, "testnet" to connect to trisatest.net, and "localhost" to connect to locally running development servers. The profiles are configured in a YAML file that is stored in an OS-specific configuration directory.
 
-To get started with profiles, install them using the `gds profiles`, `gdsutil profiles` or `trtl profiles` commands that are found in the `./cmd` directory.
+You must first install the CLI Tools described in the section above. After that, install the profiles helper tools:
+
 
 ```
 $ gds profiles --install
+$ gdsutil profiles --install
+$ trtl profiles --install
 ```
 
-This will create the YAML file in the OS-specific configuration directory. To view the path of the configuration file:
+This will create YAML files in your OS-specific configuration directory. To view the path of the configuration files (e.g. for the GDS tool):
 
 ```
 $ gds profiles --path

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ docker compose -f ./containers/docker-compose.yaml --profile=all up
 
 ## CLI Tools
 
-There are several CLI helper tools within the repository designed to make it easier to test out the RPCs and experiment locally. The code for these CLI tools is contained in the `cmd` folder. (*Note: CLI tools are not maintained to the same degree as the rest of the codebase; if you notice any odd behavior, don't hesitate to ask.)
+There are several CLI helper tools within the repository designed to make it easier to test out the RPCs and experiment locally. The code for these CLI tools is contained in the `cmd` folder. (*Note: CLI tools are not maintained to the same degree as the rest of the codebase; if you notice any odd behavior, don't hesitate to ask.*)
 
 ### GDS CLI
 

--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -534,9 +534,9 @@ func main() {
 			},
 			{
 				Name:      "profile",
-				Aliases:   []string{"config"},
+				Aliases:   []string{"config", "profiles"},
 				Usage:     "view and manage profiles to configure client with",
-				UsageText: "gds profile [name]\n   gds profile --activate [name]\n   gds profile --list\n   gds profile --path\n   gds profile --install",
+				UsageText: "gds profile [name]\n   gds profile --activate [name]\n   gds profile --list\n   gds profile --path\n   gds profile --install\n   gds profile --edit",
 				Action:    manageProfiles,
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
@@ -553,6 +553,11 @@ func main() {
 						Name:    "install",
 						Aliases: []string{"i"},
 						Usage:   "install the default profiles and exit",
+					},
+					&cli.BoolFlag{
+						Name:    "edit",
+						Aliases: []string{"e"},
+						Usage:   "edit the profiles YAML using $EDITOR",
 					},
 					&cli.StringFlag{
 						Name:    "activate",
@@ -1214,6 +1219,14 @@ func manageProfiles(c *cli.Context) (err error) {
 	// Handle install and then exit
 	if c.Bool("install") {
 		if err = profiles.Install(); err != nil {
+			return cli.Exit(err, 1)
+		}
+		return nil
+	}
+
+	// Handle edit and then exit
+	if c.Bool("edit") {
+		if err = profiles.EditProfiles(); err != nil {
 			return cli.Exit(err, 1)
 		}
 		return nil

--- a/cmd/gdsutil/main.go
+++ b/cmd/gdsutil/main.go
@@ -178,29 +178,34 @@ func main() {
 		},
 		{
 			Name:      "profile",
-			Aliases:   []string{"config"},
+			Aliases:   []string{"config", "profiles"},
 			Usage:     "view and manage profiles to configure gdsutil with",
-			UsageText: "gdsutil profile [name]\n   gdsutil profile --activate [name]\n   gdsutil profile --list\n   gdsutil profile --path\n   gdsutil profile --install",
+			UsageText: "gdsutil profile [name]\n   gdsutil profile --activate [name]\n   gdsutil profile --list\n   gdsutil profile --path\n   gdsutil profile --install\n   gdsutil profile --edit",
 			Action:    manageProfiles,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:    "l",
-					Aliases: []string{"list"},
+					Name:    "list",
+					Aliases: []string{"l"},
 					Usage:   "list the available profiles and exit",
 				},
 				&cli.BoolFlag{
-					Name:    "p",
-					Aliases: []string{"path"},
+					Name:    "path",
+					Aliases: []string{"p"},
 					Usage:   "show the path to the configuration and exit",
 				},
 				&cli.BoolFlag{
-					Name:    "i",
-					Aliases: []string{"install"},
+					Name:    "install",
+					Aliases: []string{"i"},
 					Usage:   "install the default profiles and exit",
 				},
+				&cli.BoolFlag{
+					Name:    "edit",
+					Aliases: []string{"e"},
+					Usage:   "edit the profiles YAML using $EDITOR",
+				},
 				&cli.StringFlag{
-					Name:    "a",
-					Aliases: []string{"activate"},
+					Name:    "activate",
+					Aliases: []string{"a"},
 					Usage:   "activate the profile with the specified name",
 				},
 			},
@@ -722,6 +727,14 @@ func manageProfiles(c *cli.Context) (err error) {
 	// Handle install and then exit
 	if c.Bool("install") {
 		if err = profiles.Install(); err != nil {
+			return cli.Exit(err, 1)
+		}
+		return nil
+	}
+
+	// Handle edit and then exit
+	if c.Bool("edit") {
+		if err = profiles.EditProfiles(); err != nil {
 			return cli.Exit(err, 1)
 		}
 		return nil

--- a/cmd/trtl/main.go
+++ b/cmd/trtl/main.go
@@ -311,29 +311,34 @@ func main() {
 		},
 		{
 			Name:      "profile",
-			Aliases:   []string{"config"},
+			Aliases:   []string{"config", "profiles"},
 			Usage:     "view and manage profiles to configure trtl with",
-			UsageText: "trtl profile [name]\n   trtl profile --activate [name]\n   trtl profile --list\n   trtl profile --path\n   trtl profile --install",
+			UsageText: "trtl profile [name]\n   trtl profile --activate [name]\n   trtl profile --list\n   trtl profile --path\n   trtl profile --install\n   trtl profile --edit",
 			Action:    manageProfiles,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:    "l",
-					Aliases: []string{"list"},
+					Name:    "list",
+					Aliases: []string{"l"},
 					Usage:   "list the available profiles and exit",
 				},
 				&cli.BoolFlag{
-					Name:    "p",
-					Aliases: []string{"path"},
+					Name:    "path",
+					Aliases: []string{"p"},
 					Usage:   "show the path to the configuration and exit",
 				},
 				&cli.BoolFlag{
-					Name:    "i",
-					Aliases: []string{"install"},
+					Name:    "install",
+					Aliases: []string{"i"},
 					Usage:   "install the default profiles and exit",
 				},
+				&cli.BoolFlag{
+					Name:    "edit",
+					Aliases: []string{"e"},
+					Usage:   "edit the profiles YAML using $EDITOR",
+				},
 				&cli.StringFlag{
-					Name:    "a",
-					Aliases: []string{"activate"},
+					Name:    "activate",
+					Aliases: []string{"a"},
 					Usage:   "activate the profile with the specified name",
 				},
 			},
@@ -668,6 +673,14 @@ func manageProfiles(c *cli.Context) (err error) {
 	// Handle install and then exit
 	if c.Bool("install") {
 		if err = profiles.Install(); err != nil {
+			return cli.Exit(err, 1)
+		}
+		return nil
+	}
+
+	// Handle edit and then exit
+	if c.Bool("edit") {
+		if err = profiles.EditProfiles(); err != nil {
 			return cli.Exit(err, 1)
 		}
 		return nil

--- a/pkg/gds/client/editor.go
+++ b/pkg/gds/client/editor.go
@@ -1,0 +1,219 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"gopkg.in/yaml.v2"
+)
+
+//===========================================================================
+// Edit the profile from the command line app
+//===========================================================================
+
+// The command line editors to search the $PATH for if $EDITOR is not specified.
+var editorSearch = [3]string{"vim", "emacs", "nano"}
+
+// Edit the profiles YAML at the specified path
+func EditProfiles() (err error) {
+	var path string
+	if path, err = ProfilesPath(); err != nil {
+		return err
+	}
+	return Edit(path, ValidProfiles)
+}
+
+// Edit the file at the specified path using a command line editor.
+func Edit(path string, validate validator) error {
+	return EditWith(path, "", validate)
+}
+
+// Edit the file at the specified path using the specified command line editor.
+func EditWith(path, editor string, validate validator) (err error) {
+	// Find the editor to use
+	if editor, err = findEditor(editor); err != nil {
+		return err
+	}
+
+	// Create a temporary file and copy the original file to it
+	var tmpf string
+	if tmpf, err = mktmpf(); err != nil {
+		return fmt.Errorf("could not create temporary file for editing: %v", err)
+	}
+	defer os.Remove(tmpf)
+
+	if err = copy2(path, tmpf); err != nil {
+		return fmt.Errorf("could not copy source contents into temporary file for editing: %v", err)
+	}
+
+	// Execute the editor on the temporary file
+	cmd := exec.Command(editor, tmpf)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("could not exec %s: %v", editor, err)
+	}
+
+	// Validate the written file before editing the original
+	if validate != nil {
+		if err = validate(tmpf); err != nil {
+			return fmt.Errorf("validation error: %s", err)
+		}
+	}
+
+	// If the editor exited succesfully, copy temporary file back to original file
+	if err = copy2(tmpf, path); err != nil {
+		return fmt.Errorf("could not copy temporary file contents back to source after editing: %v", err)
+	}
+	return nil
+}
+
+// Finds the path to the specified editor name, or if none is specified, uses the
+// $EDITOR environment variable or a search for the standard editors. Returns an error
+// if an editor can not be found in the $PATH.
+func findEditor(name string) (string, error) {
+	if name == "" {
+		name = os.Getenv("EDITOR")
+	}
+
+	// Determine if the specified editor can be executed
+	if name != "" {
+		// Expand environment variables and ~ for the home directory.
+		name = expand(name)
+
+		// If name is a full path and the file is executable, return it.
+		if isExecutable(name) {
+			return name, nil
+		}
+
+		// Check if the name exists in the Path, if so, return it.
+		return inPath(name)
+	}
+
+	// Search for one of the editors in the $PATH
+	for _, name := range editorSearch {
+		if path, err := inPath(name); err == nil {
+			return path, nil
+		}
+	}
+
+	// Could not find an editor
+	return "", errors.New("could not find an editor")
+}
+
+//===========================================================================
+// Validators
+//===========================================================================
+
+// A validator is applied to an editor to ensure that the edited file is in the correct
+// format or meets other formatting specifications before the original file is modified.
+type validator func(path string) error
+
+// ValidProfiles loads the edited YAML into a profiles struct to ensure it's valid.
+func ValidProfiles(path string) (err error) {
+	var p *Profiles
+	var data []byte
+	if data, err = ioutil.ReadFile(path); err != nil {
+		return err
+	}
+
+	if err = yaml.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("invalid profiles YAML: %s", err)
+	}
+	return nil
+}
+
+//===========================================================================
+// Helper Functions
+//===========================================================================
+
+// Returns true if the file exists and it can be executed on Unix systems.
+func isExecutable(path string) bool {
+	if stat, err := os.Stat(path); err == nil {
+		if !stat.IsDir() {
+			return stat.Mode()&0111 != 0
+		}
+	}
+	return false
+}
+
+// Searches for the specified editor in the $PATH
+func inPath(name string) (path string, err error) {
+	var fname string
+	if fname, err = exec.LookPath(name); err != nil {
+		return "", fmt.Errorf("could not find %q in $PATH", name)
+	}
+	if path, err = filepath.Abs(fname); err != nil {
+		return fname, nil
+	}
+	return path, nil
+}
+
+// Expand the path from environment variables and handle ~ for the home directory.
+func expand(path string) string {
+	if strings.HasPrefix(path, "~") {
+		path = strings.Replace(path, "~", "$HOME", 1)
+	}
+	return os.ExpandEnv(path)
+}
+
+func mktmpf() (_ string, err error) {
+	var f *os.File
+	if f, err = ioutil.TempFile("", "goedit-*"); err != nil {
+		return "", err
+	}
+	f.Close()
+	return f.Name(), nil
+}
+
+// Copy the contents from the src path to the dst path
+func copy2(src, dst string) (err error) {
+	// Check the source path to make sure it is editable.
+	var stat os.FileInfo
+	if stat, err = os.Stat(src); err != nil {
+		return fmt.Errorf("could not stat source file: %v", err)
+	}
+
+	if !stat.Mode().IsRegular() {
+		return fmt.Errorf("%q is not a regular file", src)
+	}
+
+	var (
+		source *os.File
+		target *os.File
+	)
+
+	if source, err = os.Open(src); err != nil {
+		return fmt.Errorf("could not open %q: %v", src, err)
+	}
+	defer source.Close()
+
+	if target, err = os.Create(dst); err != nil {
+		return fmt.Errorf("could not create %q: %v", dst, err)
+	}
+	defer target.Close()
+
+	if _, err = io.Copy(target, source); err != nil {
+		return fmt.Errorf("could not copy file: %v", err)
+	}
+
+	// Attempt to change the mode of the target file to the original mode (ignore errors)
+	target.Close()
+	os.Chmod(dst, stat.Mode())
+
+	// Attempt to cahnge the owners of the target file to the original owners (ignore errors)
+	if info, ok := stat.Sys().(*syscall.Stat_t); ok {
+		os.Chown(dst, int(info.Uid), int(info.Gid))
+	}
+
+	return nil
+}


### PR DESCRIPTION
This extension allows you to use --edit with the gds profiles, gdsutil
profiles, and trtl profiles command to directly edit the profiles YAML
in the command line with vim, emacs, or nano. You can specify the editor
of your choice using the $EDITOR environment variable. Note however that
a forking editor like VSCode will not work with this CLI app right now.