### PR TITLE
Trtl Anti-Entropy refinement

### DIFF
--- a/pkg/trtl/metrics/metrics.go
+++ b/pkg/trtl/metrics/metrics.go
@@ -149,20 +149,20 @@ func initMetrics() {
 	PmAEVersions = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: PmNamespace,
 		Name:      "versions",
-		Help:      "count of all observed versions, labeled by peer and region",
-	}, []string{"peer", "region"})
+		Help:      "count of all observed versions, labeled by peer, region, and perspective",
+	}, []string{"peer", "region", "perspective"})
 
 	PmAERepairs = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: PmNamespace,
 		Name:      "pulls",
-		Help:      "pulled objects during anti entropy, labeled by peer and region",
-	}, []string{"peer", "region"})
+		Help:      "pulled objects during anti entropy, labeled by peer, region, and perspective",
+	}, []string{"peer", "region", "perspective"})
 
 	PmAEUpdates = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: PmNamespace,
 		Name:      "pushes",
-		Help:      "pushed objects during anti entropy, labeled by peer and region",
-	}, []string{"peer", "region"})
+		Help:      "pushed objects during anti entropy, labeled by peer, region and perspective",
+	}, []string{"peer", "region", "perspective"})
 
 	PmAEStomps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: PmNamespace,

--- a/pkg/trtl/replica/sync.go
+++ b/pkg/trtl/replica/sync.go
@@ -504,6 +504,7 @@ gossip:
 				log.Info().
 					Uint64("local_repairs", repairs).
 					Uint64("remote_updates", updates).
+					Uint64("versions", versions).
 					Msg("anti-entropy synchronization complete")
 			} else {
 				log.Debug().Msg("anti-entropy complete with no synchronization")
@@ -515,9 +516,9 @@ gossip:
 			log.Trace().Msg("initiator phase 2 complete")
 
 			// Update Prometheus metrics
-			prom.PmAEVersions.WithLabelValues(r.conf.Name, r.conf.Region).Observe(float64(versions))
-			prom.PmAEUpdates.WithLabelValues(r.conf.Name, r.conf.Region).Observe(float64(updates))
-			prom.PmAERepairs.WithLabelValues(r.conf.Name, r.conf.Region).Observe(float64(repairs))
+			prom.PmAEVersions.WithLabelValues(r.conf.Name, r.conf.Region, "initiator").Observe(float64(versions))
+			prom.PmAEUpdates.WithLabelValues(r.conf.Name, r.conf.Region, "initiator").Observe(float64(updates))
+			prom.PmAERepairs.WithLabelValues(r.conf.Name, r.conf.Region, "initiator").Observe(float64(repairs))
 
 			return
 


### PR DESCRIPTION
In the interest of assisting with some anti entropy debugging, this PR adds new sync message for each case inside sync.go as well as version logging and a "perspective" parameter for version, update, and repair metrics in prometheus.