### PR TITLE
sc-2938 fix sectigo testing behavior for dev

### DIFF
--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -39,6 +39,7 @@ var testEnv = map[string]string{
 	"SECTIGO_USERNAME":                         "foo",
 	"SECTIGO_PASSWORD":                         "supersecret",
 	"SECTIGO_PROFILE":                          "17",
+	"SECTIGO_TESTING":                          "true",
 	"GDS_SERVICE_EMAIL":                        "test@example.com",
 	"GDS_ADMIN_EMAIL":                          "admin@example.com",
 	"SENDGRID_API_KEY":                         "bar1234",
@@ -100,6 +101,7 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, testEnv["SECTIGO_USERNAME"], conf.Sectigo.Username)
 	require.Equal(t, testEnv["SECTIGO_PASSWORD"], conf.Sectigo.Password)
 	require.Equal(t, testEnv["SECTIGO_PROFILE"], conf.Sectigo.Profile)
+	require.True(t, conf.Sectigo.Testing)
 	require.Equal(t, testEnv["GDS_SERVICE_EMAIL"], conf.Email.ServiceEmail)
 	require.Equal(t, testEnv["GDS_ADMIN_EMAIL"], conf.Email.AdminEmail)
 	require.Equal(t, testEnv["SENDGRID_API_KEY"], conf.Email.SendGridAPIKey)

--- a/pkg/sectigo/config.go
+++ b/pkg/sectigo/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	Username string `envconfig:"SECTIGO_USERNAME" required:"false"`
 	Password string `envconfig:"SECTIGO_PASSWORD" required:"false"`
 	Profile  string `envconfig:"SECTIGO_PROFILE" default:"CipherTrace EE"`
-	Testing  bool   `split_words:"true" default:"false"`
+	Testing  bool   `envconfig:"SECTIGO_TESTING" default:"false"`
 }
 
 func (c Config) Validate() error {


### PR DESCRIPTION
This fixes two things related to the sectigo configuration for the dev environment. The first is that the `SECTIGO_TESTING` flag was not being picked up from the configuration. The second is that GDS was erroring on startup if the sectigo testing flag was set. This has been fixed by moving the localhost check to when we try to send requests instead of on startup. This allows us to boot up GDS in Sectigo testing mode without it crashing.