### PR TITLE
BFF Tests and Mock GDS

### DIFF
--- a/pkg/bff/mock/gds.go
+++ b/pkg/bff/mock/gds.go
@@ -1,0 +1,125 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/trisacrypto/directory/pkg/bff/config"
+	"github.com/trisacrypto/directory/pkg/utils/bufconn"
+	gds "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
+	"google.golang.org/grpc"
+)
+
+const bufSize = 1024 * 1024
+
+func NewGDS(conf config.DirectoryConfig) (g *GDS, err error) {
+	g = &GDS{
+		srv:   grpc.NewServer(),
+		sock:  bufconn.New(bufSize),
+		Calls: make(map[string]uint32),
+	}
+
+	gds.RegisterTRISADirectoryServer(g.srv, g)
+	go g.srv.Serve(g.sock.Listener)
+	return g, nil
+}
+
+// GDS implements a mock gRPC server that listens on a buffconc and registers the
+// TRISA directory service. The RPC methods are able to be set from individual tests
+// so that the user can specify the return of the RPC in order to test specific
+// functionality. The mock allows us to test dual GDS (TestNet and MainNet) handling
+// from the BFF without having to set up a whole microservices architecture with data
+// storage and managing fixtures.
+//
+// To set the response of the mock for a particular test, update the GDS OnRPC method.
+// e.g. to mock the Register RPC, set the OnRegister method. The number of calls to the
+// RPC will be recorded to verifiy that the service is being called correctly. Use the
+// Reset method to remove all RPC handlers and set calls back to 0.
+//
+// NOTE: this mock is not safe for concurrent use.
+// NOTE: if the OnRPC function is not set, the test will panic
+type GDS struct {
+	gds.UnimplementedTRISADirectoryServer
+	sock            *bufconn.GRPCListener
+	srv             *grpc.Server
+	client          gds.TRISADirectoryClient
+	Calls           map[string]uint32
+	OnRegister      func(context.Context, *gds.RegisterRequest) (*gds.RegisterReply, error)
+	OnLookup        func(context.Context, *gds.LookupRequest) (*gds.LookupReply, error)
+	OnSearch        func(context.Context, *gds.SearchRequest) (*gds.SearchReply, error)
+	OnVerification  func(context.Context, *gds.VerificationRequest) (*gds.VerificationReply, error)
+	OnVerifyContact func(context.Context, *gds.VerifyContactRequest) (*gds.VerifyContactReply, error)
+	OnStatus        func(context.Context, *gds.HealthCheck) (*gds.ServiceState, error)
+}
+
+func (g *GDS) Client() (client gds.TRISADirectoryClient, err error) {
+	if g.client == nil {
+		if err = g.sock.Connect(); err != nil {
+			return nil, err
+		}
+		g.client = gds.NewTRISADirectoryClient(g.sock.Conn)
+	}
+	return g.client, nil
+}
+
+func (g *GDS) Shutdown() {
+	// Close the connection that any clients may have opened
+	if g.sock.Conn != nil {
+		g.sock.Close()
+		g.sock.Conn = nil
+	}
+
+	// Stop the gRPC server
+	g.srv.GracefulStop()
+
+	// Release the buffcon
+	if g.sock != nil {
+		g.sock.Release()
+		g.sock = nil
+	}
+}
+
+func (g *GDS) Reset() {
+	// Set the calls to 0
+	for key := range g.Calls {
+		g.Calls[key] = 0
+	}
+
+	// Reset all of the gRPC methods to ensure that an RPC from a previous test doesn't
+	// interfere with the operation of a current test.
+	g.OnRegister = nil
+	g.OnLookup = nil
+	g.OnSearch = nil
+	g.OnVerification = nil
+	g.OnVerifyContact = nil
+	g.OnStatus = nil
+}
+
+func (g *GDS) Register(ctx context.Context, in *gds.RegisterRequest) (*gds.RegisterReply, error) {
+	g.Calls["Register"]++
+	return g.OnRegister(ctx, in)
+}
+
+func (g *GDS) Lookup(ctx context.Context, in *gds.LookupRequest) (*gds.LookupReply, error) {
+	g.Calls["Lookup"]++
+	return g.OnLookup(ctx, in)
+}
+
+func (g *GDS) Search(ctx context.Context, in *gds.SearchRequest) (*gds.SearchReply, error) {
+	g.Calls["Search"]++
+	return g.OnSearch(ctx, in)
+}
+
+func (g *GDS) Verification(ctx context.Context, in *gds.VerificationRequest) (*gds.VerificationReply, error) {
+	g.Calls["Verification"]++
+	return g.OnVerification(ctx, in)
+}
+
+func (g *GDS) VerifyContact(ctx context.Context, in *gds.VerifyContactRequest) (*gds.VerifyContactReply, error) {
+	g.Calls["VerifyContact"]++
+	return g.OnVerifyContact(ctx, in)
+}
+
+func (g *GDS) Status(ctx context.Context, in *gds.HealthCheck) (*gds.ServiceState, error) {
+	g.Calls["Status"]++
+	return g.OnStatus(ctx, in)
+}

--- a/pkg/bff/server_test.go
+++ b/pkg/bff/server_test.go
@@ -1,0 +1,89 @@
+package bff_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/suite"
+	"github.com/trisacrypto/directory/pkg/bff"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
+	"github.com/trisacrypto/directory/pkg/bff/config"
+	"github.com/trisacrypto/directory/pkg/bff/mock"
+	"github.com/trisacrypto/directory/pkg/utils/logger"
+)
+
+// The BFF Test Suite provides mock functionality and fixtures for running BFF tests
+// that expect to interact with two GDS services: TestNet and MainNet.
+type bffTestSuite struct {
+	suite.Suite
+	bff     *bff.Server
+	client  api.BFFClient
+	testnet *mock.GDS
+	mainnet *mock.GDS
+}
+
+func (s *bffTestSuite) SetupSuite() {
+	var err error
+	require := s.Require()
+
+	// This configuration will run the BFF as a fully functional server on an open port
+	// on the system for local loop-back only. It is also in test mode, so a Gin context
+	// can also be used to test endpoints. The BFF server runs for the duration of the
+	// tests and must be shutdown when the test suite terminates.
+	conf, err := config.Config{
+		Maintenance: false,
+		BindAddr:    "127.0.0.1:0",
+		Mode:        gin.TestMode,
+		LogLevel:    logger.LevelDecoder(zerolog.DebugLevel),
+		ConsoleLog:  true,
+		TestNet: config.DirectoryConfig{
+			Insecure: true,
+			Endpoint: "bufnet",
+			Timeout:  1 * time.Second,
+		},
+		MainNet: config.DirectoryConfig{
+			Insecure: true,
+			Endpoint: "bufnet",
+			Timeout:  1 * time.Second,
+		},
+	}.Mark()
+	require.NoError(err, "could not mark configuration")
+
+	// Create the GDS mocks for testnet and mainnet
+	s.testnet, err = mock.NewGDS(conf.TestNet)
+	require.NoError(err, "could not create testnet mock")
+
+	s.mainnet, err = mock.NewGDS(conf.MainNet)
+	require.NoError(err, "could not create mainnet mock")
+
+	s.bff, err = bff.New(conf)
+	require.NoError(err, "could not create the bff")
+
+	// Add the GDS mock clients to the BFF server
+	tnClient, err := s.testnet.Client()
+	require.NoError(err, "could not create testnet GDS client")
+	mnClient, err := s.mainnet.Client()
+	require.NoError(err, "could not create mainnet GDS client")
+	s.bff.SetClients(tnClient, mnClient)
+
+	// Start the BFF server - the goal of the BFF tests is to have the server run for
+	// the entire duration of the tests. Implement reset methods to ensure the server
+	// state doesn't change between tests.
+	go s.bff.Serve()
+
+	// Create the BFF client for making requests to the server
+	s.client, err = api.New(s.bff.GetURL())
+	require.NoError(err, "could not initialize BFF client")
+}
+
+func (s *bffTestSuite) TearDownSuite() {
+	require := s.Require()
+	err := s.bff.Shutdown()
+	require.NoError(err, "could not shutdown the BFF server after tests")
+}
+
+func TestBFF(t *testing.T) {
+	suite.Run(t, new(bffTestSuite))
+}


### PR DESCRIPTION
This PR creates the BFF test suite and implements a Mock GDS for those tests. 

The goal of the BFF tests is test the expected contract between the UI and the BFF. Therefore the following decisions were made:

1. The BFF server is run on a live, local-loopback socket similar to the Go builtin [httptest.Server](https://cs.opensource.google/go/go/+/refs/tags/go1.17.8:src/net/http/httptest/server.go;l=28;drc=refs%2Ftags%2Fgo1.17.8;bpv=1;bpt=1). This allows end-to-end HTTP testing and also allows us to use the api.v1.BFFClient for tests, which should make developement and testing simpler. To ensure that this is possible, instead of implementing `ListenAndServe`, we've implemented separate `Listen` and `Serve` steps so that we can get the URL of the server and create the client in tests.
2. Rather than attempt to run the actual GDS for both TestNet and MainNet (and have to deal with leveldb, fixtures, etc.) we've opted to mock the GDS. The MockGDS allows the BFF to specify what it expects to be returned from GDS and simplifies the testing process. This means that we may need to create integration tests between the BFF and the actual GDS in addition to unit testing, but will allow us to focus on the client to BFF interactions rather than the BFF to GDS interactions. 

Minor changes may be needed as we start to implement tests, but I think this is a solid foundation with which to start building our RPC endpoints on. 