### PR TITLE
sc-2540 change duplicate name warning to debug

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -534,7 +534,11 @@ func (s *Admin) Autocomplete(c *gin.Context) {
 				if _, ok := out.Names[name]; !ok {
 					out.Names[name] = vasp.Id
 				} else {
-					log.Warn().Str("name", name).Msg("duplicate name detected")
+					// Since this is not a unique index and multiple certs have been
+					// issued to organizations in the past, we will encounter name
+					// collisions here. We want this to be at debug level instead of at
+					// warning level to avoid alert spam.
+					log.Debug().Str("name", name).Msg("duplicate name detected")
 				}
 			}
 		}


### PR DESCRIPTION
This changes the duplicate name warning on the autocomplete endpoint to a debug to avoid the alert spam.