### PR TITLE
sc-848 DirectoryIterator improved error handling

### DIFF
--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -436,8 +436,9 @@ func (s *Admin) Summary(c *gin.Context) {
 	for iter.Next() {
 		// Fetch VASP from the database
 		var vasp *pb.VASP
-		if vasp = iter.VASP(); vasp == nil {
-			// VASP could not be parsed; error logged in VASP() method continue iteration
+		var err error
+		if vasp, err = iter.VASP(); err != nil {
+			log.Error().Err(err).Msg("could not parse VASP from database")
 			continue
 		}
 
@@ -480,8 +481,9 @@ func (s *Admin) Summary(c *gin.Context) {
 	for iter2.Next() {
 		// Fetch CertificateRequest from the database
 		var certreq *models.CertificateRequest
-		if certreq = iter2.CertReq(); certreq == nil {
-			// CertificateRequest could not be parsed; error logged in CertReq() method continue iteration
+		var err error
+		if certreq, err = iter2.CertReq(); err != nil {
+			log.Error().Err(err).Msg("could not parse CertificateRequest from database")
 			continue
 		}
 
@@ -520,8 +522,9 @@ func (s *Admin) Autocomplete(c *gin.Context) {
 	for iter.Next() {
 		// Fetch VASP from the database
 		var vasp *pb.VASP
-		if vasp = iter.VASP(); vasp == nil {
-			// VASP could not be parsed; error logged in VASP() method continue iteration
+		var err error
+		if vasp, err = iter.VASP(); err != nil {
+			log.Error().Err(err).Msg("could not parse VASP from database")
 			continue
 		}
 
@@ -653,8 +656,9 @@ func (s *Admin) ReviewTimeline(c *gin.Context) {
 	for iter.Next() {
 		// Fetch VASP from the database
 		var vasp *pb.VASP
-		if vasp = iter.VASP(); vasp == nil {
-			// VASP could not be parsed; error logged in VASP() method continue iteration
+		var err error
+		if vasp, err = iter.VASP(); err != nil {
+			log.Error().Err(err).Msg("could not parse VASP from database")
 			continue
 		}
 
@@ -758,8 +762,9 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 			// In the page range so add to the list reply
 			// Fetch VASP from the database
 			var vasp *pb.VASP
-			if vasp = iter.VASP(); vasp == nil {
-				// VASP could not be parsed; error logged in VASP() method continue iteration
+			var err error
+			if vasp, err = iter.VASP(); err != nil {
+				log.Error().Err(err).Msg("could not parse VASP from database")
 				out.Count--
 				continue
 			}

--- a/pkg/gds/certs.go
+++ b/pkg/gds/certs.go
@@ -62,8 +62,9 @@ func (s *Service) CertManager(stop <-chan struct{}) {
 		log.Debug().Msg("cert-manager checking certificate request pipelines")
 
 		for careqs.Next() {
-			req := careqs.CertReq()
-			if req == nil {
+			var req *models.CertificateRequest
+			if req, err = careqs.CertReq(); err != nil {
+				log.Error().Err(err).Msg("could not parse certificate request from database")
 				continue
 			}
 

--- a/pkg/gds/members.go
+++ b/pkg/gds/members.go
@@ -199,7 +199,7 @@ func (s *Members) List(ctx context.Context, in *api.ListRequest) (out *api.ListR
 		// Collect the VASP from the iterator
 		var vasp *pb.VASP
 		if vasp, err = iter.VASP(); err != nil {
-			log.Warn().Err(err).Msg("could not parse VASP from database")
+			log.Error().Err(err).Msg("could not parse VASP from database")
 			continue
 		}
 

--- a/pkg/gds/members.go
+++ b/pkg/gds/members.go
@@ -197,7 +197,11 @@ func (s *Members) List(ctx context.Context, in *api.ListRequest) (out *api.ListR
 		}
 
 		// Collect the VASP from the iterator
-		vasp := iter.VASP()
+		var vasp *pb.VASP
+		if vasp, err = iter.VASP(); err != nil {
+			log.Warn().Err(err).Msg("could not parse VASP from database")
+			continue
+		}
 
 		// Skip any VASPs that are not verified yet
 		if vasp.VerificationStatus != pb.VerificationState_VERIFIED {

--- a/pkg/gds/store/iterator/iface.go
+++ b/pkg/gds/store/iterator/iface.go
@@ -17,7 +17,7 @@ type Iterator interface {
 type DirectoryIterator interface {
 	Iterator
 	Id() string
-	VASP() *pb.VASP
+	VASP() (*pb.VASP, error)
 	All() ([]*pb.VASP, error)
 	Seek(vaspID string) bool
 }
@@ -25,6 +25,6 @@ type DirectoryIterator interface {
 // CertificateIterator allows access to CertificateStore models
 type CertificateIterator interface {
 	Iterator
-	CertReq() *models.CertificateRequest
+	CertReq() (*models.CertificateRequest, error)
 	All() ([]*models.CertificateRequest, error)
 }

--- a/pkg/gds/store/leveldb/iterator.go
+++ b/pkg/gds/store/leveldb/iterator.go
@@ -37,13 +37,13 @@ func (i *iterWrapper) Release() {
 	i.iter.Release()
 }
 
-func (i *vaspIterator) VASP() *pb.VASP {
+func (i *vaspIterator) VASP() (*pb.VASP, error) {
 	vasp := new(pb.VASP)
 	if err := proto.Unmarshal(i.iter.Value(), vasp); err != nil {
 		log.Error().Err(err).Str("type", wire.NamespaceVASPs).Str("key", string(i.iter.Key())).Msg("corrupted data encountered")
-		return nil
+		return nil, err
 	}
-	return vasp
+	return vasp, nil
 }
 
 func (i *vaspIterator) All() (vasps []*pb.VASP, err error) {
@@ -75,13 +75,13 @@ func (i *vaspIterator) Seek(vaspID string) bool {
 	return i.iter.Seek(key)
 }
 
-func (i *certReqIterator) CertReq() *models.CertificateRequest {
+func (i *certReqIterator) CertReq() (*models.CertificateRequest, error) {
 	r := new(models.CertificateRequest)
 	if err := proto.Unmarshal(i.iter.Value(), r); err != nil {
 		log.Error().Err(err).Str("type", wire.NamespaceCertReqs).Str("key", string(i.iter.Key())).Msg("corrupted data encountered")
-		return nil
+		return nil, err
 	}
-	return r
+	return r, nil
 }
 
 func (i *certReqIterator) All() (reqs []*models.CertificateRequest, err error) {


### PR DESCRIPTION
This changes the `DirectoryIterator` methods so that they return an error if we are unable to parse the object from the database. This allows us to better distinguish between iteration errors and parsing errors (corrupted data) when iterating over VASPs or CertReqs.