### PR TITLE
Defines BFF API v1

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"context"
+	"time"
+)
+
+//===========================================================================
+// Service Interface
+//===========================================================================
+
+type BFFClient interface {
+	Status(ctx context.Context) (out *StatusReply, err error)
+}
+
+//===========================================================================
+// Top Level Requests and Responses
+//===========================================================================
+
+// Reply contains standard fields that are used for generic API responses and errors
+type Reply struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+// StatusReply is returned on status requests. Note that no request is needed.
+type StatusReply struct {
+	Status    string    `json:"status"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Version   string    `json:"version,omitempty"`
+}

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"time"
+)
+
+// New creates a new api.v1 API client that implements the BFF interface.
+func New(endpoint string) (_ BFFClient, err error) {
+	c := &APIv1{
+		client: &http.Client{
+			Transport:     nil,
+			CheckRedirect: nil,
+			Timeout:       30 * time.Second,
+		},
+	}
+
+	// Create cookie jar
+	if c.client.Jar, err = cookiejar.New(nil); err != nil {
+		return nil, fmt.Errorf("could not create cookiejar: %s", err)
+	}
+
+	if c.endpoint, err = url.Parse(endpoint); err != nil {
+		return nil, fmt.Errorf("could not parse endpoint: %s", err)
+	}
+	return c, nil
+}
+
+// APIv1 implements the BFFClient interface.
+type APIv1 struct {
+	endpoint *url.URL
+	client   *http.Client
+}
+
+// Ensure the API implments the BFFClient interface.
+var _ BFFClient = &APIv1{}
+
+//===========================================================================
+// Client Methods
+//===========================================================================
+
+func (s *APIv1) Status(ctx context.Context) (out *StatusReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/status", nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	// NOTE: cannot use s.Do because we want to parse 503 Unavailable errors
+	var rep *http.Response
+	if rep, err = s.client.Do(req); err != nil {
+		return nil, fmt.Errorf("could not execute request: %s", err)
+	}
+	defer rep.Body.Close()
+
+	// Detect other errors
+	if rep.StatusCode != http.StatusOK && rep.StatusCode != http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("[%d] %s", rep.StatusCode, rep.Status)
+	}
+
+	// Deserialize the JSON data from the response
+	out = &StatusReply{}
+	if err = json.NewDecoder(rep.Body).Decode(out); err != nil {
+		return nil, fmt.Errorf("could not deserialize StatusReply: %s", err)
+	}
+	return out, nil
+}
+
+//===========================================================================
+// Helper Methods
+//===========================================================================
+
+const (
+	userAgent    = "GDS BFF API Client/v1"
+	accept       = "application/json"
+	acceptLang   = "en-US,en"
+	acceptEncode = "gzip, deflate, br"
+	contentType  = "application/json; charset=utf-8"
+)
+
+// NewRequest creates an http.Request with the specified context and method, resolving
+// the path to the root endpoint of the API (e.g. /v2) and serializes the data to JSON.
+// This method also sets the default headers of all GDS Admin API v2 client requests.
+func (s *APIv1) NewRequest(ctx context.Context, method, path string, data interface{}, params *url.Values) (req *http.Request, err error) {
+	// Resolve the URL reference from the path
+	endpoint := s.endpoint.ResolveReference(&url.URL{Path: path})
+	if params != nil && len(*params) > 0 {
+		endpoint.RawQuery = params.Encode()
+	}
+
+	var body io.ReadWriter
+	if data != nil {
+		body = &bytes.Buffer{}
+		if err = json.NewEncoder(body).Encode(data); err != nil {
+			return nil, fmt.Errorf("could not serialize request data: %s", err)
+		}
+	} else {
+		body = nil
+	}
+
+	// Create the http request
+	if req, err = http.NewRequestWithContext(ctx, method, endpoint.String(), body); err != nil {
+		return nil, fmt.Errorf("could not create request: %s", err)
+	}
+
+	// Set the headers on the request
+	req.Header.Add("User-Agent", userAgent)
+	req.Header.Add("Accept", accept)
+	req.Header.Add("Accept-Language", acceptLang)
+	req.Header.Add("Accept-Encoding", acceptEncode)
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// Do executes an http request against the server, performs error checking, and
+// deserializes the response data into the specified struct if requested.
+func (s *APIv1) Do(req *http.Request, data interface{}, checkStatus bool) (rep *http.Response, err error) {
+	if rep, err = s.client.Do(req); err != nil {
+		return rep, fmt.Errorf("could not execute request: %s", err)
+	}
+	defer rep.Body.Close()
+
+	// Detect errors if they've occurred
+	if checkStatus {
+		if rep.StatusCode < 200 || rep.StatusCode >= 300 {
+			// Attempt to read the error response from the JSON, ignore body
+			// deserialization or read errors and simply return the status error.
+			var reply Reply
+			if err = json.NewDecoder(rep.Body).Decode(&reply); err == nil {
+				if reply.Error != "" {
+					return rep, fmt.Errorf("[%d] %s", rep.StatusCode, reply.Error)
+				}
+			}
+			return rep, errors.New(rep.Status)
+		}
+	}
+
+	// Check the content type to ensure data deserialization is possible
+	if ct := rep.Header.Get("Content-Type"); ct != contentType {
+		return rep, fmt.Errorf("unexpected content type: %q", ct)
+	}
+
+	// Deserialize the JSON data from the body
+	if data != nil && rep.StatusCode >= 200 && rep.StatusCode < 300 {
+		if err = json.NewDecoder(rep.Body).Decode(data); err != nil {
+			return nil, fmt.Errorf("could not deserialize response data: %s", err)
+		}
+	}
+
+	return rep, nil
+}

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -1,0 +1,109 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
+)
+
+func TestClient(t *testing.T) {
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			require.Equal(t, int64(0), r.ContentLength)
+			w.Header().Add("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, "{\"hello\":\"world\"}")
+			return
+		}
+
+		require.Equal(t, int64(18), r.ContentLength)
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintln(w, "{\"error\":\"bad request\"}")
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err)
+
+	// Ensure that the latest version of the client is returned
+	bffv1, ok := client.(*api.APIv1)
+	require.True(t, ok)
+
+	// Create a new GET request to a basic path
+	req, err := bffv1.NewRequest(context.TODO(), http.MethodGet, "/foo", nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "/foo", req.URL.Path)
+	require.Equal(t, "", req.URL.RawQuery)
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, "GDS BFF API Client/v1", req.Header.Get("User-Agent"))
+	require.Equal(t, "application/json", req.Header.Get("Accept"))
+	require.Equal(t, "application/json; charset=utf-8", req.Header.Get("Content-Type"))
+
+	// Create a new GET request with query params
+	params := url.Values{}
+	params.Add("q", "searching")
+	params.Add("key", "open says me")
+	req, err = bffv1.NewRequest(context.TODO(), http.MethodGet, "/foo", nil, &params)
+	require.NoError(t, err)
+	require.Equal(t, "key=open+says+me&q=searching", req.URL.RawQuery)
+
+	data := make(map[string]string)
+	rep, err := bffv1.Do(req, &data, true)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rep.StatusCode)
+	require.Contains(t, data, "hello")
+	require.Equal(t, "world", data["hello"])
+
+	// Create a new POST request and check error handling
+	req, err = bffv1.NewRequest(context.TODO(), http.MethodPost, "/bar", data, nil)
+	require.NoError(t, err)
+	rep, err = bffv1.Do(req, nil, false)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, rep.StatusCode)
+
+	req, err = bffv1.NewRequest(context.TODO(), http.MethodPost, "/bar", data, nil)
+	require.NoError(t, err)
+	_, err = bffv1.Do(req, nil, true)
+	require.EqualError(t, err, "[400] bad request")
+}
+
+func TestStatus(t *testing.T) {
+	fixture := &api.StatusReply{
+		Status:    "ok",
+		Timestamp: time.Now(),
+		Version:   "1.0.test",
+	}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/status", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err)
+
+	out, err := client.Status(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, fixture.Status, out.Status)
+	require.True(t, fixture.Timestamp.Equal(out.Timestamp))
+	require.Equal(t, fixture.Version, out.Version)
+}

--- a/pkg/bff/api/v1/errors.go
+++ b/pkg/bff/api/v1/errors.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	unsuccessful = Reply{Success: false}
+	notFound     = Reply{Success: false, Error: "resource not found"}
+	notAllowed   = Reply{Success: false, Error: "method not allowed"}
+)
+
+// ErrorResponse constructs an new response from the error or returns a success: false.
+func ErrorResponse(err interface{}) Reply {
+	if err == nil {
+		return unsuccessful
+	}
+
+	rep := Reply{Success: false}
+	switch err := err.(type) {
+	case error:
+		rep.Error = err.Error()
+	case string:
+		rep.Error = err
+	case fmt.Stringer:
+		rep.Error = err.String()
+	case json.Marshaler:
+		data, e := err.MarshalJSON()
+		if e != nil {
+			panic(err)
+		}
+		rep.Error = string(data)
+	default:
+		rep.Error = "unhandled error response"
+	}
+
+	return rep
+}
+
+// NotFound returns a JSON 404 response for the API.
+func NotFound(c *gin.Context) {
+	c.JSON(http.StatusNotFound, notFound)
+}
+
+// NotAllowed returns a JSON 405 response for the API.
+func NotAllowed(c *gin.Context) {
+	c.JSON(http.StatusMethodNotAllowed, notAllowed)
+}

--- a/pkg/bff/api/v1/errors_test.go
+++ b/pkg/bff/api/v1/errors_test.go
@@ -1,0 +1,45 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	. "github.com/trisacrypto/directory/pkg/gds/admin/v2"
+)
+
+func TestNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(r)
+	NotFound(ctx)
+
+	result := r.Result()
+	defer result.Body.Close()
+	require.Equal(t, result.StatusCode, http.StatusNotFound)
+	require.Equal(t, "application/json; charset=utf-8", result.Header.Get("Content-Type"))
+
+	var data map[string]interface{}
+	err := json.NewDecoder(result.Body).Decode(&data)
+	require.NoError(t, err)
+
+}
+
+func TestNotAllowed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(r)
+	NotAllowed(ctx)
+
+	result := r.Result()
+	defer result.Body.Close()
+	require.Equal(t, result.StatusCode, http.StatusMethodNotAllowed)
+	require.Equal(t, "application/json; charset=utf-8", result.Header.Get("Content-Type"))
+
+	var data map[string]interface{}
+	err := json.NewDecoder(result.Body).Decode(&data)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR defines the GDS BFF v1 API. The purpose of this package is to define the JSON data structures for requests and responses in the v1 API. It also implements a BFFClient which is used in testing and can also be used from a CLI implementation, though we have no plans to implement a CLI except for debugging and development. 

This package mirrors the `admin/v2` package, though it does omit the authentication and credentials components. The BFF epic currently has no authenticated endpoints, so I figured we'd save this until it was required for the GDS User UI.