### PR TITLE
BFF Test Fixtures

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -10,6 +10,7 @@ import (
 
 type BFFClient interface {
 	Status(ctx context.Context, in *StatusParams) (out *StatusReply, err error)
+	Lookup(ctx context.Context, in *LookupParams) (out *LookupReply, err error)
 }
 
 //===========================================================================
@@ -34,4 +35,27 @@ type StatusReply struct {
 	Version string `json:"version,omitempty"`
 	TestNet string `json:"testnet,omitempty"`
 	MainNet string `json:"mainnet,omitempty"`
+}
+
+//===========================================================================
+// BFF v1 API Requests and Responses
+//===========================================================================
+
+// LookupParams is converted into a GDS LookupRequest.
+type LookupParams struct {
+	ID         string `url:"uuid,omitempty" form:"uuid"`
+	CommonName string `url:"common_name,omitempty" form:"common_name"`
+}
+
+// LookupReply can return 1..2 results either one result found from one directory
+// service or results found from both TestNet and MainNet. If no results are found, the
+// Lookup endpoint returns a 404 error (not found). The result is the simplest case,
+// just a JSON serialization of the protocol buffers returned from GDS to help long term
+// maintainability. The protocol buffers contain a "registered_directory" field that
+// will have either vaspdirectory.net or trisatest.net inside of it - which can be used
+// to identify which network the record is associated with. The protocol buffers may
+// also contain an "error" field - the BFF will handle this field by logging the error
+// but will exclude it from any results returned.
+type LookupReply struct {
+	Results []map[string]interface{} `json:"results"`
 }

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -83,6 +83,27 @@ func (s *APIv1) Status(ctx context.Context, in *StatusParams) (out *StatusReply,
 	return out, nil
 }
 
+func (s *APIv1) Lookup(ctx context.Context, in *LookupParams) (out *LookupReply, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if params, err = query.Values(in); err != nil {
+		return nil, fmt.Errorf("could not encode query params: %s", err)
+	}
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/lookup", nil, &params); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &LookupReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 //===========================================================================
 // Helper Methods
 //===========================================================================

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -3,11 +3,20 @@ package bff
 import (
 	"context"
 	"crypto/tls"
+	"net/http"
+	"sync"
+	"time"
 
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
 	"github.com/trisacrypto/directory/pkg/bff/config"
+	"github.com/trisacrypto/directory/pkg/utils/wire"
 	gds "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 )
 
 // ConnectGDS creates a gRPC client to the TRISA Directory Service specified in the
@@ -31,4 +40,96 @@ func ConnectGDS(conf config.DirectoryConfig) (_ gds.TRISADirectoryClient, err er
 		return nil, err
 	}
 	return gds.NewTRISADirectoryClient(cc), nil
+}
+
+// Lookup makes a request on behalf of the user to both the TestNet and MainNet GDS
+// servers, returning 1..2 results (e.g. either or both GDS responses). If no results
+// are returned, Lookup returns a 404 not found error. If one of the GDS requests fails,
+// the error is logged, but the valid response is returned. If both GDS requests fail,
+// a 500 error is returned. This endpoint passes through the response from GDS as JSON,
+// the result should contain a registered_directory field that identifies which network
+// the record is associated with.
+func (s *Server) Lookup(c *gin.Context) {
+	// Bind the parameters associated with the lookup
+	params := &api.LookupParams{}
+	if err := c.ShouldBindQuery(&params); err != nil {
+		log.Warn().Err(err).Msg("could not bind request with query params")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// Ensure that we have either ID or CommonName
+	if params.ID == "" && params.CommonName == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("must provide either uuid or common_name in query params"))
+		return
+	}
+
+	// Create the LookupRequest, omit registered directory as it is assumed we're
+	// looking up the value for the directory we're making the request to.
+	req := &gds.LookupRequest{Id: params.ID, CommonName: params.CommonName}
+	errs := make([]error, 2)
+	results := make([]map[string]interface{}, 2)
+
+	// Execute the request in parallel to both the testnet and the mainnet
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 25*time.Second)
+	var wg sync.WaitGroup
+	defer cancel()
+	wg.Add(2)
+
+	lookup := func(client gds.TRISADirectoryClient, idx int, name string) {
+		defer wg.Done()
+		var (
+			err error
+			rep *gds.LookupReply
+		)
+
+		if rep, err = client.Lookup(ctx, req); err != nil {
+			serr, _ := status.FromError(err)
+			if serr.Code() != codes.NotFound {
+				log.Error().Err(err).Str("network", name).Msg("GDS lookup unsuccessful")
+				errs[idx] = err
+			}
+			return
+		}
+
+		if results[idx], err = wire.Rewire(rep); err != nil {
+			log.Error().Err(err).Str("network", name).Msg("could not rewire LookupReply")
+			errs[idx] = err
+		}
+	}
+
+	go lookup(s.testnet, 0, "testnet")
+	go lookup(s.mainnet, 1, "mainnet")
+	wg.Wait()
+
+	// If there were multiple errors, return a 500
+	nErrs := 0
+	for _, err := range errs {
+		if err != nil {
+			nErrs++
+		}
+	}
+	if nErrs == 2 {
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("unable to execute Lookup request"))
+		return
+	}
+
+	// Flatten results
+	out := &api.LookupReply{
+		Results: make([]map[string]interface{}, 0, 2),
+	}
+	for _, result := range results {
+		if len(result) > 0 {
+			out.Results = append(out.Results, result)
+		}
+	}
+
+	// Check if there are results to return
+	if len(out.Results) == 0 {
+		c.JSON(http.StatusNotFound, api.ErrorResponse("no results returned for query"))
+		return
+	}
+
+	// Serialize the results and return a successful response
+	c.JSON(http.StatusOK, out)
 }

--- a/pkg/bff/mock/gds.go
+++ b/pkg/bff/mock/gds.go
@@ -2,14 +2,27 @@ package mock
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
 
 	"github.com/trisacrypto/directory/pkg/bff/config"
 	"github.com/trisacrypto/directory/pkg/utils/bufconn"
 	gds "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
-const bufSize = 1024 * 1024
+const (
+	bufSize          = 1024 * 1024
+	RegisterRPC      = "Register"
+	LookupRPC        = "Lookup"
+	SearchRPC        = "Search"
+	VerificationRPC  = "Verification"
+	VerifyContactRPC = "VerifyContact"
+	StatusRPC        = "Status"
+)
 
 func NewGDS(conf config.DirectoryConfig) (g *GDS, err error) {
 	g = &GDS{
@@ -94,32 +107,135 @@ func (g *GDS) Reset() {
 	g.OnStatus = nil
 }
 
+// UseFixture allows you to specify a JSON fixture that is loaded from disk as the
+// protocol buffer response for the specified RPC, simplifying the handler mocking.
+func (g *GDS) UseFixture(rpc, path string) (err error) {
+	// Read the fixture data from disk
+	var data []byte
+	if data, err = ioutil.ReadFile(path); err != nil {
+		return fmt.Errorf("could not read fixture data: %s", err)
+	}
+
+	// Create a protobuf JSON unmarshaler
+	jsonpb := &protojson.UnmarshalOptions{
+		AllowPartial:   true,
+		DiscardUnknown: true,
+	}
+
+	switch rpc {
+	case RegisterRPC:
+		out := &gds.RegisterReply{}
+		if err = jsonpb.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("could not unmarshal json into %T: %s", out, err)
+		}
+		g.OnRegister = func(context.Context, *gds.RegisterRequest) (*gds.RegisterReply, error) {
+			return out, nil
+		}
+	case LookupRPC:
+		out := &gds.LookupReply{}
+		if err = jsonpb.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("could not unmarshal json into %T: %s", out, err)
+		}
+		g.OnLookup = func(context.Context, *gds.LookupRequest) (*gds.LookupReply, error) {
+			return out, nil
+		}
+	case SearchRPC:
+		out := &gds.SearchReply{}
+		if err = jsonpb.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("could not unmarshal json into %T: %s", out, err)
+		}
+		g.OnSearch = func(context.Context, *gds.SearchRequest) (*gds.SearchReply, error) {
+			return out, nil
+		}
+	case VerificationRPC:
+		out := &gds.VerificationReply{}
+		if err = jsonpb.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("could not unmarshal json into %T: %s", out, err)
+		}
+		g.OnVerification = func(context.Context, *gds.VerificationRequest) (*gds.VerificationReply, error) {
+			return out, nil
+		}
+	case VerifyContactRPC:
+		out := &gds.VerifyContactReply{}
+		if err = jsonpb.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("could not unmarshal json into %T: %s", out, err)
+		}
+		g.OnVerifyContact = func(context.Context, *gds.VerifyContactRequest) (*gds.VerifyContactReply, error) {
+			return out, nil
+		}
+	case StatusRPC:
+		out := &gds.ServiceState{}
+		if err = jsonpb.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("could not unmarshal json into %T: %s", out, err)
+		}
+		g.OnStatus = func(context.Context, *gds.HealthCheck) (*gds.ServiceState, error) {
+			return out, nil
+		}
+	default:
+		return fmt.Errorf("unknown rpc %q", rpc)
+	}
+	return nil
+}
+
+// UseError allows you to specify a gRPC status error to return from the specified RPC.
+func (g *GDS) UseError(rpc string, code codes.Code, msg string) error {
+	switch rpc {
+	case RegisterRPC:
+		g.OnRegister = func(context.Context, *gds.RegisterRequest) (*gds.RegisterReply, error) {
+			return nil, status.Error(code, msg)
+		}
+	case LookupRPC:
+		g.OnLookup = func(context.Context, *gds.LookupRequest) (*gds.LookupReply, error) {
+			return nil, status.Error(code, msg)
+		}
+	case SearchRPC:
+		g.OnSearch = func(context.Context, *gds.SearchRequest) (*gds.SearchReply, error) {
+			return nil, status.Error(code, msg)
+		}
+	case VerificationRPC:
+		g.OnVerification = func(context.Context, *gds.VerificationRequest) (*gds.VerificationReply, error) {
+			return nil, status.Error(code, msg)
+		}
+	case VerifyContactRPC:
+		g.OnVerifyContact = func(context.Context, *gds.VerifyContactRequest) (*gds.VerifyContactReply, error) {
+			return nil, status.Error(code, msg)
+		}
+	case StatusRPC:
+		g.OnStatus = func(context.Context, *gds.HealthCheck) (*gds.ServiceState, error) {
+			return nil, status.Error(code, msg)
+		}
+	default:
+		return fmt.Errorf("unknown rpc %q", rpc)
+	}
+	return nil
+}
+
 func (g *GDS) Register(ctx context.Context, in *gds.RegisterRequest) (*gds.RegisterReply, error) {
-	g.Calls["Register"]++
+	g.Calls[RegisterRPC]++
 	return g.OnRegister(ctx, in)
 }
 
 func (g *GDS) Lookup(ctx context.Context, in *gds.LookupRequest) (*gds.LookupReply, error) {
-	g.Calls["Lookup"]++
+	g.Calls[LookupRPC]++
 	return g.OnLookup(ctx, in)
 }
 
 func (g *GDS) Search(ctx context.Context, in *gds.SearchRequest) (*gds.SearchReply, error) {
-	g.Calls["Search"]++
+	g.Calls[SearchRPC]++
 	return g.OnSearch(ctx, in)
 }
 
 func (g *GDS) Verification(ctx context.Context, in *gds.VerificationRequest) (*gds.VerificationReply, error) {
-	g.Calls["Verification"]++
+	g.Calls[VerificationRPC]++
 	return g.OnVerification(ctx, in)
 }
 
 func (g *GDS) VerifyContact(ctx context.Context, in *gds.VerifyContactRequest) (*gds.VerifyContactReply, error) {
-	g.Calls["VerifyContact"]++
+	g.Calls[VerifyContactRPC]++
 	return g.OnVerifyContact(ctx, in)
 }
 
 func (g *GDS) Status(ctx context.Context, in *gds.HealthCheck) (*gds.ServiceState, error) {
-	g.Calls["Status"]++
+	g.Calls[StatusRPC]++
 	return g.OnStatus(ctx, in)
 }

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -192,6 +192,9 @@ func (s *Server) setupRoutes() (err error) {
 	{
 		// Heartbeat route (no authentication required)
 		v1.GET("/status", s.Status)
+
+		// GDS public routes (no authentication required)
+		v1.GET("/lookup", s.Lookup)
 	}
 
 	// NotFound and NotAllowed routes


### PR DESCRIPTION
This PR implements fixture loading for the GDS mocks to make implementing tests easier.

The basic use case is as follows:

1. Create a test fixture as JSON data in `pkg/bff/testdata` (e.g. `search_test_valid.json`) 
2. Call `s.testnet.UseFixture(mock.SearchRPC, "testdata/search_test_valid.json") - this will set `OnSearch` with a return type of the data that is in the fixture, returning an error if the fixture cannot be loaded or parsed. 
3. Execute a BFF request, verifying the response is expected from the fixture

Notes:

- the first parameter, `rpc` is the name of the RPC to use the fixture for, I've created string constants for each of the GDS RPCs. 
- the second parameter `path` must be a path to a JSON file that can be unmarshalled into the protocol buffer of the reply type of the RPC
- `UseFixture` can be called multiple times during the test to change fixtures in between. 

I've also created a `UseError` method to have the RPC mock return an error a bit easier. It follows the same pattern as `UseFixture`, but the user specifies a code and message for the gRPC error return. 

Open question:

Should I create `UseRegisterFixture`, `UseSearchFixture`, `UseRegisterError`, `UseSearchError`, etc. which are aliases for `UseFixture(RegisterRPC)`? 

This PR follows #401 so includes files from that PR, the files to review are:

- `pkg/bff/mock/gds.go` 
