### PR TITLE
sc-916 improve contact handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.2.0
 	github.com/googleapis/gax-go v1.0.3
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/klauspost/compress v1.13.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -315,11 +315,14 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/pkg/gds/gds.go
+++ b/pkg/gds/gds.go
@@ -192,7 +192,7 @@ func (s *GDS) Register(ctx context.Context, in *api.RegisterRequest) (out *api.R
 	// Create the verification tokens and save the VASP back to the database
 	iter := models.NewContactIterator(vasp.Contacts, true, false)
 	for iter.Next() {
-		contact, kind, _ := iter.Value()
+		contact, kind := iter.Value()
 		if err = models.SetContactVerification(contact, secrets.CreateToken(48), false); err != nil {
 			log.Error().Err(err).Str("contact", kind).Str("vasp", vasp.Id).Msg("could not set contact verification token")
 			return nil, status.Error(codes.Aborted, "could not send contact verification emails")
@@ -444,7 +444,7 @@ func (s *GDS) VerifyContact(ctx context.Context, in *api.VerifyContactRequest) (
 
 	iter := models.NewContactIterator(vasp.Contacts, false, false)
 	for iter.Next() {
-		contact, kind, _ := iter.Value()
+		contact, kind := iter.Value()
 		// Get the verification status
 		token, verified, err := models.GetContactVerification(contact)
 		if err != nil {
@@ -579,7 +579,7 @@ func (s *GDS) Status(ctx context.Context, in *api.HealthCheck) (out *api.Service
 func getContactEmail(vasp *pb.VASP) string {
 	iter := models.NewContactIterator(vasp.Contacts, true, false)
 	for iter.Next() {
-		contact, _, _ := iter.Value()
+		contact, _ := iter.Value()
 		return contact.Email
 	}
 	return ""

--- a/pkg/gds/gds.go
+++ b/pkg/gds/gds.go
@@ -190,19 +190,11 @@ func (s *GDS) Register(ctx context.Context, in *api.RegisterRequest) (out *api.R
 	// Begin verification process by sending emails to all contacts in the VASP record.
 	// TODO: add to processing queue to return sooner/parallelize work
 	// Create the verification tokens and save the VASP back to the database
-	var contacts = []*pb.Contact{
-		vasp.Contacts.Technical,
-		vasp.Contacts.Administrative,
-		vasp.Contacts.Billing,
-		vasp.Contacts.Legal,
-	}
-
-	for idx, contact := range contacts {
-		if contact != nil && contact.Email != "" {
-			if err = models.SetContactVerification(contact, secrets.CreateToken(48), false); err != nil {
-				log.Error().Err(err).Int("index", idx).Str("vasp", vasp.Id).Msg("could not set contact verification token")
-				return nil, status.Error(codes.Aborted, "could not send contact verification emails")
-			}
+	next := models.IterContacts(vasp.Contacts, true)
+	for contact, kind := next(); contact != nil; contact, kind = next() {
+		if err = models.SetContactVerification(contact, secrets.CreateToken(48), false); err != nil {
+			log.Error().Err(err).Str("contact", kind).Str("vasp", vasp.Id).Msg("could not set contact verification token")
+			return nil, status.Error(codes.Aborted, "could not send contact verification emails")
 		}
 	}
 
@@ -448,18 +440,9 @@ func (s *GDS) VerifyContact(ctx context.Context, in *api.VerifyContactRequest) (
 	prevVerified := 0
 	found := false
 	contactEmail := ""
-	contacts := []*pb.Contact{
-		vasp.Contacts.Technical,
-		vasp.Contacts.Administrative,
-		vasp.Contacts.Billing,
-		vasp.Contacts.Legal,
-	}
-	for idx, contact := range contacts {
-		// Ignore empty contacts
-		if contact == nil {
-			continue
-		}
 
+	next := models.IterContacts(vasp.Contacts, false)
+	for contact, kind := next(); contact != nil; contact, kind = next() {
 		// Get the verification status
 		token, verified, err := models.GetContactVerification(contact)
 		if err != nil {
@@ -470,7 +453,7 @@ func (s *GDS) VerifyContact(ctx context.Context, in *api.VerifyContactRequest) (
 		// Perform token check and if token matches, mark contact as verified
 		if token == in.Token {
 			found = true
-			log.Info().Str("vasp", vasp.Id).Int("index", idx).Msg("contact email verified")
+			log.Info().Str("vasp", vasp.Id).Str("contact", kind).Msg("contact email verified")
 			if err = models.SetContactVerification(contact, "", true); err != nil {
 				log.Error().Err(err).Msg("could not set verification on contact extra data field")
 				return nil, status.Error(codes.Aborted, "could not verify contact")
@@ -592,17 +575,9 @@ func (s *GDS) Status(ctx context.Context, in *api.HealthCheck) (out *api.Service
 
 // Get a valid email address from the contacts on a VASP.
 func getContactEmail(vasp *pb.VASP) string {
-	contacts := []*pb.Contact{
-		vasp.Contacts.Technical,
-		vasp.Contacts.Administrative,
-		vasp.Contacts.Billing,
-		vasp.Contacts.Legal,
-	}
-
-	for _, contact := range contacts {
-		if contact != nil && contact.Email != "" {
-			return contact.Email
-		}
+	next := models.IterContacts(vasp.Contacts, true)
+	for contact, _ := next(); contact != nil; contact, _ = next() {
+		return contact.Email
 	}
 	return ""
 }

--- a/pkg/gds/models/v1/contacts.go
+++ b/pkg/gds/models/v1/contacts.go
@@ -1,0 +1,153 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+const (
+	TechnicalContact      = "technical"
+	AdministrativeContact = "administrative"
+	BillingContact        = "billing"
+	LegalContact          = "legal"
+)
+
+type contactType struct {
+	contact *pb.Contact
+	kind    string
+}
+
+// Returns True if a Contact is not nil and has an email address.
+func ContactExists(contact *pb.Contact) bool {
+	return contact != nil && contact.Email != ""
+}
+
+// Returns True if a Contact is verified.
+func ContactVerified(contact *pb.Contact) (verified bool, err error) {
+	if _, verified, err = GetContactVerification(contact); err != nil {
+		return false, err
+	}
+	return verified, nil
+}
+
+// Returns a function which iterates over the contacts in a Contacts object.
+func IterContacts(contacts *pb.Contacts, onlyVerified bool) func() (*pb.Contact, string, error) {
+	all := []*contactType{
+		{contact: contacts.Technical, kind: TechnicalContact},
+		{contact: contacts.Administrative, kind: AdministrativeContact},
+		{contact: contacts.Billing, kind: BillingContact},
+		{contact: contacts.Legal, kind: LegalContact},
+	}
+	i := 0
+	return func() (contact *pb.Contact, kind string, err error) {
+		// Return the next contact that exists or nil.
+		for i < len(all) {
+			contact = all[i].contact
+			kind = all[i].kind
+			i++
+			if ContactExists(contact) {
+				if onlyVerified {
+					var verified bool
+					if verified, err = ContactVerified(contact); err != nil {
+						return nil, "", err
+					}
+					if verified {
+						return contact, kind, nil
+					}
+				} else {
+					return contact, kind, nil
+				}
+			}
+		}
+		return nil, "", nil
+	}
+}
+
+// GetContactVerification token and verified status from the extra data field on the Contact.
+func GetContactVerification(contact *pb.Contact) (_ string, _ bool, err error) {
+	// Return zero-valued defaults with no error if extra is nil.
+	if contact == nil || contact.Extra == nil {
+		return "", false, nil
+	}
+
+	// Unmarshal the extra data field on the Contact
+	extra := &GDSContactExtraData{}
+	if err = contact.Extra.UnmarshalTo(extra); err != nil {
+		return "", false, err
+	}
+	return extra.GetToken(), extra.GetVerified(), nil
+}
+
+// SetContactVerification token and verified status on the Contact record.
+func SetContactVerification(contact *pb.Contact, token string, verified bool) (err error) {
+	if contact == nil {
+		return errors.New("cannot set verification on nil contact")
+	}
+
+	// Unmarshal previous extra data.
+	extra := &GDSContactExtraData{}
+	if contact.Extra != nil {
+		if err = contact.Extra.UnmarshalTo(extra); err != nil {
+			return fmt.Errorf("could not deserialize previous extra: %s", err)
+		}
+	}
+
+	// Set contact verification.
+	extra.Verified = verified
+	extra.Token = token
+	if contact.Extra, err = anypb.New(extra); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetEmailLog from the extra data on the Contact record.
+func GetEmailLog(contact *pb.Contact) (_ []*EmailLogEntry, err error) {
+	// If the extra data is nil, return nil (no email log).
+	if contact == nil || contact.Extra == nil {
+		return nil, nil
+	}
+
+	// Unmarshal the extra data field on the VASP.
+	extra := &GDSContactExtraData{}
+	if err = contact.Extra.UnmarshalTo(extra); err != nil {
+		return nil, err
+	}
+	return extra.GetEmailLog(), nil
+}
+
+// Create and add a new entry to the EmailLog on the extra data on the Contact record.
+func AppendEmailLog(contact *pb.Contact, reason string, subject string) (err error) {
+	// Contact must be non-nil.
+	if contact == nil {
+		return errors.New("cannot append entry to nil contact")
+	}
+
+	// Unmarshal previous extra data.
+	extra := &GDSContactExtraData{}
+	if contact.Extra != nil {
+		if err = contact.Extra.UnmarshalTo(extra); err != nil {
+			return fmt.Errorf("could not deserialize previous extra: %s", err)
+		}
+	} else {
+		extra.EmailLog = make([]*EmailLogEntry, 0, 1)
+	}
+
+	// Append entry to the previous log.
+	entry := &EmailLogEntry{
+		Timestamp: time.Now().Format(time.RFC3339),
+		Reason:    reason,
+		Subject:   subject,
+	}
+	extra.EmailLog = append(extra.EmailLog, entry)
+
+	// Serialize the extra data back to the VASP.
+	if contact.Extra, err = anypb.New(extra); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/gds/models/v1/contacts_test.go
+++ b/pkg/gds/models/v1/contacts_test.go
@@ -89,7 +89,7 @@ func TestIterContacts(t *testing.T) {
 	require.Equal(t, expectedKinds, actualKinds)
 }
 
-func TestIterVerfiiedContacts(t *testing.T) {
+func TestIterVerifiedContacts(t *testing.T) {
 	contacts := &pb.Contacts{
 		Technical: &pb.Contact{
 			Email: "technical@example.com",

--- a/pkg/gds/models/v1/contacts_test.go
+++ b/pkg/gds/models/v1/contacts_test.go
@@ -42,11 +42,11 @@ func TestIterContacts(t *testing.T) {
 	// Should iterate over all contacts.
 	iter := models.NewContactIterator(contacts, false, false)
 	for iter.Next() {
-		contact, kind, err := iter.Value()
-		require.NoError(t, err)
+		contact, kind := iter.Value()
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
+	require.NoError(t, iter.Error())
 	require.Equal(t, expectedContacts, actualContacts)
 	require.Equal(t, expectedKinds, actualKinds)
 
@@ -64,11 +64,11 @@ func TestIterContacts(t *testing.T) {
 	}
 	iter = models.NewContactIterator(contacts, true, false)
 	for iter.Next() {
-		contact, kind, err := iter.Value()
-		require.NoError(t, err)
+		contact, kind := iter.Value()
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
+	require.NoError(t, iter.Error())
 	require.Equal(t, expectedContacts, actualContacts)
 	require.Equal(t, expectedKinds, actualKinds)
 
@@ -80,11 +80,11 @@ func TestIterContacts(t *testing.T) {
 	contacts.Billing = nil
 	iter = models.NewContactIterator(contacts, false, false)
 	for iter.Next() {
-		contact, kind, err := iter.Value()
-		require.NoError(t, err)
+		contact, kind := iter.Value()
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
+	require.NoError(t, iter.Error())
 	require.Equal(t, expectedContacts, actualContacts)
 	require.Equal(t, expectedKinds, actualKinds)
 }
@@ -111,11 +111,11 @@ func TestIterVerfiiedContacts(t *testing.T) {
 	// No contacts are verified.
 	iter := models.NewContactIterator(contacts, false, true)
 	for iter.Next() {
-		contact, kind, err := iter.Value()
-		require.NoError(t, err)
+		contact, kind := iter.Value()
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
+	require.NoError(t, iter.Error())
 	require.Equal(t, []*pb.Contact{}, actualContacts)
 	require.Equal(t, []string{}, actualKinds)
 
@@ -135,11 +135,11 @@ func TestIterVerfiiedContacts(t *testing.T) {
 	}
 	iter = models.NewContactIterator(contacts, false, true)
 	for iter.Next() {
-		contact, kind, err := iter.Value()
-		require.NoError(t, err)
+		contact, kind := iter.Value()
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
+	require.NoError(t, iter.Error())
 	require.Equal(t, expectedContacts, actualContacts)
 	require.Equal(t, expectedKinds, actualKinds)
 }

--- a/pkg/gds/models/v1/contacts_test.go
+++ b/pkg/gds/models/v1/contacts_test.go
@@ -40,8 +40,10 @@ func TestIterContacts(t *testing.T) {
 	actualKinds := []string{}
 
 	// Should iterate over all contacts.
-	next := models.IterContacts(contacts, false)
-	for contact, kind := next(); contact != nil; contact, kind = next() {
+	iter := models.NewContactIterator(contacts, false, false)
+	for iter.Next() {
+		contact, kind, err := iter.Value()
+		require.NoError(t, err)
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
@@ -60,8 +62,10 @@ func TestIterContacts(t *testing.T) {
 		models.AdministrativeContact,
 		models.LegalContact,
 	}
-	next = models.IterContacts(contacts, true)
-	for contact, kind := next(); contact != nil; contact, kind = next() {
+	iter = models.NewContactIterator(contacts, true, false)
+	for iter.Next() {
+		contact, kind, err := iter.Value()
+		require.NoError(t, err)
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
@@ -74,8 +78,10 @@ func TestIterContacts(t *testing.T) {
 	// Should skip nil contacts.
 	contacts.Technical = nil
 	contacts.Billing = nil
-	next = models.IterContacts(contacts, false)
-	for contact, kind := next(); contact != nil; contact, kind = next() {
+	iter = models.NewContactIterator(contacts, false, false)
+	for iter.Next() {
+		contact, kind, err := iter.Value()
+		require.NoError(t, err)
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
@@ -103,13 +109,13 @@ func TestIterVerfiiedContacts(t *testing.T) {
 	actualKinds := []string{}
 
 	// No contacts are verified.
-	next := models.IterVerifiedContacts(contacts)
-	contact, kind, err := next()
-	for ; err == nil && contact != nil; contact, kind, err = next() {
+	iter := models.NewContactIterator(contacts, false, true)
+	for iter.Next() {
+		contact, kind, err := iter.Value()
+		require.NoError(t, err)
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
-	require.NoError(t, err)
 	require.Equal(t, []*pb.Contact{}, actualContacts)
 	require.Equal(t, []string{}, actualKinds)
 
@@ -127,13 +133,13 @@ func TestIterVerfiiedContacts(t *testing.T) {
 		models.TechnicalContact,
 		models.LegalContact,
 	}
-	next = models.IterVerifiedContacts(contacts)
-	contact, kind, err = next()
-	for ; err == nil && contact != nil; contact, kind, err = next() {
+	iter = models.NewContactIterator(contacts, false, true)
+	for iter.Next() {
+		contact, kind, err := iter.Value()
+		require.NoError(t, err)
 		actualContacts = append(actualContacts, contact)
 		actualKinds = append(actualKinds, kind)
 	}
-	require.NoError(t, err)
 	require.Equal(t, expectedContacts, actualContacts)
 	require.Equal(t, expectedKinds, actualKinds)
 }

--- a/pkg/gds/models/v1/contacts_test.go
+++ b/pkg/gds/models/v1/contacts_test.go
@@ -1,0 +1,139 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/gds/models/v1"
+	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
+)
+
+func TestIterContacts(t *testing.T) {
+	contacts := &pb.Contacts{
+		Technical: &pb.Contact{
+			Name: "technical",
+		},
+		Administrative: &pb.Contact{
+			Email: "administrative@example.com",
+		},
+		Billing: &pb.Contact{
+			Name: "billing",
+		},
+		Legal: &pb.Contact{
+			Email: "legal@example.com",
+		},
+	}
+	expectedContacts := []*pb.Contact{
+		contacts.Technical,
+		contacts.Administrative,
+		contacts.Legal,
+		contacts.Billing,
+	}
+	expectedKinds := []string{
+		models.TechnicalContact,
+		models.AdministrativeContact,
+		models.LegalContact,
+		models.BillingContact,
+	}
+
+	actualContacts := []*pb.Contact{}
+	actualKinds := []string{}
+
+	// Should iterate over all contacts.
+	next := models.IterContacts(contacts, false)
+	for contact, kind := next(); contact != nil; contact, kind = next() {
+		actualContacts = append(actualContacts, contact)
+		actualKinds = append(actualKinds, kind)
+	}
+	require.Equal(t, expectedContacts, actualContacts)
+	require.Equal(t, expectedKinds, actualKinds)
+
+	actualContacts = []*pb.Contact{}
+	actualKinds = []string{}
+
+	// Should skip contacts without an email address.
+	expectedContacts = []*pb.Contact{
+		contacts.Administrative,
+		contacts.Legal,
+	}
+	expectedKinds = []string{
+		models.AdministrativeContact,
+		models.LegalContact,
+	}
+	next = models.IterContacts(contacts, true)
+	for contact, kind := next(); contact != nil; contact, kind = next() {
+		actualContacts = append(actualContacts, contact)
+		actualKinds = append(actualKinds, kind)
+	}
+	require.Equal(t, expectedContacts, actualContacts)
+	require.Equal(t, expectedKinds, actualKinds)
+
+	actualContacts = []*pb.Contact{}
+	actualKinds = []string{}
+
+	// Should skip nil contacts.
+	contacts.Technical = nil
+	contacts.Billing = nil
+	next = models.IterContacts(contacts, false)
+	for contact, kind := next(); contact != nil; contact, kind = next() {
+		actualContacts = append(actualContacts, contact)
+		actualKinds = append(actualKinds, kind)
+	}
+	require.Equal(t, expectedContacts, actualContacts)
+	require.Equal(t, expectedKinds, actualKinds)
+}
+
+func TestIterVerfiiedContacts(t *testing.T) {
+	contacts := &pb.Contacts{
+		Technical: &pb.Contact{
+			Email: "technical@example.com",
+		},
+		Administrative: &pb.Contact{
+			Email: "administrative@example.com",
+		},
+		Billing: &pb.Contact{
+			Email: "billing@example.com",
+		},
+		Legal: &pb.Contact{
+			Email: "legal@example.com",
+		},
+	}
+
+	actualContacts := []*pb.Contact{}
+	actualKinds := []string{}
+
+	// No contacts are verified.
+	next := models.IterVerifiedContacts(contacts)
+	contact, kind, err := next()
+	for ; err == nil && contact != nil; contact, kind, err = next() {
+		actualContacts = append(actualContacts, contact)
+		actualKinds = append(actualKinds, kind)
+	}
+	require.NoError(t, err)
+	require.Equal(t, []*pb.Contact{}, actualContacts)
+	require.Equal(t, []string{}, actualKinds)
+
+	actualContacts = []*pb.Contact{}
+	actualKinds = []string{}
+
+	// Should only iterate through the verified contacts.
+	require.NoError(t, models.SetContactVerification(contacts.Technical, "", true))
+	require.NoError(t, models.SetContactVerification(contacts.Legal, "", true))
+	expectedContacts := []*pb.Contact{
+		contacts.Technical,
+		contacts.Legal,
+	}
+	expectedKinds := []string{
+		models.TechnicalContact,
+		models.LegalContact,
+	}
+	next = models.IterVerifiedContacts(contacts)
+	contact, kind, err = next()
+	for ; err == nil && contact != nil; contact, kind, err = next() {
+		actualContacts = append(actualContacts, contact)
+		actualKinds = append(actualKinds, kind)
+	}
+	require.NoError(t, err)
+	require.Equal(t, expectedContacts, actualContacts)
+	require.Equal(t, expectedKinds, actualKinds)
+}

--- a/pkg/gds/models/v1/models.go
+++ b/pkg/gds/models/v1/models.go
@@ -326,40 +326,6 @@ func DeleteReviewNote(vasp *pb.VASP, id string) (err error) {
 	return nil
 }
 
-// VerifiedContacts returns a map of contact type to email address for all verified
-// contacts, omitting any contacts that are not verified or do not exist.
-func VerifiedContacts(vasp *pb.VASP) (contacts map[string]string, err error) {
-	contacts = make(map[string]string)
-	next := IterContacts(vasp.Contacts, true)
-	contact, kind, err := next()
-	for ; err == nil && contact != nil; contact, kind, err = next() {
-		contacts[kind] = contact.Email
-	}
-	if err != nil {
-		return nil, err
-	}
-	return contacts, nil
-}
-
-// ContactVerifications returns a map of contact type to verified status, omitting any
-// contacts that do not exist.
-func ContactVerifications(vasp *pb.VASP) (contacts map[string]bool, err error) {
-	contacts = make(map[string]bool)
-	next := IterContacts(vasp.Contacts, false)
-	contact, kind, err := next()
-	for ; err == nil && contact != nil; contact, kind, err = next() {
-		var verified bool
-		if verified, err = ContactVerified(contact); err != nil {
-			return nil, err
-		}
-		contacts[kind] = verified
-	}
-	if err != nil {
-		return nil, err
-	}
-	return contacts, nil
-}
-
 // IsTraveler returns true if the VASP common name ends in traveler.ciphertrace.com
 func IsTraveler(vasp *pb.VASP) bool {
 	return strings.HasSuffix(vasp.CommonName, "traveler.ciphertrace.com")

--- a/pkg/gds/models/v1/models_test.go
+++ b/pkg/gds/models/v1/models_test.go
@@ -436,7 +436,6 @@ func TestVeriedContacts(t *testing.T) {
 	require.NoError(t, err)
 
 	contacts = VerifiedContacts(vasp)
-	require.NoError(t, err)
 	require.Len(t, contacts, 1)
 
 	err = SetContactVerification(vasp.Contacts.Technical, "", true)
@@ -446,7 +445,6 @@ func TestVeriedContacts(t *testing.T) {
 	require.NoError(t, err)
 
 	contacts = VerifiedContacts(vasp)
-	require.NoError(t, err)
 	require.Len(t, contacts, 2)
 }
 

--- a/pkg/gds/models/v1/models_test.go
+++ b/pkg/gds/models/v1/models_test.go
@@ -426,16 +426,18 @@ func TestVeriedContacts(t *testing.T) {
 		},
 	}
 
-	contacts := VerifiedContacts(vasp)
+	contacts, err := VerifiedContacts(vasp)
+	require.NoError(t, err)
 	require.Len(t, contacts, 0)
 
-	err := SetContactVerification(vasp.Contacts.Administrative, "", true)
+	err = SetContactVerification(vasp.Contacts.Administrative, "", true)
 	require.NoError(t, err)
 
 	err = SetContactVerification(vasp.Contacts.Technical, "12345", false)
 	require.NoError(t, err)
 
-	contacts = VerifiedContacts(vasp)
+	contacts, err = VerifiedContacts(vasp)
+	require.NoError(t, err)
 	require.Len(t, contacts, 1)
 
 	err = SetContactVerification(vasp.Contacts.Technical, "", true)
@@ -444,7 +446,8 @@ func TestVeriedContacts(t *testing.T) {
 	err = SetContactVerification(vasp.Contacts.Legal, "12345", false)
 	require.NoError(t, err)
 
-	contacts = VerifiedContacts(vasp)
+	contacts, err = VerifiedContacts(vasp)
+	require.NoError(t, err)
 	require.Len(t, contacts, 2)
 }
 

--- a/pkg/gds/models/v1/models_test.go
+++ b/pkg/gds/models/v1/models_test.go
@@ -426,17 +426,16 @@ func TestVeriedContacts(t *testing.T) {
 		},
 	}
 
-	contacts, err := VerifiedContacts(vasp)
-	require.NoError(t, err)
+	contacts := VerifiedContacts(vasp)
 	require.Len(t, contacts, 0)
 
-	err = SetContactVerification(vasp.Contacts.Administrative, "", true)
+	err := SetContactVerification(vasp.Contacts.Administrative, "", true)
 	require.NoError(t, err)
 
 	err = SetContactVerification(vasp.Contacts.Technical, "12345", false)
 	require.NoError(t, err)
 
-	contacts, err = VerifiedContacts(vasp)
+	contacts = VerifiedContacts(vasp)
 	require.NoError(t, err)
 	require.Len(t, contacts, 1)
 
@@ -446,7 +445,7 @@ func TestVeriedContacts(t *testing.T) {
 	err = SetContactVerification(vasp.Contacts.Legal, "12345", false)
 	require.NoError(t, err)
 
-	contacts, err = VerifiedContacts(vasp)
+	contacts = VerifiedContacts(vasp)
 	require.NoError(t, err)
 	require.Len(t, contacts, 2)
 }


### PR DESCRIPTION
This adds some utilities for dealing with the contacts. The main thing is a way to iterate through the contacts on a VASP more easily. Previously, we had to specify the contacts in a slice and then iterate through that slice every time a function wanted to iterate through the contacts. This PR adds two functions for iteration, `IterContacts` and `IterVerifiedContacts`, which both return anonymous functions which can be used to perform the iteration. This ensures that we are always iterating through the contacts in the same order and gets us access to the contact "kinds" if we need them ("technical", "administrative", "legal", and "billing").