### PR TITLE
sc-3009 sectigo cert profiles tests

### DIFF
--- a/pkg/sectigo/sectigo_test.go
+++ b/pkg/sectigo/sectigo_test.go
@@ -112,7 +112,11 @@ func (s *SectigoTestSuite) refresh(t *testing.T) {
 }
 
 func (s *SectigoTestSuite) createSingleCertBatch(t *testing.T) {
-	rep, err := s.api.CreateSingleCertBatch(42, "foo", map[string]string{"foo": "bar"})
+	rep, err := s.api.CreateSingleCertBatch(42, "foo", map[string]string{
+		"commonName":     "foo",
+		"dNSName":        "foo.example.com",
+		"pkcs12Password": "bar",
+	})
 	require.NoError(t, err)
 	require.NotNil(t, rep)
 }


### PR DESCRIPTION
This adds some tests for the certificate manager to verify that we are building the sectigo request parameters properly. In order to do this, some validation code was added to the sectigo mock which checks if the provided parameters match the required parameters for `ProfileCipherTraceEndEntityCertificate` and `ProfileCipherTraceEE`.