### PR TITLE
BFF Lookup Endpoint

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -47,7 +47,7 @@ type LookupParams struct {
 	CommonName string `url:"common_name,omitempty" form:"common_name"`
 }
 
-// LookupReply can return 1..2 results either one result found from one directory
+// LookupReply can return 1-2 results either one result found from one directory
 // service or results found from both TestNet and MainNet. If no results are found, the
 // Lookup endpoint returns a 404 error (not found). The result is the simplest case,
 // just a JSON serialization of the protocol buffers returned from GDS to help long term

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -10,6 +10,7 @@ import (
 
 type BFFClient interface {
 	Status(ctx context.Context, in *StatusParams) (out *StatusReply, err error)
+	Lookup(ctx context.Context, in *LookupParams) (out *LookupReply, err error)
 }
 
 //===========================================================================
@@ -34,4 +35,27 @@ type StatusReply struct {
 	Version string `json:"version,omitempty"`
 	TestNet string `json:"testnet,omitempty"`
 	MainNet string `json:"mainnet,omitempty"`
+}
+
+//===========================================================================
+// BFF v1 API Requests and Responses
+//===========================================================================
+
+// LookupParams is converted into a GDS LookupRequest.
+type LookupParams struct {
+	ID         string `url:"uuid,omitempty" form:"uuid"`
+	CommonName string `url:"common_name,omitempty" form:"common_name"`
+}
+
+// LookupReply can return 1..2 results either one result found from one directory
+// service or results found from both TestNet and MainNet. If no results are found, the
+// Lookup endpoint returns a 404 error (not found). The result is the simplest case,
+// just a JSON serialization of the protocol buffers returned from GDS to help long term
+// maintainability. The protocol buffers contain a "registered_directory" field that
+// will have either vaspdirectory.net or trisatest.net inside of it - which can be used
+// to identify which network the record is associated with. The protocol buffers may
+// also contain an "error" field - the BFF will handle this field by logging the error
+// but will exclude it from any results returned.
+type LookupReply struct {
+	Results []map[string]interface{} `json:"results"`
 }

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -83,6 +83,27 @@ func (s *APIv1) Status(ctx context.Context, in *StatusParams) (out *StatusReply,
 	return out, nil
 }
 
+func (s *APIv1) Lookup(ctx context.Context, in *LookupParams) (out *LookupReply, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if params, err = query.Values(in); err != nil {
+		return nil, fmt.Errorf("could not encode query params: %s", err)
+	}
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/lookup", nil, &params); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &LookupReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 //===========================================================================
 // Helper Methods
 //===========================================================================

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -3,6 +3,7 @@ package bff
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -17,6 +18,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	testnet = "testnet"
+	mainnet = "mainnet"
 )
 
 // ConnectGDS creates a gRPC client to the TRISA Directory Service specified in the
@@ -43,7 +49,7 @@ func ConnectGDS(conf config.DirectoryConfig) (_ gds.TRISADirectoryClient, err er
 }
 
 // Lookup makes a request on behalf of the user to both the TestNet and MainNet GDS
-// servers, returning 1..2 results (e.g. either or both GDS responses). If no results
+// servers, returning 1-2 results (e.g. either or both GDS responses). If no results
 // are returned, Lookup returns a 404 not found error. If one of the GDS requests fails,
 // the error is logged, but the valid response is returned. If both GDS requests fail,
 // a 500 error is returned. This endpoint passes through the response from GDS as JSON,
@@ -90,6 +96,19 @@ func (s *Server) Lookup(c *gin.Context) {
 				errs[idx] = err
 			}
 			return
+		}
+
+		// There is currently an error message on the reply that is unused. This check
+		// future proofs the use case where that field is returned and also ensures that
+		// an empty reply is not returned.
+		if rep.Error != nil && rep.Error.Code != 0 {
+			rerr := fmt.Errorf("[%d] %s", rep.Error.Code, rep.Error.Message)
+			log.Warn().Err(rerr).Msg("received error in response body with a gRPC status ok")
+			if rep.Id == "" && rep.CommonName == "" {
+				// If we don't have an ID or common name, don't return an empty result
+				errs[idx] = rerr
+				return
+			}
 		}
 
 		if results[idx], err = wire.Rewire(rep); err != nil {

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -3,11 +3,20 @@ package bff
 import (
 	"context"
 	"crypto/tls"
+	"net/http"
+	"sync"
+	"time"
 
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
 	"github.com/trisacrypto/directory/pkg/bff/config"
+	"github.com/trisacrypto/directory/pkg/utils/wire"
 	gds "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 )
 
 // ConnectGDS creates a gRPC client to the TRISA Directory Service specified in the
@@ -31,4 +40,96 @@ func ConnectGDS(conf config.DirectoryConfig) (_ gds.TRISADirectoryClient, err er
 		return nil, err
 	}
 	return gds.NewTRISADirectoryClient(cc), nil
+}
+
+// Lookup makes a request on behalf of the user to both the TestNet and MainNet GDS
+// servers, returning 1..2 results (e.g. either or both GDS responses). If no results
+// are returned, Lookup returns a 404 not found error. If one of the GDS requests fails,
+// the error is logged, but the valid response is returned. If both GDS requests fail,
+// a 500 error is returned. This endpoint passes through the response from GDS as JSON,
+// the result should contain a registered_directory field that identifies which network
+// the record is associated with.
+func (s *Server) Lookup(c *gin.Context) {
+	// Bind the parameters associated with the lookup
+	params := &api.LookupParams{}
+	if err := c.ShouldBindQuery(&params); err != nil {
+		log.Warn().Err(err).Msg("could not bind request with query params")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// Ensure that we have either ID or CommonName
+	if params.ID == "" && params.CommonName == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("must provide either uuid or common_name in query params"))
+		return
+	}
+
+	// Create the LookupRequest, omit registered directory as it is assumed we're
+	// looking up the value for the directory we're making the request to.
+	req := &gds.LookupRequest{Id: params.ID, CommonName: params.CommonName}
+	errs := make([]error, 2)
+	results := make([]map[string]interface{}, 2)
+
+	// Execute the request in parallel to both the testnet and the mainnet
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 25*time.Second)
+	var wg sync.WaitGroup
+	defer cancel()
+	wg.Add(2)
+
+	lookup := func(client gds.TRISADirectoryClient, idx int, name string) {
+		defer wg.Done()
+		var (
+			err error
+			rep *gds.LookupReply
+		)
+
+		if rep, err = client.Lookup(ctx, req); err != nil {
+			serr, _ := status.FromError(err)
+			if serr.Code() != codes.NotFound {
+				log.Error().Err(err).Str("network", name).Msg("GDS lookup unsuccessful")
+				errs[idx] = err
+			}
+			return
+		}
+
+		if results[idx], err = wire.Rewire(rep); err != nil {
+			log.Error().Err(err).Str("network", name).Msg("could not rewire LookupReply")
+			errs[idx] = err
+		}
+	}
+
+	go lookup(s.testnet, 0, "testnet")
+	go lookup(s.mainnet, 1, "mainnet")
+	wg.Wait()
+
+	// If there were multiple errors, return a 500
+	nErrs := 0
+	for _, err := range errs {
+		if err != nil {
+			nErrs++
+		}
+	}
+	if nErrs == 2 {
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("unable to execute Lookup request"))
+		return
+	}
+
+	// Flatten results
+	out := &api.LookupReply{
+		Results: make([]map[string]interface{}, 0, 2),
+	}
+	for _, result := range results {
+		if len(result) > 0 {
+			out.Results = append(out.Results, result)
+		}
+	}
+
+	// Check if there are results to return
+	if len(out.Results) == 0 {
+		c.JSON(http.StatusNotFound, api.ErrorResponse("no results returned for query"))
+		return
+	}
+
+	// Serialize the results and return a successful response
+	c.JSON(http.StatusOK, out)
 }

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -117,8 +117,8 @@ func (s *Server) Lookup(c *gin.Context) {
 		}
 	}
 
-	go lookup(s.testnet, 0, "testnet")
-	go lookup(s.mainnet, 1, "mainnet")
+	go lookup(s.testnet, 0, testnet)
+	go lookup(s.mainnet, 1, mainnet)
 	wg.Wait()
 
 	// If there were multiple errors, return a 500

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -192,6 +192,9 @@ func (s *Server) setupRoutes() (err error) {
 	{
 		// Heartbeat route (no authentication required)
 		v1.GET("/status", s.Status)
+
+		// GDS public routes (no authentication required)
+		v1.GET("/lookup", s.Lookup)
 	}
 
 	// NotFound and NotAllowed routes

--- a/pkg/bff/status.go
+++ b/pkg/bff/status.go
@@ -48,10 +48,10 @@ func (s *Server) Status(c *gin.Context) {
 		go func() {
 			defer wg.Done()
 			if status, err := s.testnet.Status(ctx, &gds.HealthCheck{}); err != nil {
-				log.Warn().Err(err).Str("network", "testnet").Msg("could not connect to GDS")
+				log.Warn().Err(err).Str("network", testnet).Msg("could not connect to GDS")
 				out.TestNet = "unavailable"
 			} else {
-				log.Debug().Str("network", "testnet").
+				log.Debug().Str("network", testnet).
 					Str("status", status.Status.String()).
 					Str("not_before", status.NotBefore).
 					Str("not_after", status.NotAfter).
@@ -63,10 +63,10 @@ func (s *Server) Status(c *gin.Context) {
 		go func() {
 			defer wg.Done()
 			if status, err := s.mainnet.Status(ctx, &gds.HealthCheck{}); err != nil {
-				log.Warn().Err(err).Str("network", "mainnet").Msg("could not connect to GDS")
+				log.Warn().Err(err).Str("network", mainnet).Msg("could not connect to GDS")
 				out.MainNet = "unavailable"
 			} else {
-				log.Debug().Str("network", "mainnet").
+				log.Debug().Str("network", mainnet).
 					Str("status", status.Status.String()).
 					Str("not_before", status.NotBefore).
 					Str("not_after", status.NotAfter).


### PR DESCRIPTION
This PR implements the BFF Lookup endpoint. The endpoint makes parallel Lookup requests to the GDS endpoint and returns an array of results marshaled directly from the `LookupReply`. It can return 1 or maybe 2 results (though 2 would be an unusual result); the response contains a `registered_directory` field to identify which directory the record came from. If no results are returned, a 404 is returned; if both GDS servers error, a 500 is returned. If only one errors, the response from the other is sent back and the error is logged.