### PR TITLE
sc-2013 add code generation to workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,9 +51,13 @@ jobs:
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
 
-      # # TODO: figure out code generation and include TRISA repo in GitHub actions
-      # - name: Code Generation
-      #   run: go generate ./...
+      - name: Clone TRISA repository
+        uses: actions/checkout@main
+        with:
+          name: trisacrypto/trisa
+
+      - name: Code Generation
+        run: go generate ./...
 
       - name: Run Unit Tests
         run: go test -v -coverprofile=coverage.txt -covermode=atomic --race ./...
@@ -89,9 +93,13 @@ jobs:
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
 
-      # # TODO: figure out code generation and include TRISA repo in GitHub actions
-      # - name: Code Generation
-      #   run: go generate ./...
+      - name: Clone TRISA repository
+        uses: actions/checkout@main
+        with:
+          name: trisacrypto/trisa
+
+      - name: Code Generation
+        run: go generate ./...
 
       - name: Build
         run: go build ./cmd/...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,8 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: trisacrypto/trisa
+          ref: main
+          path: ../
 
       - name: Code Generation
         run: go generate ./...
@@ -97,6 +99,8 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: trisacrypto/trisa
+          ref: main
+          path: ../
 
       - name: Code Generation
         run: go generate ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,9 @@ jobs:
   test:
     name: Go Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./directory
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -47,7 +50,6 @@ jobs:
           version: '3.x'
 
       - name: Install Dependencies
-        working-directory: ./directory
         run: |
           go version
           go get -u github.com/kevinburke/go-bindata/...
@@ -62,24 +64,24 @@ jobs:
           path: trisa
 
       - name: Code Generation
-        working-directory: ./directory
         run: go generate ./...
 
       - name: Run Unit Tests
-        working-directory: ./directory
         run: go test -v -coverprofile=coverage.txt -covermode=atomic --race ./...
 
       - name: Upload Coverage report to CodeCov
-        working-directory: ./directory
         uses: codecov/codecov-action@v1.0.0
         with:
           # Make sure to add to GitHub secrets!
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.txt
+          file: ./directory/coverage.txt
 
   build:
     name: Go Build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./directory
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -97,7 +99,6 @@ jobs:
           version: '3.x'
 
       - name: Install Dependencies
-        working-directory: ./directory
         run: |
           go version
           go get -u github.com/kevinburke/go-bindata/...
@@ -112,9 +113,7 @@ jobs:
           path: trisa
 
       - name: Code Generation
-        working-directory: ./directory
         run: go generate ./...
 
       - name: Build
-        working-directory: ./directory
         run: go build ./cmd/...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          path: ./directory
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -45,6 +47,7 @@ jobs:
           version: '3.x'
 
       - name: Install Dependencies
+        working-directory: ./directory
         run: |
           go version
           go get -u github.com/kevinburke/go-bindata/...
@@ -56,15 +59,18 @@ jobs:
         with:
           repository: trisacrypto/trisa
           ref: main
-          path: ../
+          path: trisa
 
       - name: Code Generation
+        working-directory: ./directory
         run: go generate ./...
 
       - name: Run Unit Tests
+        working-directory: ./directory
         run: go test -v -coverprofile=coverage.txt -covermode=atomic --race ./...
 
       - name: Upload Coverage report to CodeCov
+        working-directory: ./directory
         uses: codecov/codecov-action@v1.0.0
         with:
           # Make sure to add to GitHub secrets!
@@ -82,6 +88,8 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          path: ./directory
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -89,6 +97,7 @@ jobs:
           version: '3.x'
 
       - name: Install Dependencies
+        working-directory: ./directory
         run: |
           go version
           go get -u github.com/kevinburke/go-bindata/...
@@ -100,10 +109,12 @@ jobs:
         with:
           repository: trisacrypto/trisa
           ref: main
-          path: ../
+          path: trisa
 
       - name: Code Generation
+        working-directory: ./directory
         run: go generate ./...
 
       - name: Build
+        working-directory: ./directory
         run: go build ./cmd/...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Clone TRISA repository
         uses: actions/checkout@main
         with:
-          name: trisacrypto/trisa
+          repository: trisacrypto/trisa
 
       - name: Code Generation
         run: go generate ./...
@@ -96,7 +96,7 @@ jobs:
       - name: Clone TRISA repository
         uses: actions/checkout@main
         with:
-          name: trisacrypto/trisa
+          repository: trisacrypto/trisa
 
       - name: Code Generation
         run: go generate ./...

--- a/proto/gds/models/v1/models.proto
+++ b/proto/gds/models/v1/models.proto
@@ -16,7 +16,7 @@ message CertificateRequest {
 
     // VASP information for the request
     string vasp = 2;
-    string common_name = 4;
+    string common_name = 3;
 
     // Request pipeline status
     CertificateRequestState status = 4;

--- a/proto/gds/models/v1/models.proto
+++ b/proto/gds/models/v1/models.proto
@@ -16,7 +16,7 @@ message CertificateRequest {
 
     // VASP information for the request
     string vasp = 2;
-    string common_name = 3;
+    string common_name = 4;
 
     // Request pipeline status
     CertificateRequestState status = 4;


### PR DESCRIPTION
This adds a code generation step to the GitHub workflow to verify that the protocol buffers build correctly. This has a dependency on the trisacrypto/trisa repo so that repository is checked out to a separate directory before doing the generation.