### PR TITLE
Increase expiration time for cookies

### DIFF
--- a/pkg/gds/admin/v2/csurf.go
+++ b/pkg/gds/admin/v2/csurf.go
@@ -66,7 +66,7 @@ func SetDoubleCookieTokens(c *gin.Context, domain string, exp int64) error {
 	}
 
 	// Compute max age from the expires unix timestamp of the refresh token.
-	maxAge := int((time.Until(time.Unix(exp, 0))).Seconds()) + 1
+	maxAge := int((time.Until(time.Unix(exp, 0))).Seconds()) + 60
 
 	// Set the reference cookie
 	c.SetCookie(CSRFReferenceCookie, token, maxAge, "/", domain, true, true)


### PR DESCRIPTION
This PR attempts to resolve the "no csrf token cookie in request" warning message. After a bit of research, our best guess is that it is an expiration issue, so we are slightly increasing the time allotment to see if it has an impact.