### PR TITLE
Anti-entropy metrics with prometheus sc-2365 (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,14 @@ Server side configuration is done with the environment. Please see the instructi
 
 Client-side configuration is setup using profiles. A profile is a set of related configurations for both development and production. For example, the default environments are "production" to connect to vaspdirectory.net, "testnet" to connect to trisatest.net, and "localhost" to connect to locally running development servers. The profiles are configured in a YAML file that is stored in an OS-specific configuration directory.
 
-You must first install the CLI Tools described in the section above. After that, install the profiles helper tools:
+You must first install the CLI Tools described in the section above. After that, install the profiles helper tool:
 
 
 ```
 $ gds profiles --install
-$ gdsutil profiles --install
-$ trtl profiles --install
 ```
 
-This will create YAML files in your OS-specific configuration directory. To view the path of the configuration files (e.g. for the GDS tool):
+This will create YAML files in your OS-specific configuration directory. To view the path of the configuration file:
 
 ```
 $ gds profiles --path

--- a/pkg/gds/client/profiles.go
+++ b/pkg/gds/client/profiles.go
@@ -50,37 +50,43 @@ const (
 func DefaultProfiles() *Profiles {
 	return &Profiles{
 		Version: ProfileVersion,
-		Active:  "testnet",
+		Active:  "localhost",
 		Profiles: map[string]*Profile{
 			"production": {
 				Directory: &DirectoryProfile{
 					Endpoint: "api.vaspdirectory.net:443",
+					Insecure: true,
 				},
 				Admin: &AdminProfile{
 					Endpoint: "https://api.admin.vaspdirectory.net",
 				},
 				Members: &MembersProfile{
 					Endpoint: "members.vaspdirectory.net:443",
+					Insecure: true,
 				},
 				TrtlProfiles: []*TrtlProfile{
 					{
 						Endpoint: "trtl.us.vaspdirectory.net:443",
+						Insecure: true,
 					},
 				},
 			},
 			"testnet": {
 				Directory: &DirectoryProfile{
 					Endpoint: "api.trisatest.net:443",
+					Insecure: true,
 				},
 				Admin: &AdminProfile{
 					Endpoint: "https://api.admin.trisatest.net",
 				},
 				Members: &MembersProfile{
 					Endpoint: "members.trisatest.net:443",
+					Insecure: true,
 				},
 				TrtlProfiles: []*TrtlProfile{
 					{
 						Endpoint: "trtl.us.trisatest.net:443",
+						Insecure: true,
 					},
 				},
 			},

--- a/pkg/trtl/metrics.go
+++ b/pkg/trtl/metrics.go
@@ -12,19 +12,19 @@ import (
 )
 
 var (
-	pmPuts  *prometheus.CounterVec // count of trtl Puts per namespace
-	pmGets  *prometheus.CounterVec // count of trtl Gets per namespace
-	pmDels  *prometheus.CounterVec // count of trtl Deletes per namespace
-	pmIters *prometheus.CounterVec // count of trtl Iters per namespace
-	// pmObjects    *prometheus.CounterVec   // count of objects being managed by trtl, by namespace
-	// pmTombstones *prometheus.CounterVec   // count of tombstones per namespace; increases on delete, decrease on overwrite of tombstone
-	pmLatency       *prometheus.HistogramVec // the time it is taking for successful RPC calls to complete, labeled by RPC type, success, and failure
-	pmAESyncs       *prometheus.CounterVec   // count of anti entropy sessions per peer and per region
-	pmAESyncLatency *prometheus.HistogramVec // the time it is taking for anti entropy sessions to complete, by peer
-	pmAEPushes      *prometheus.HistogramVec // pushed objects during anti entropy, by peer and region
-	pmAEPulls       *prometheus.HistogramVec // pulled objects during anti entropy, by peer and region
-	pmAEPushVSPull  prometheus.Gauge         // a gauge of objects pushed vs pulled
-	pmAEStomps      *prometheus.CounterVec   // count of stomped versions, per peer and region
+	PmPuts  *prometheus.CounterVec // count of trtl Puts per namespace
+	PmGets  *prometheus.CounterVec // count of trtl Gets per namespace
+	PmDels  *prometheus.CounterVec // count of trtl Deletes per namespace
+	PmIters *prometheus.CounterVec // count of trtl Iters per namespace
+	// PmObjects    *prometheus.CounterVec   // count of objects being managed by trtl, by namespace
+	// PmTombstones *prometheus.CounterVec   // count of tombstones per namespace; increases on delete, decrease on overwrite of tombstone
+	PmLatency       *prometheus.HistogramVec // the time it is taking for successful RPC calls to complete, labeled by RPC type, success, and failure
+	PmAESyncs       *prometheus.CounterVec   // count of anti entropy sessions per peer and per region
+	PmAESyncLatency *prometheus.HistogramVec // the time it is taking for anti entropy sessions to complete, by peer
+	PmAEPushes      *prometheus.HistogramVec // pushed objects during anti entropy, by peer and region
+	PmAEPulls       *prometheus.HistogramVec // pulled objects during anti entropy, by peer and region
+	PmAEPushVSPull  prometheus.Gauge         // a gauge of objects pushed vs pulled
+	PmAEStomps      *prometheus.CounterVec   // count of stomped versions, per peer and region
 )
 
 // A MetricsService manages Prometheus metrics
@@ -65,138 +65,138 @@ func (m *MetricsService) Shutdown() error {
 }
 
 const (
-	pmNamespace = "trtl"
+	PmNamespace = "trtl"
 )
 
 func initMetrics() {
-	pmPuts = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: pmNamespace,
+	PmPuts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: PmNamespace,
 		Name:      "puts",
 		Help:      "the count of puts, labeled by namespace",
 	}, []string{"namespace"})
 
-	pmGets = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: pmNamespace,
+	PmGets = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: PmNamespace,
 		Name:      "gets",
 		Help:      "the count of gets, labeled by namespace",
 	}, []string{"namespace"})
 
-	pmDels = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: pmNamespace,
+	PmDels = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: PmNamespace,
 		Name:      "deletes",
 		Help:      "the count of deletes, labeled by namespace",
 	}, []string{"namespace"})
 
-	pmIters = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: pmNamespace,
+	PmIters = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: PmNamespace,
 		Name:      "iters",
 		Help:      "the count of iters, labeled by namespace",
 	}, []string{"namespace"})
 
-	// pmObjects = prometheus.NewCounterVec(prometheus.CounterOpts{
-	// 	Namespace: pmNamespace,
+	// PmObjects = prometheus.NewCounterVec(prometheus.CounterOpts{
+	// 	Namespace: PmNamespace,
 	// 	Name:      "objects",
 	// 	Help:      "the count of trtl objects, labeled by namespace",
 	// }, []string{"namespace"})
 
-	// pmTombstones = prometheus.NewCounterVec(prometheus.CounterOpts{
-	// 	Namespace: pmNamespace,
+	// PmTombstones = prometheus.NewCounterVec(prometheus.CounterOpts{
+	// 	Namespace: PmNamespace,
 	// 	Name:      "tombstones",
 	// 	Help:      "the count of tombstones, labeled by namespace",
 	// }, []string{"namespace"})
 
-	pmLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: pmNamespace,
+	PmLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: PmNamespace,
 		Name:      "latency",
 		Help:      "time to RPC call completion, labeled by RPC (Put, Get, Delete, Iter)",
 	}, []string{"call"})
 
-	pmAESyncs = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: pmNamespace,
+	PmAESyncs = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: PmNamespace,
 		Name:      "syncs",
 		Help:      "the count of anti-entropy sessions, labeled by peer and region",
 	}, []string{"peer", "region"})
 
-	pmAESyncLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: pmNamespace,
+	PmAESyncLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: PmNamespace,
 		Name:      "sync_latency",
 		Help:      "time to anti-entropy session completion, labeled by peer",
 	}, []string{"peer"})
 
-	pmAEPulls = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: pmNamespace,
+	PmAEPulls = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: PmNamespace,
 		Name:      "pulls",
 		Help:      "pulled objects during anti entropy, labeled by peer and region",
 	}, []string{"peer", "region"})
 
-	pmAEPushes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: pmNamespace,
+	PmAEPushes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: PmNamespace,
 		Name:      "pushes",
 		Help:      "pushed objects during anti entropy, labeled by peer and region",
 	}, []string{"peer", "region"})
 
-	pmAEPushVSPull = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: pmNamespace,
+	PmAEPushVSPull = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: PmNamespace,
 		Name:      "push_vs_pull",
 		Help:      "objects pushed vs pulled",
 	})
 
-	pmAEStomps = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: pmNamespace,
+	PmAEStomps = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: PmNamespace,
 		Name:      "stomps",
 		Help:      "count of stomped versions, labeled by peer and region",
 	}, []string{"peer", "region"})
 }
 
 func registerMetrics() error {
-	if err := prometheus.Register(pmPuts); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmPuts")
+	if err := prometheus.Register(PmPuts); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmPuts")
 		return err
 	}
-	if err := prometheus.Register(pmGets); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmGets")
+	if err := prometheus.Register(PmGets); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmGets")
 		return err
 	}
-	if err := prometheus.Register(pmDels); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmDels")
+	if err := prometheus.Register(PmDels); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmDels")
 		return err
 	}
-	if err := prometheus.Register(pmIters); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmIters")
+	if err := prometheus.Register(PmIters); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmIters")
 		return err
 	}
-	// if err := prometheus.Register(pmObjects); err != nil {
-	// 	log.Debug().Err(err).Msg("unable to register pmObjects")
+	// if err := prometheus.Register(PmObjects); err != nil {
+	// 	log.Debug().Err(err).Msg("unable to register PmObjects")
 	// 	return err
 	// }
-	// if err := prometheus.Register(pmTombstones); err != nil {
-	// 	log.Debug().Err(err).Msg("unable to register pmTombstones")
+	// if err := prometheus.Register(PmTombstones); err != nil {
+	// 	log.Debug().Err(err).Msg("unable to register PmTombstones")
 	// 	return err
 	// }
-	if err := prometheus.Register(pmLatency); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmLatency")
+	if err := prometheus.Register(PmLatency); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmLatency")
 		return err
 	}
-	if err := prometheus.Register(pmAESyncs); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmAESyncs")
+	if err := prometheus.Register(PmAESyncs); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmAESyncs")
 	}
-	if err := prometheus.Register(pmAESyncLatency); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmAESyncLatency")
+	if err := prometheus.Register(PmAESyncLatency); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmAESyncLatency")
 	}
-	if err := prometheus.Register(pmAEPulls); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmAEPulls")
+	if err := prometheus.Register(PmAEPulls); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmAEPulls")
 		return err
 	}
-	if err := prometheus.Register(pmAEPushes); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmAEPushes")
+	if err := prometheus.Register(PmAEPushes); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmAEPushes")
 		return err
 	}
-	if err := prometheus.Register(pmAEPushVSPull); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmAEPushVSPull")
+	if err := prometheus.Register(PmAEPushVSPull); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmAEPushVSPull")
 		return err
 	}
-	if err := prometheus.Register(pmAEStomps); err != nil {
-		log.Debug().Err(err).Msg("unable to register pmAEStomps")
+	if err := prometheus.Register(PmAEStomps); err != nil {
+		log.Debug().Err(err).Msg("unable to register PmAEStomps")
 		return err
 	}
 	return nil

--- a/pkg/trtl/metrics.go
+++ b/pkg/trtl/metrics.go
@@ -18,7 +18,13 @@ var (
 	pmIters *prometheus.CounterVec // count of trtl Iters per namespace
 	// pmObjects    *prometheus.CounterVec   // count of objects being managed by trtl, by namespace
 	// pmTombstones *prometheus.CounterVec   // count of tombstones per namespace; increases on delete, decrease on overwrite of tombstone
-	pmLatency *prometheus.HistogramVec // the time it is taking for successful RPC calls to complete, labeled by RPC type, success, and failure
+	pmLatency       *prometheus.HistogramVec // the time it is taking for successful RPC calls to complete, labeled by RPC type, success, and failure
+	pmAESyncs       *prometheus.CounterVec   // count of anti entropy sessions per peer and per region
+	pmAESyncLatency *prometheus.HistogramVec // the time it is taking for anti entropy sessions to complete, by peer
+	pmAEPushes      *prometheus.HistogramVec // pushed objects during anti entropy, by peer and region
+	pmAEPulls       *prometheus.HistogramVec // pulled objects during anti entropy, by peer and region
+	pmAEPushVSPull  prometheus.Gauge         // a gauge of objects pushed vs pulled
+	pmAEStomps      *prometheus.CounterVec   // count of stomped versions, per peer and region
 )
 
 // A MetricsService manages Prometheus metrics
@@ -104,6 +110,42 @@ func initMetrics() {
 		Name:      "latency",
 		Help:      "time to RPC call completion, labeled by RPC (Put, Get, Delete, Iter)",
 	}, []string{"call"})
+
+	pmAESyncs = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pmNamespace,
+		Name:      "syncs",
+		Help:      "the count of anti-entropy sessions, labeled by peer and region",
+	}, []string{"peer", "region"})
+
+	pmAESyncLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: pmNamespace,
+		Name:      "sync_latency",
+		Help:      "time to anti-entropy session completion, labeled by peer",
+	}, []string{"peer"})
+
+	pmAEPulls = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: pmNamespace,
+		Name:      "pulls",
+		Help:      "pulled objects during anti entropy, labeled by peer and region",
+	}, []string{"peer", "region"})
+
+	pmAEPushes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: pmNamespace,
+		Name:      "pushes",
+		Help:      "pushed objects during anti entropy, labeled by peer and region",
+	}, []string{"peer", "region"})
+
+	pmAEPushVSPull = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: pmNamespace,
+		Name:      "push_vs_pull",
+		Help:      "objects pushed vs pulled",
+	})
+
+	pmAEStomps = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pmNamespace,
+		Name:      "stomps",
+		Help:      "count of stomped versions, labeled by peer and region",
+	}, []string{"peer", "region"})
 }
 
 func registerMetrics() error {
@@ -135,6 +177,27 @@ func registerMetrics() error {
 		log.Debug().Err(err).Msg("unable to register pmLatency")
 		return err
 	}
-
+	if err := prometheus.Register(pmAESyncs); err != nil {
+		log.Debug().Err(err).Msg("unable to register pmAESyncs")
+	}
+	if err := prometheus.Register(pmAESyncLatency); err != nil {
+		log.Debug().Err(err).Msg("unable to register pmAESyncLatency")
+	}
+	if err := prometheus.Register(pmAEPulls); err != nil {
+		log.Debug().Err(err).Msg("unable to register pmAEPulls")
+		return err
+	}
+	if err := prometheus.Register(pmAEPushes); err != nil {
+		log.Debug().Err(err).Msg("unable to register pmAEPushes")
+		return err
+	}
+	if err := prometheus.Register(pmAEPushVSPull); err != nil {
+		log.Debug().Err(err).Msg("unable to register pmAEPushVSPull")
+		return err
+	}
+	if err := prometheus.Register(pmAEStomps); err != nil {
+		log.Debug().Err(err).Msg("unable to register pmAEStomps")
+		return err
+	}
 	return nil
 }

--- a/pkg/trtl/metrics/metrics.go
+++ b/pkg/trtl/metrics/metrics.go
@@ -39,6 +39,10 @@ type MetricsService struct {
 	srv *http.Server
 }
 
+// New creates a metrics service and also initializes all of the prometheus metrics.
+// The trtl server *must* create the metrics service by calling New before any
+// metrics are logged to Prometheus. Even in the case of tests, the metrics service
+// must be created before the tests can be run.
 func New() (*MetricsService, error) {
 	initMetrics()
 	return &MetricsService{srv: &http.Server{}}, nil

--- a/pkg/trtl/server.go
+++ b/pkg/trtl/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/trisacrypto/directory/pkg/trtl/config"
+	prom "github.com/trisacrypto/directory/pkg/trtl/metrics"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"github.com/trisacrypto/directory/pkg/trtl/peers/v1"
 	"github.com/trisacrypto/directory/pkg/trtl/replica"
@@ -36,15 +37,15 @@ func init() {
 // 2. A peers management service for interacting with remote peers
 // 3. A replication service which implements auto-adapting anti-entropy replication.
 type Server struct {
-	srv     *grpc.Server     // The gRPC server that listens on its own independent port
-	conf    config.Config    // Configuration for the trtl server
-	db      *honu.DB         // Database connection for managing objects
-	trtl    *TrtlService     // Service for interacting with a Honu database
-	peers   *PeerService     // Service for managing remote peers
-	replica *replica.Service // Service that handles anti-entropy replication
-	metrics *MetricsService  // Service for Prometheus metrics
-	started time.Time        // The timestamp that the server was started (for uptime)
-	echan   chan error       // Channel for receiving errors from the gRPC server
+	srv     *grpc.Server         // The gRPC server that listens on its own independent port
+	conf    config.Config        // Configuration for the trtl server
+	db      *honu.DB             // Database connection for managing objects
+	trtl    *TrtlService         // Service for interacting with a Honu database
+	peers   *PeerService         // Service for managing remote peers
+	replica *replica.Service     // Service that handles anti-entropy replication
+	metrics *prom.MetricsService // Service for Prometheus metrics
+	started time.Time            // The timestamp that the server was started (for uptime)
+	echan   chan error           // Channel for receiving errors from the gRPC server
 }
 
 // New creates a new trtl server given a configuration.
@@ -118,7 +119,7 @@ func New(conf config.Config) (s *Server, err error) {
 	replication.RegisterReplicationServer(s.srv, s.replica)
 
 	// Initialize Metrics service for Prometheus
-	if s.metrics, err = NewMetricsService(); err != nil {
+	if s.metrics, err = prom.New(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/trtl/trtl.go
+++ b/pkg/trtl/trtl.go
@@ -84,10 +84,10 @@ func (h *TrtlService) Get(ctx context.Context, in *pb.GetRequest) (*pb.GetReply,
 
 		// Compute latency in milliseconds
 		latency := float64(time.Since(start)/1000) / 1000.0
-		pmLatency.WithLabelValues("Get").Observe(latency)
+		PmLatency.WithLabelValues("Get").Observe(latency)
 
 		// Update prometheus metrics
-		pmGets.WithLabelValues(object.Namespace).Inc()
+		PmGets.WithLabelValues(object.Namespace).Inc()
 
 		return &pb.GetReply{
 			Value: object.Data,
@@ -100,10 +100,10 @@ func (h *TrtlService) Get(ctx context.Context, in *pb.GetRequest) (*pb.GetReply,
 
 	// Compute Get latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	pmLatency.WithLabelValues("Get").Observe(latency)
+	PmLatency.WithLabelValues("Get").Observe(latency)
 
 	// Increment prometheus Get count
-	pmGets.WithLabelValues(object.Namespace).Inc()
+	PmGets.WithLabelValues(object.Namespace).Inc()
 
 	return &pb.GetReply{
 		Value: object.Data,
@@ -152,10 +152,10 @@ func (h *TrtlService) Put(ctx context.Context, in *pb.PutRequest) (out *pb.PutRe
 
 	// Compute Put latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	pmLatency.WithLabelValues("Put").Observe(latency)
+	PmLatency.WithLabelValues("Put").Observe(latency)
 
 	// Increment prometheus Put counter
-	pmPuts.WithLabelValues(object.Namespace).Inc()
+	PmPuts.WithLabelValues(object.Namespace).Inc()
 
 	// TODO: prometheus; see sc-2576
 	// If in.Options.ReturnMeta is true, we will get metadata from honu
@@ -203,10 +203,10 @@ func (h *TrtlService) Delete(ctx context.Context, in *pb.DeleteRequest) (out *pb
 
 	// Compute Delete latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	pmLatency.WithLabelValues("Delete").Observe(latency)
+	PmLatency.WithLabelValues("Delete").Observe(latency)
 
 	// Increment Prometheus Delete counter
-	pmDels.WithLabelValues(object.Namespace).Inc()
+	PmDels.WithLabelValues(object.Namespace).Inc()
 
 	// TODO: Increment Prometheus Tombstone counter; see sc-2576
 	// Unfortunately we can't decrement yet! (see note in `Put`)
@@ -383,10 +383,10 @@ func (h *TrtlService) Iter(ctx context.Context, in *pb.IterRequest) (out *pb.Ite
 
 	// Compute Iter latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	pmLatency.WithLabelValues("Iter").Observe(latency)
+	PmLatency.WithLabelValues("Iter").Observe(latency)
 
 	// Increment Prometheus Iter counter
-	pmIters.WithLabelValues(iter.Namespace()).Inc()
+	PmIters.WithLabelValues(iter.Namespace()).Inc()
 
 	// Request complete
 	log.Info().

--- a/pkg/trtl/trtl.go
+++ b/pkg/trtl/trtl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/trisacrypto/directory/pkg"
 	"github.com/trisacrypto/directory/pkg/trtl/internal"
+	prom "github.com/trisacrypto/directory/pkg/trtl/metrics"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -84,10 +85,10 @@ func (h *TrtlService) Get(ctx context.Context, in *pb.GetRequest) (*pb.GetReply,
 
 		// Compute latency in milliseconds
 		latency := float64(time.Since(start)/1000) / 1000.0
-		PmLatency.WithLabelValues("Get").Observe(latency)
+		prom.PmRPCLatency.WithLabelValues("Get").Observe(latency)
 
 		// Update prometheus metrics
-		PmGets.WithLabelValues(object.Namespace).Inc()
+		prom.PmGets.WithLabelValues(object.Namespace).Inc()
 
 		return &pb.GetReply{
 			Value: object.Data,
@@ -100,10 +101,10 @@ func (h *TrtlService) Get(ctx context.Context, in *pb.GetRequest) (*pb.GetReply,
 
 	// Compute Get latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	PmLatency.WithLabelValues("Get").Observe(latency)
+	prom.PmRPCLatency.WithLabelValues("Get").Observe(latency)
 
 	// Increment prometheus Get count
-	PmGets.WithLabelValues(object.Namespace).Inc()
+	prom.PmGets.WithLabelValues(object.Namespace).Inc()
 
 	return &pb.GetReply{
 		Value: object.Data,
@@ -152,10 +153,10 @@ func (h *TrtlService) Put(ctx context.Context, in *pb.PutRequest) (out *pb.PutRe
 
 	// Compute Put latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	PmLatency.WithLabelValues("Put").Observe(latency)
+	prom.PmRPCLatency.WithLabelValues("Put").Observe(latency)
 
 	// Increment prometheus Put counter
-	PmPuts.WithLabelValues(object.Namespace).Inc()
+	prom.PmPuts.WithLabelValues(object.Namespace).Inc()
 
 	// TODO: prometheus; see sc-2576
 	// If in.Options.ReturnMeta is true, we will get metadata from honu
@@ -203,14 +204,14 @@ func (h *TrtlService) Delete(ctx context.Context, in *pb.DeleteRequest) (out *pb
 
 	// Compute Delete latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	PmLatency.WithLabelValues("Delete").Observe(latency)
+	prom.PmRPCLatency.WithLabelValues("Delete").Observe(latency)
 
 	// Increment Prometheus Delete counter
-	PmDels.WithLabelValues(object.Namespace).Inc()
+	prom.PmDels.WithLabelValues(object.Namespace).Inc()
 
 	// TODO: Increment Prometheus Tombstone counter; see sc-2576
 	// Unfortunately we can't decrement yet! (see note in `Put`)
-	// pmTombstones.WithLabelValues(object.Namespace).Inc()
+	// prom.pmTombstones.WithLabelValues(object.Namespace).Inc()
 
 	return out, nil
 }
@@ -383,10 +384,10 @@ func (h *TrtlService) Iter(ctx context.Context, in *pb.IterRequest) (out *pb.Ite
 
 	// Compute Iter latency in milliseconds
 	latency := float64(time.Since(start)/1000) / 1000.0
-	PmLatency.WithLabelValues("Iter").Observe(latency)
+	prom.PmRPCLatency.WithLabelValues("Iter").Observe(latency)
 
 	// Increment Prometheus Iter counter
-	PmIters.WithLabelValues(iter.Namespace()).Inc()
+	prom.PmIters.WithLabelValues(iter.Namespace()).Inc()
 
 	// Request complete
 	log.Info().


### PR DESCRIPTION
This PR adds replication monitoring to Trtl with prometheus, moving metrics into a standalone package that can be accessed from the various places within `trtl` where we'd like to be tracking behavior.

Requirements:

- [x] number of initiated anti-entropy sessions per peer/per region (initiator perspective)
- [x] number of received anti-entropy sessions per peer/per region (remote perspective) 
- [x] phase 1 (initiator perspective) anti-entropy session latency per peer 
- [x] phase 2 (remote perspective) anti-entropy session latency per peer 
- [x] total (initiator perspective) anti-entropy session latency per peer 
- [x] number of skips (initiator and remote perspective)
- [x] number of stomps (initiator and remote perspective)
- [x] number of versions (initiator and remote perspective)
- [x] number of updates (initiator and remote perspective)
- [x] number of repairs (initiator and remote perspective)