### PR TITLE
Implements GDS BFF Configuration

### DIFF
--- a/pkg/bff/config/config.go
+++ b/pkg/bff/config/config.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/rs/zerolog"
+	"github.com/trisacrypto/directory/pkg/utils/logger"
+)
+
+// Config uses envconfig to load the required settings from the environment, parse and
+// validate them in preparation for running the GDS BFF API service.
+type Config struct {
+	Maintenance bool                `split_words:"true" default:"false"`
+	BindAddr    string              `split_words:"true" default:":4437"`
+	Mode        string              `split_words:"true" default:"release"`
+	LogLevel    logger.LevelDecoder `split_words:"true" default:"info"`
+	ConsoleLog  bool                `split_words:"true" default:"false"`
+	processed   bool
+}
+
+// New creates a new Config object from environment variables prefixed with GDS_BFF.
+func New() (conf Config, err error) {
+	if err = envconfig.Process("gds_bff", &conf); err != nil {
+		return Config{}, err
+	}
+
+	// Validate the configuration
+	if err = conf.Validate(); err != nil {
+		return Config{}, err
+	}
+
+	conf.processed = true
+	return conf, nil
+}
+
+func (c Config) GetLogLevel() zerolog.Level {
+	return zerolog.Level(c.LogLevel)
+}
+
+func (c Config) IsZero() bool {
+	return !c.processed
+}
+
+// Mark a manually constructed as processed as long as it is validated.
+func (c Config) Mark() (Config, error) {
+	if err := c.Validate(); err != nil {
+		return c, err
+	}
+	c.processed = true
+	return c, nil
+}
+
+// Validate the config to make sure that it is usable to run the GDS BFF server.
+func (c Config) Validate() error {
+	if c.Mode != gin.ReleaseMode && c.Mode != gin.DebugMode && c.Mode != gin.TestMode {
+		return fmt.Errorf("%q is not a valid gin mode", c.Mode)
+	}
+	return nil
+}

--- a/pkg/bff/config/config_test.go
+++ b/pkg/bff/config/config_test.go
@@ -1,0 +1,78 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/bff/config"
+)
+
+var testEnv = map[string]string{
+	"GDS_BFF_MAINTENANCE": "false",
+	"GDS_BFF_BIND_ADDR":   "8080",
+	"GDS_BFF_MODE":        "debug",
+	"GDS_BFF_LOG_LEVEL":   "debug",
+	"GDS_BFF_CONSOLE_LOG": "true",
+}
+
+func TestConfig(t *testing.T) {
+	// Set required environment variables and cleanup after
+	prevEnv := curEnv()
+	t.Cleanup(func() {
+		for key, val := range prevEnv {
+			if val != "" {
+				os.Setenv(key, val)
+			} else {
+				os.Unsetenv(key)
+			}
+		}
+	})
+	setEnv()
+
+	conf, err := config.New()
+	require.NoError(t, err)
+	require.False(t, conf.IsZero())
+
+	require.False(t, conf.Maintenance)
+	require.Equal(t, testEnv["GDS_BFF_BIND_ADDR"], conf.BindAddr)
+	require.Equal(t, testEnv["GDS_BFF_MODE"], conf.Mode)
+	require.Equal(t, zerolog.DebugLevel, conf.GetLogLevel())
+	require.True(t, conf.ConsoleLog)
+}
+
+// Returns the current environment for the specified keys, or if no keys are specified
+// then returns the current environment for all keys in testEnv.
+func curEnv(keys ...string) map[string]string {
+	env := make(map[string]string)
+	if len(keys) > 0 {
+		for _, envvar := range keys {
+			if val, ok := os.LookupEnv(envvar); ok {
+				env[envvar] = val
+			}
+		}
+	} else {
+		for key := range testEnv {
+			env[key] = os.Getenv(key)
+		}
+	}
+
+	return env
+}
+
+// Sets the environment variable from the testEnv, if no keys are specified, then sets
+// all environment variables from the test env.
+func setEnv(keys ...string) {
+	if len(keys) > 0 {
+		for _, key := range keys {
+			if val, ok := testEnv[key]; ok {
+				os.Setenv(key, val)
+			}
+		}
+	} else {
+		for key, val := range testEnv {
+			os.Setenv(key, val)
+		}
+	}
+}

--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -77,6 +77,7 @@ func TestConfig(t *testing.T) {
 
 	conf, err := config.New()
 	require.NoError(t, err)
+	require.False(t, conf.IsZero())
 
 	// Test configuration set from the environment
 	require.Equal(t, false, conf.Maintenance)


### PR DESCRIPTION
Implements the GDS BFF configuration including loading the configuration from the environment, some basic Gin server configs such as mode, log level, and bind addr, validation, mark, iszero, and some quick sanity-check tests. 

Blocked by #378 