### PR TITLE
Status Endpoint

### DIFF
--- a/cmd/bff/main.go
+++ b/cmd/bff/main.go
@@ -54,6 +54,12 @@ func main() {
 						EnvVars: []string{"GDS_BFF_CLIENT_URL"},
 						Value:   "http://localhost:4437",
 					},
+					&cli.BoolFlag{
+						Name:    "nogds",
+						Aliases: []string{"no-gds", "G"},
+						Usage:   "health check the BFF without requesting GDS status",
+						Value:   false,
+					},
 				},
 			},
 		},
@@ -100,8 +106,15 @@ func status(c *cli.Context) (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	var params *api.StatusParams
+	if c.Bool("nogds") {
+		params = &api.StatusParams{
+			NoGDS: true,
+		}
+	}
+
 	var rep *api.StatusReply
-	if rep, err = client.Status(ctx); err != nil {
+	if rep, err = client.Status(ctx, params); err != nil {
 		return cli.Exit(err, 1)
 	}
 

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -9,7 +9,7 @@ import (
 //===========================================================================
 
 type BFFClient interface {
-	Status(ctx context.Context) (out *StatusReply, err error)
+	Status(ctx context.Context, in *StatusParams) (out *StatusReply, err error)
 }
 
 //===========================================================================
@@ -22,9 +22,16 @@ type Reply struct {
 	Error   string `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
+// StatusParams is parsed from the query parameters of the GET request
+type StatusParams struct {
+	NoGDS bool `url:"nogds,omitempty" form:"nogds" default:"false"`
+}
+
 // StatusReply is returned on status requests. Note that no request is needed.
 type StatusReply struct {
 	Status  string `json:"status"`
 	Uptime  string `json:"uptime,omitempty"`
 	Version string `json:"version,omitempty"`
+	TestNet string `json:"testnet,omitempty"`
+	MainNet string `json:"mainnet,omitempty"`
 }

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 )
 
 //===========================================================================
@@ -25,7 +24,7 @@ type Reply struct {
 
 // StatusReply is returned on status requests. Note that no request is needed.
 type StatusReply struct {
-	Status    string    `json:"status"`
-	Timestamp time.Time `json:"timestamp,omitempty"`
-	Version   string    `json:"version,omitempty"`
+	Status  string `json:"status"`
+	Uptime  string `json:"uptime,omitempty"`
+	Version string `json:"version,omitempty"`
 }

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -53,7 +53,7 @@ func (s *APIv1) Status(ctx context.Context, in *StatusParams) (out *StatusReply,
 	// Create the query params from the input
 	var params url.Values
 	if params, err = query.Values(in); err != nil {
-		return nil, fmt.Errorf("could not encdoe query params: %s", err)
+		return nil, fmt.Errorf("could not encode query params: %s", err)
 	}
 
 	//  Make the HTTP request

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -11,6 +11,8 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"time"
+
+	"github.com/google/go-querystring/query"
 )
 
 // New creates a new api.v1 API client that implements the BFF interface.
@@ -47,10 +49,16 @@ var _ BFFClient = &APIv1{}
 // Client Methods
 //===========================================================================
 
-func (s *APIv1) Status(ctx context.Context) (out *StatusReply, err error) {
+func (s *APIv1) Status(ctx context.Context, in *StatusParams) (out *StatusReply, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if params, err = query.Values(in); err != nil {
+		return nil, fmt.Errorf("could not encdoe query params: %s", err)
+	}
+
 	//  Make the HTTP request
 	var req *http.Request
-	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/status", nil, nil); err != nil {
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/status", nil, &params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -101,7 +101,15 @@ func TestStatus(t *testing.T) {
 	client, err := api.New(ts.URL)
 	require.NoError(t, err)
 
-	out, err := client.Status(context.TODO())
+	// Test with nil params
+	out, err := client.Status(context.TODO(), nil)
+	require.NoError(t, err)
+	require.Equal(t, fixture.Status, out.Status)
+	require.Equal(t, fixture.Uptime, out.Uptime)
+	require.Equal(t, fixture.Version, out.Version)
+
+	// Test with params
+	out, err = client.Status(context.TODO(), &api.StatusParams{NoGDS: true})
 	require.NoError(t, err)
 	require.Equal(t, fixture.Status, out.Status)
 	require.Equal(t, fixture.Uptime, out.Uptime)

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -81,9 +81,9 @@ func TestClient(t *testing.T) {
 
 func TestStatus(t *testing.T) {
 	fixture := &api.StatusReply{
-		Status:    "ok",
-		Timestamp: time.Now(),
-		Version:   "1.0.test",
+		Status:  "ok",
+		Uptime:  (2 * time.Second).String(),
+		Version: "1.0.test",
 	}
 
 	// Create a Test Server
@@ -104,6 +104,6 @@ func TestStatus(t *testing.T) {
 	out, err := client.Status(context.TODO())
 	require.NoError(t, err)
 	require.Equal(t, fixture.Status, out.Status)
-	require.True(t, fixture.Timestamp.Equal(out.Timestamp))
+	require.Equal(t, fixture.Uptime, out.Uptime)
 	require.Equal(t, fixture.Version, out.Version)
 }

--- a/pkg/bff/mock/gds.go
+++ b/pkg/bff/mock/gds.go
@@ -15,7 +15,7 @@ func NewGDS(conf config.DirectoryConfig) (g *GDS, err error) {
 	g = &GDS{
 		srv:   grpc.NewServer(),
 		sock:  bufconn.New(bufSize),
-		Calls: make(map[string]uint32),
+		Calls: make(map[string]int),
 	}
 
 	gds.RegisterTRISADirectoryServer(g.srv, g)
@@ -42,7 +42,7 @@ type GDS struct {
 	sock            *bufconn.GRPCListener
 	srv             *grpc.Server
 	client          gds.TRISADirectoryClient
-	Calls           map[string]uint32
+	Calls           map[string]int
 	OnRegister      func(context.Context, *gds.RegisterRequest) (*gds.RegisterReply, error)
 	OnLookup        func(context.Context, *gds.LookupRequest) (*gds.LookupReply, error)
 	OnSearch        func(context.Context, *gds.SearchRequest) (*gds.SearchReply, error)

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -95,6 +95,7 @@ type Server struct {
 	router  *gin.Engine
 	testnet gds.TRISADirectoryClient
 	mainnet gds.TRISADirectoryClient
+	started time.Time
 	healthy bool
 	url     string
 	echan   chan error
@@ -127,6 +128,7 @@ func (s *Server) Serve() (err error) {
 
 	// Set the URL from the listener
 	s.url = "http://" + sock.Addr().String()
+	s.started = time.Now()
 
 	// Listen for HTTP requests on the specified address and port
 	go func() {
@@ -177,6 +179,13 @@ func (s *Server) setupRoutes() (err error) {
 	s.router.Use(ginzerolog.Logger("gin"))
 	s.router.Use(gin.Recovery())
 	s.router.Use(s.Available())
+
+	// Add the v1 API routes
+	v1 := s.router.Group("/v1")
+	{
+		// Heartbeat route (no authentication required)
+		v1.GET("/status", s.Status)
+	}
 
 	// NotFound and NotAllowed routes
 	s.router.NoRoute(api.NotFound)

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -127,7 +127,7 @@ func (s *Server) Serve() (err error) {
 	}
 
 	// Set the URL from the listener
-	s.url = "http://" + sock.Addr().String()
+	s.SetURL("http://" + sock.Addr().String())
 	s.started = time.Now()
 
 	// Listen for HTTP requests on the specified address and port
@@ -172,6 +172,13 @@ func (s *Server) SetHealth(health bool) {
 	s.healthy = health
 	s.Unlock()
 	log.Debug().Bool("healthy", health).Msg("server health set")
+}
+
+func (s *Server) SetURL(url string) {
+	s.Lock()
+	s.url = url
+	s.Unlock()
+	log.Debug().Str("url", url).Msg("server url set")
 }
 
 func (s *Server) setupRoutes() (err error) {
@@ -226,5 +233,7 @@ func (s *Server) GetMainNet() gds.TRISADirectoryClient {
 // GetURL returns the URL that the server can be reached if it has been started. This
 // accessor is primarily used to create a test client.
 func (s *Server) GetURL() string {
+	s.RLock()
+	defer s.RUnlock()
 	return s.url
 }

--- a/pkg/bff/server_test.go
+++ b/pkg/bff/server_test.go
@@ -73,9 +73,18 @@ func (s *bffTestSuite) SetupSuite() {
 	// state doesn't change between tests.
 	go s.bff.Serve()
 
+	// Wait for 500 ms to ensure the BFF starts serving
+	time.Sleep(500 * time.Millisecond)
+
 	// Create the BFF client for making requests to the server
+	require.NotEmpty(s.bff.GetURL(), "no url to connect to client on")
 	s.client, err = api.New(s.bff.GetURL())
 	require.NoError(err, "could not initialize BFF client")
+}
+
+func (s *bffTestSuite) AfterTest(suiteName, testName string) {
+	s.testnet.Reset()
+	s.mainnet.Reset()
 }
 
 func (s *bffTestSuite) TearDownSuite() {

--- a/pkg/bff/server_test.go
+++ b/pkg/bff/server_test.go
@@ -80,8 +80,9 @@ func (s *bffTestSuite) SetupSuite() {
 
 func (s *bffTestSuite) TearDownSuite() {
 	require := s.Require()
-	err := s.bff.Shutdown()
-	require.NoError(err, "could not shutdown the BFF server after tests")
+	require.NoError(s.bff.Shutdown(), "could not shutdown the BFF server after tests")
+	s.testnet.Shutdown()
+	s.mainnet.Shutdown()
 }
 
 func TestBFF(t *testing.T) {

--- a/pkg/bff/status.go
+++ b/pkg/bff/status.go
@@ -1,12 +1,17 @@
 package bff
 
 import (
+	"context"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 	"github.com/trisacrypto/directory/pkg"
 	"github.com/trisacrypto/directory/pkg/bff/api/v1"
+	gds "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
 )
 
 const (
@@ -22,6 +27,56 @@ func (s *Server) Status(c *gin.Context) {
 		Status:  serverStatusOK,
 		Version: pkg.Version(),
 		Uptime:  time.Since(s.started).String(),
+	}
+
+	// Check if the user has supplied a nogds query param
+	params := &api.StatusParams{}
+	if err := c.ShouldBindQuery(&params); err != nil {
+		log.Warn().Err(err).Msg("could not bind request with query params")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// Get the status of the TestNet and MainNet GDS servers
+	if !params.NoGDS {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			if status, err := s.testnet.Status(ctx, &gds.HealthCheck{}); err != nil {
+				log.Warn().Err(err).Str("network", "testnet").Msg("could not connect to GDS")
+				out.TestNet = "unavailable"
+			} else {
+				log.Debug().Str("network", "testnet").
+					Str("status", status.Status.String()).
+					Str("not_before", status.NotBefore).
+					Str("not_after", status.NotAfter).
+					Msg("GDS status")
+				out.TestNet = strings.ToLower(status.Status.String())
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			if status, err := s.mainnet.Status(ctx, &gds.HealthCheck{}); err != nil {
+				log.Warn().Err(err).Str("network", "mainnet").Msg("could not connect to GDS")
+				out.MainNet = "unavailable"
+			} else {
+				log.Debug().Str("network", "mainnet").
+					Str("status", status.Status.String()).
+					Str("not_before", status.NotBefore).
+					Str("not_after", status.NotAfter).
+					Msg("GDS status")
+				out.MainNet = strings.ToLower(status.Status.String())
+			}
+
+		}()
+
+		wg.Wait()
 	}
 
 	// Render the response

--- a/pkg/bff/status.go
+++ b/pkg/bff/status.go
@@ -15,6 +15,19 @@ const (
 	serverStatusMaintenance = "maintenance"
 )
 
+func (s *Server) Status(c *gin.Context) {
+	// The available middleware handles stopping and maintenance mode. If the request
+	// has come this far, the status is necessarily ok.
+	out := api.StatusReply{
+		Status:  serverStatusOK,
+		Version: pkg.Version(),
+		Uptime:  time.Since(s.started).String(),
+	}
+
+	// Render the response
+	c.JSON(http.StatusOK, out)
+}
+
 // Available is middleware that uses the healthy boolean to return a service unavailable
 // http status code if the server is shutting down. This middleware must be first in the
 // chain to ensure that complex handling to slow the shutdown of the server.
@@ -31,9 +44,9 @@ func (s *Server) Available() gin.HandlerFunc {
 			}
 
 			c.JSON(http.StatusServiceUnavailable, api.StatusReply{
-				Status:    status,
-				Timestamp: time.Now(),
-				Version:   pkg.Version(),
+				Status:  status,
+				Uptime:  time.Since(s.started).String(),
+				Version: pkg.Version(),
 			})
 
 			c.Abort()

--- a/pkg/bff/status_test.go
+++ b/pkg/bff/status_test.go
@@ -7,18 +7,93 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/trisacrypto/directory/pkg/bff"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
 	"github.com/trisacrypto/directory/pkg/bff/config"
+	gds "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *bffTestSuite) TestStatus() {
 	var err error
 	require := s.Require()
 
-	rep, err := s.client.Status(context.TODO())
+	// Set the Status RPC for the mocks
+	healthy := func(ctx context.Context, in *gds.HealthCheck) (*gds.ServiceState, error) {
+		return &gds.ServiceState{
+			Status:    gds.ServiceState_HEALTHY,
+			NotBefore: time.Now().Add(1 * time.Hour).Format(time.RFC3339Nano),
+			NotAfter:  time.Now().Format(time.RFC3339Nano),
+		}, nil
+	}
+	s.testnet.OnStatus = healthy
+	s.mainnet.OnStatus = healthy
+
+	// Test Status with nil params (should default to getting GDS status)
+	rep, err := s.client.Status(context.TODO(), nil)
 	require.NoError(err, "could not make status request")
 	require.Equal("ok", rep.Status, "server did not return an ok status")
 	require.NotEmpty(rep.Uptime, "server did not return an uptime")
 	require.NotEmpty(rep.Version, "server did not return a version")
+	require.Equal("healthy", rep.TestNet)
+	require.Equal("healthy", rep.MainNet)
+	require.Equal(s.testnet.Calls["Status"], 1)
+	require.Equal(s.mainnet.Calls["Status"], 1)
+
+	// Test Status with default params
+	rep, err = s.client.Status(context.TODO(), &api.StatusParams{NoGDS: false})
+	require.NoError(err, "could not make status request")
+	require.Equal("ok", rep.Status, "server did not return an ok status")
+	require.NotEmpty(rep.Uptime, "server did not return an uptime")
+	require.NotEmpty(rep.Version, "server did not return a version")
+	require.Equal("healthy", rep.TestNet)
+	require.Equal("healthy", rep.MainNet)
+	require.Equal(s.testnet.Calls["Status"], 2)
+	require.Equal(s.mainnet.Calls["Status"], 2)
+
+	// Test Status with NoGDS
+	rep, err = s.client.Status(context.TODO(), &api.StatusParams{NoGDS: true})
+	require.NoError(err, "could not make status request")
+	require.Equal("ok", rep.Status, "server did not return an ok status")
+	require.NotEmpty(rep.Uptime, "server did not return an uptime")
+	require.NotEmpty(rep.Version, "server did not return a version")
+	require.Empty(rep.TestNet)
+	require.Empty(rep.MainNet)
+	require.Equal(s.testnet.Calls["Status"], 2)
+	require.Equal(s.mainnet.Calls["Status"], 2)
+
+	// Test Status with TestNet Error
+	s.testnet.OnStatus = func(ctx context.Context, in *gds.HealthCheck) (*gds.ServiceState, error) {
+		return nil, status.Error(codes.Unavailable, "unreachable host")
+	}
+	rep, err = s.client.Status(context.TODO(), nil)
+	require.NoError(err, "could not make status request")
+	require.Equal("ok", rep.Status, "server did not return an ok status")
+	require.NotEmpty(rep.Uptime, "server did not return an uptime")
+	require.NotEmpty(rep.Version, "server did not return a version")
+	require.Equal("unavailable", rep.TestNet)
+	require.Equal("healthy", rep.MainNet)
+	require.Equal(s.testnet.Calls["Status"], 3)
+	require.Equal(s.mainnet.Calls["Status"], 3)
+
+	// Test Status with MainNet bad state
+	s.mainnet.OnStatus = func(ctx context.Context, in *gds.HealthCheck) (*gds.ServiceState, error) {
+		return &gds.ServiceState{
+			Status:    gds.ServiceState_DANGER,
+			NotBefore: time.Now().Add(1 * time.Hour).Format(time.RFC3339Nano),
+			NotAfter:  time.Now().Format(time.RFC3339Nano),
+		}, nil
+	}
+	rep, err = s.client.Status(context.TODO(), nil)
+	require.NoError(err, "could not make status request")
+	require.Equal("ok", rep.Status, "server did not return an ok status")
+	require.NotEmpty(rep.Uptime, "server did not return an uptime")
+	require.NotEmpty(rep.Version, "server did not return a version")
+	require.Equal("unavailable", rep.TestNet)
+	require.Equal("danger", rep.MainNet)
+	require.Equal(s.testnet.Calls["Status"], 4)
+	require.Equal(s.mainnet.Calls["Status"], 4)
+
 }
 
 func (s *bffTestSuite) TestAvailableMiddleware() {
@@ -30,7 +105,7 @@ func (s *bffTestSuite) TestAvailableMiddleware() {
 	defer s.bff.SetHealth(true)
 
 	// Perform a status request, the Available middleware should intercept and return "stopping"
-	rep, err := s.client.Status(context.TODO())
+	rep, err := s.client.Status(context.TODO(), nil)
 	require.NoError(err, "an error was returned from the status endpoint")
 	require.Equal("stopping", rep.Status, "incorrect response from unhealthy server")
 }

--- a/pkg/bff/status_test.go
+++ b/pkg/bff/status_test.go
@@ -1,0 +1,72 @@
+package bff_test
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/trisacrypto/directory/pkg/bff"
+	"github.com/trisacrypto/directory/pkg/bff/config"
+)
+
+func (s *bffTestSuite) TestStatus() {
+	var err error
+	require := s.Require()
+
+	rep, err := s.client.Status(context.TODO())
+	require.NoError(err, "could not make status request")
+	require.Equal("ok", rep.Status, "server did not return an ok status")
+	require.NotEmpty(rep.Uptime, "server did not return an uptime")
+	require.NotEmpty(rep.Version, "server did not return a version")
+}
+
+func (s *bffTestSuite) TestAvailableMiddleware() {
+	var err error
+	require := s.Require()
+
+	// Set the health to false to mimic the server stopping
+	s.bff.SetHealth(false)
+	defer s.bff.SetHealth(true)
+
+	// Perform a status request, the Available middleware should intercept and return "stopping"
+	rep, err := s.client.Status(context.TODO())
+	require.NoError(err, "an error was returned from the status endpoint")
+	require.Equal("stopping", rep.Status, "incorrect response from unhealthy server")
+}
+
+func (s *bffTestSuite) TestMaintenanceMode() {
+	require := s.Require()
+
+	// To test maintenance mode, we need to create a BFF server that is in maintenance
+	// mode, which means we cannot use the BFF fixture created during SetupSuite.
+	// A minimal maintenance mode configuration.
+	conf, err := config.Config{
+		Maintenance: true,
+		Mode:        gin.TestMode,
+		TestNet:     config.DirectoryConfig{Endpoint: "bufcon"},
+		MainNet:     config.DirectoryConfig{Endpoint: "bufcon"},
+	}.Mark()
+	require.NoError(err, "configuration is not valid")
+
+	// Run the maintenance mode server
+	server, err := bff.New(conf)
+	require.NoError(err, "could not create maintenance mode server")
+	go server.Serve()
+	defer server.Shutdown()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Create an http client that sends GET requests to random endpoints, all requests
+	// should return a 503 error indicating that the service is unavailable.
+	client := &http.Client{}
+
+	for _, path := range []string{"/", "/v1", "/v1/", "/v1/status", "/v1/register", "/status"} {
+		url := server.GetURL() + path
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(err, "could not make HTTP request")
+		rep, err := client.Do(req)
+		require.NoError(err, "could not execute HTTP request")
+		require.Equal(http.StatusServiceUnavailable, rep.StatusCode, "expected unavailable status")
+	}
+}


### PR DESCRIPTION
Implements the Status endpoint and our first BFF API Tests that interact with the GDS nodes.

TODO: 

- [x] Implement `nogds` flag
- [x] Make status requests to GDS in two go routines
- [x] Test with Mock GDS status requests