### PR TITLE
sc-2870 add DeleteVASP endpoint

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -418,6 +418,20 @@ func main() {
 				},
 			},
 			{
+				Name:     "admin:delete",
+				Usage:    "delete a VASP detail record by id",
+				Category: "admin",
+				Action:   adminDeleteVASP,
+				Before:   initAdminClient,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:    "id",
+						Aliases: []string{"i"},
+						Usage:   "the uuid of the VASP to retrieve",
+					},
+				},
+			},
+			{
 				Name:     "admin:notes",
 				Usage:    "list notes associated with a VASP",
 				Category: "admin",
@@ -992,6 +1006,23 @@ func adminUpdateVASP(c *cli.Context) (err error) {
 
 	var rep *admin.UpdateVASPReply
 	if rep, err = adminClient.UpdateVASP(ctx, req); err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func adminDeleteVASP(c *cli.Context) (err error) {
+	ctx, cancel := profile.Context()
+	defer cancel()
+
+	vaspID := c.String("id")
+	if vaspID == "" {
+		cli.Exit("must specify VASP ID (--id)", 1)
+	}
+
+	var rep *admin.Reply
+	if rep, err = adminClient.DeleteVASP(ctx, vaspID); err != nil {
 		return cli.Exit(err, 1)
 	}
 

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -175,6 +175,7 @@ func (s *Admin) setupRoutes() (err error) {
 			vasps.GET("", s.ListVASPs)
 			vasps.GET("/:vaspID", s.RetrieveVASP)
 			vasps.PATCH("/:vaspID", csrf, s.UpdateVASP)
+			vasps.DELETE("/:vaspID", csrf, s.DeleteVASP)
 			vasps.GET("/:vaspID/review", s.ReviewToken)
 			vasps.POST("/:vaspID/review", csrf, s.Review)
 			vasps.POST("/:vaspID/resend", csrf, s.Resend)
@@ -1224,6 +1225,58 @@ func (s *Admin) updateVASPEndpoint(vasp *pb.VASP, commonName, endpoint, source s
 	// modifications to its certificate requests. If the VASP is not saved after this
 	// method, it could lead to an inconsistency that needs to be repaired manually.
 	return true, http.StatusOK, nil
+}
+
+// DeleteVASP removes a VASP and its associated certificate requests if and only if the
+// VASP verification status is in PENDING_REVIEW or earlier or ERRORED.
+func (s *Admin) DeleteVASP(c *gin.Context) {
+	var (
+		vaspID     string
+		vasp       *pb.VASP
+		certReqIDs []string
+		err        error
+	)
+
+	vaspID = c.Param("vaspID")
+
+	// Retrieve the VASP from the database
+	if vasp, err = s.db.RetrieveVASP(vaspID); err != nil {
+		log.Warn().Err(err).Msg("could not retrieve VASP from database")
+		c.JSON(http.StatusNotFound, admin.ErrorResponse("could not retrieve VASP record by ID"))
+		return
+	}
+
+	// Only allow deletions if the VASP has not been reviewed yet
+	if vasp.VerificationStatus > pb.VerificationState_PENDING_REVIEW && vasp.VerificationStatus < pb.VerificationState_ERRORED {
+		log.Warn().Str("status", vasp.VerificationStatus.String()).Msg("VASP is in invalid state for deletion")
+		c.JSON(http.StatusBadRequest, admin.ErrorResponse("cannot delete VASP in its current state"))
+		return
+	}
+
+	// Retrieve the associated certificate requests
+	if certReqIDs, err = models.GetCertReqIDs(vasp); err != nil {
+		log.Warn().Err(err).Msg("could not retrieve certificate request IDs for VASP")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not retrieve certificate requests for VASP"))
+		return
+	}
+
+	// Delete the certificate requests
+	for _, id := range certReqIDs {
+		if err = s.db.DeleteCertReq(id); err != nil {
+			log.Warn().Err(err).Str("certreq_id", id).Msg("could not delete certificate request")
+			c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not delete associated certificate request"))
+			return
+		}
+	}
+
+	// Delete the VASP object to finalize the VASP deletion
+	if err = s.db.DeleteVASP(vaspID); err != nil {
+		log.Error().Err(err).Msg("could not delete VASP from database")
+		c.JSON(http.StatusInternalServerError, admin.ErrorResponse("could not delete VASP record by ID"))
+		return
+	}
+
+	c.JSON(http.StatusOK, admin.Reply{Success: true})
 }
 
 // CreateReviewNote creates a new review note given the vaspID param and a CreateReviewNoteRequest.

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -23,6 +23,7 @@ type DirectoryAdministrationClient interface {
 	ListVASPs(ctx context.Context, params *ListVASPsParams) (out *ListVASPsReply, err error)
 	RetrieveVASP(ctx context.Context, id string) (out *RetrieveVASPReply, err error)
 	UpdateVASP(ctx context.Context, in *UpdateVASPRequest) (out *UpdateVASPReply, err error)
+	DeleteVASP(ctx context.Context, id string) (out *Reply, err error)
 	CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error)
 	ListReviewNotes(ctx context.Context, id string) (out *ListReviewNotesReply, err error)
 	UpdateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error)

--- a/pkg/gds/admin/v2/client.go
+++ b/pkg/gds/admin/v2/client.go
@@ -349,6 +349,35 @@ func (s *APIv2) UpdateVASP(ctx context.Context, in *UpdateVASPRequest) (out *Upd
 	return out, nil
 }
 
+func (s *APIv2) DeleteVASP(ctx context.Context, id string) (out *Reply, err error) {
+	// vaspID is required for the endpoint
+	if id == "" {
+		return nil, ErrIDRequred
+	}
+
+	// Determine the path from the request
+	path := fmt.Sprintf("/v2/vasps/%s", id)
+
+	// Must be authenticated
+	if err = s.checkAuthentication(ctx); err != nil {
+		return nil, err
+	}
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodDelete, path, nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &Reply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func (s *APIv2) CreateReviewNote(ctx context.Context, in *ModifyReviewNoteRequest) (out *ReviewNote, err error) {
 	// vaspID is required for the endpoint
 	if in.VASP == "" {

--- a/pkg/gds/admin/v2/client_test.go
+++ b/pkg/gds/admin/v2/client_test.go
@@ -548,7 +548,7 @@ func TestUpdateVASP(t *testing.T) {
 	client, err := admin.New(ts.URL, nil)
 	require.NoError(t, err)
 
-	// Ensure a VASP ID is required to create a note
+	// Ensure a VASP ID is required to update a VASP
 	_, err = client.UpdateVASP(context.TODO(), &admin.UpdateVASPRequest{})
 	require.EqualError(t, err, "request requires a valid ID to determine endpoint")
 
@@ -556,6 +556,38 @@ func TestUpdateVASP(t *testing.T) {
 	out, err := client.UpdateVASP(context.TODO(), req)
 	require.NoError(t, err)
 	require.NotZero(t, out)
+	require.Equal(t, fixture, out)
+}
+
+func TestDeleteVASP(t *testing.T) {
+	id := "83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5"
+	fixture := &admin.Reply{
+		Success: true,
+	}
+
+	// Create a test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/v2/vasps/83dc8b6a-c3a8-4cb2-bc9d-b0d3fbd090c5", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := admin.New(ts.URL, nil)
+	require.NoError(t, err)
+
+	// Ensure a VASP ID is required to delete a VASP
+	_, err = client.DeleteVASP(context.TODO(), "")
+	require.EqualError(t, err, "request requires a valid ID to determine endpoint")
+
+	// Correctly formatted request
+	out, err := client.DeleteVASP(context.TODO(), id)
+	require.NoError(t, err)
+	require.NotNil(t, out)
 	require.Equal(t, fixture, out)
 }
 


### PR DESCRIPTION
This adds the DeleteVASP endpoint to delete a VASP and its associated certificate requests if it is in the correct state. The correct state is defined as `PENDING_REVIEW` or earlier, or `ERRORED`. I thought it made sense to allow deleting errored VASPs given that we intend to use this API for cleaning up bad registrations and such and it might help us avoid editing the database manually.