### PR TITLE
Fix docker compose for grpc-web

### DIFF
--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -71,6 +71,7 @@ services:
     ports:
       - 8080:8080
     profiles:
+      - proxy
       - api
       - all
 
@@ -79,7 +80,7 @@ services:
       context: ../
       dockerfile: ./containers/gds-ui/Dockerfile
       args:
-        REACT_APP_GDS_API_ENDPOINT: http://localhost:8080/
+        REACT_APP_GDS_API_ENDPOINT: http://localhost:8080
         REACT_APP_GDS_IS_TESTNET: "true"
         REACT_APP_ANALYTICS_ID: ${REACT_APP_ANALYTICS_ID}
     image: trisa/gds-ui

--- a/containers/grpc-proxy/Dockerfile
+++ b/containers/grpc-proxy/Dockerfile
@@ -1,2 +1,2 @@
-FROM envoyproxy/envoy-dev:933e67a9ecac814839f514fb5c31c78f3d33e5fe
+FROM envoyproxy/envoy-dev:cc089aa5b162c711e7b7767e9b02c08eb238677a
 COPY containers/grpc-proxy/envoy.yaml /etc/envoy/envoy.yaml

--- a/containers/grpc-proxy/envoy.yaml
+++ b/containers/grpc-proxy/envoy.yaml
@@ -1,3 +1,8 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
 static_resources:
   listeners:
   - name: listener_0
@@ -5,8 +10,9 @@ static_resources:
       socket_address: { address: 0.0.0.0, port_value: 8080 }
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
-        config:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -14,26 +20,36 @@ static_resources:
             virtual_hosts:
             - name: local_service
               domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route:
+                  cluster: gds
+                  timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               cors:
                 allow_origin_string_match:
-                - safe_regex:
-                    google_re2: {}
-                    regex: \*
+                - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
-              routes:
-              - match: { prefix: "/" }
-                route: { cluster: gds }
           http_filters:
-          - name: envoy.grpc_web
-          - name: envoy.cors
-          - name: envoy.router
+          - name: envoy.filters.http.grpc_web
+          - name: envoy.filters.http.cors
+          - name: envoy.filters.http.router
   clusters:
   - name: gds
     connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: gds, port_value: 4433 }}]
+    load_assignment:
+      cluster_name: cluster_0
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: gds
+                    port_value: 4433


### PR DESCRIPTION
This is a fix for the `"unknown service /trisa.gds.api.v1beta1.DirectoryService"` error when running the GDS UI with grpc-web in docker compose. The problem was a trailing slash in the `REACT_APP_GDS_API_ENDPOINT: http://localhost:8080/` configuration - no trailing slashes allowed!

Thanks to: https://stackoverflow.com/questions/54994392/how-do-i-set-up-an-envoy-proxy-in-minikube-for-a-grpc-service for helping me finally unlock things. 

In my attempt to fix things, I think I've ended up with a newer (maybe) envoy config and docker image. I still need to verify that this will work on k8s. 