### PR TITLE
BFF Verify Contact Endpoint

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -12,6 +12,7 @@ type BFFClient interface {
 	Status(ctx context.Context, in *StatusParams) (out *StatusReply, err error)
 	Lookup(ctx context.Context, in *LookupParams) (out *LookupReply, err error)
 	Register(ctx context.Context, in *RegisterRequest) (out *RegisterReply, err error)
+	VerifyContact(ctx context.Context, in *VerifyContactParams) (out *VerifyContactReply, err error)
 }
 
 //===========================================================================
@@ -84,11 +85,25 @@ type RegisterRequest struct {
 
 // RegisterReply is converted from a protocol buffer RegisterReply.
 type RegisterReply struct {
-	Error               map[string]interface{} `json:"error"`
+	Error               map[string]interface{} `json:"error,omitempty"`
 	Id                  string                 `json:"id"`
 	RegisteredDirectory string                 `json:"registered_directory"`
 	CommonName          string                 `json:"common_name"`
 	Status              string                 `json:"status"`
 	Message             string                 `json:"message"`
 	PKCS12Password      string                 `json:"pkcs12password"`
+}
+
+// VerifyContactParams is converted into a GDS VerifyContactRequest.
+type VerifyContactParams struct {
+	ID        string `url:"vaspID,omitempty" form:"vaspID"`
+	Token     string `url:"token,omitempty" form:"token"`
+	Directory string `url:"registered_directory,omitempty" form:"registered_directory"`
+}
+
+// VerifyContactReply
+type VerifyContactReply struct {
+	Error   map[string]interface{} `json:"error,omitempty"`
+	Status  string                 `json:"status"`
+	Message string                 `json:"message"`
 }

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -129,6 +129,27 @@ func (s *APIv1) Register(ctx context.Context, in *RegisterRequest) (out *Registe
 	return out, nil
 }
 
+func (s *APIv1) VerifyContact(ctx context.Context, in *VerifyContactParams) (out *VerifyContactReply, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if params, err = query.Values(in); err != nil {
+		return nil, fmt.Errorf("could not encode query params: %s", err)
+	}
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/verify", nil, &params); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &VerifyContactReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 //===========================================================================
 // Helper Methods
 //===========================================================================

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -138,7 +138,7 @@ func (s *APIv1) VerifyContact(ctx context.Context, in *VerifyContactParams) (out
 
 	// Make the HTTP request
 	var req *http.Request
-	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/verify", nil, &params); err != nil {
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/verify-contact", nil, &params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -198,7 +198,7 @@ func TestVerifyEmail(t *testing.T) {
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "/v1/verify", r.URL.Path)
+		require.Equal(t, "/v1/verify-contact", r.URL.Path)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -188,3 +188,30 @@ func TestRegister(t *testing.T) {
 	require.Equal(t, fixture.Message, out.Message)
 	require.Equal(t, fixture.PKCS12Password, out.PKCS12Password)
 }
+
+func TestVerifyEmail(t *testing.T) {
+	fixture := &api.VerifyContactReply{
+		Status:  "PENDING_REVIEW",
+		Message: "thank you for verifying your email",
+	}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/verify", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err)
+
+	out, err := client.VerifyContact(context.TODO(), &api.VerifyContactParams{Directory: "trisatest.net", ID: "foo", Token: "bar"})
+	require.NoError(t, err)
+	require.Equal(t, fixture.Status, out.Status)
+	require.Equal(t, fixture.Message, out.Message)
+}

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -196,7 +196,7 @@ func (s *Server) setupRoutes() (err error) {
 		// GDS public routes (no authentication required)
 		v1.GET("/lookup", s.Lookup)
 		v1.POST("/register/:network", s.Register)
-		v1.GET("/verify", s.VerifyContact)
+		v1.GET("/verify-contact", s.VerifyContact)
 	}
 
 	// NotFound and NotAllowed routes

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -196,6 +196,7 @@ func (s *Server) setupRoutes() (err error) {
 		// GDS public routes (no authentication required)
 		v1.GET("/lookup", s.Lookup)
 		v1.POST("/register/:network", s.Register)
+		v1.GET("/verify", s.VerifyContact)
 	}
 
 	// NotFound and NotAllowed routes

--- a/pkg/gds/emails/client.go
+++ b/pkg/gds/emails/client.go
@@ -116,9 +116,10 @@ func (m *EmailManager) SendVerifyContacts(vasp *pb.VASP) (sent int, err error) {
 // SendVerifyContact sends a verification email to a contact.
 func (m *EmailManager) SendVerifyContact(vasp *pb.VASP, contact *pb.Contact) (err error) {
 	ctx := VerifyContactData{
-		Name:    contact.Name,
-		VID:     vasp.Id,
-		BaseURL: m.conf.VerifyContactBaseURL,
+		Name:        contact.Name,
+		VID:         vasp.Id,
+		BaseURL:     m.conf.VerifyContactBaseURL,
+		DirectoryID: m.conf.DirectoryID,
 	}
 
 	if ctx.Token, _, err = models.GetContactVerification(contact); err != nil {

--- a/pkg/gds/emails/emails.go
+++ b/pkg/gds/emails/emails.go
@@ -30,10 +30,11 @@ func init() {
 
 // VerifyContactData to complete the verify contact email templates.
 type VerifyContactData struct {
-	Name    string // Used to address the email
-	Token   string // The unique token needed to verify the email
-	VID     string // The ID of the VASP/Registration
-	BaseURL string // The URL of the verify contact endpoint to build the VerifyContactURL
+	Name        string // Used to address the email
+	Token       string // The unique token needed to verify the email
+	VID         string // The ID of the VASP/Registration
+	BaseURL     string // The URL of the verify contact endpoint to build the VerifyContactURL
+	DirectoryID string // The registered directory to build a URL accessible by the BFF
 }
 
 // VerifyContactURL composes the link to verify the contact from the context. If the
@@ -57,6 +58,7 @@ func (d VerifyContactData) VerifyContactURL() string {
 	params := link.Query()
 	params.Set("vaspID", d.VID)
 	params.Set("token", d.Token)
+	params.Set("registered_directory", d.DirectoryID)
 	link.RawQuery = params.Encode()
 	return link.String()
 }

--- a/pkg/gds/emails/emails_test.go
+++ b/pkg/gds/emails/emails_test.go
@@ -50,7 +50,7 @@ func TestEmailBuilders(t *testing.T) {
 
 	setupMIMEDir(t)
 
-	vcdata := emails.VerifyContactData{Name: recipient, Token: "abcdef1234567890", VID: "42", BaseURL: "http://localhost:8080/verify-contact"}
+	vcdata := emails.VerifyContactData{Name: recipient, Token: "abcdef1234567890", VID: "42", BaseURL: "http://localhost:8080/verify-contact", DirectoryID: "testnet.io"}
 	mail, err := emails.VerifyContactEmail(sender, senderEmail, recipient, recipientEmail, vcdata)
 	require.NoError(t, err)
 	require.Equal(t, emails.VerifyContactRE, mail.Subject)
@@ -97,6 +97,7 @@ func TestVerifyContactURL(t *testing.T) {
 	params := link.Query()
 	require.Equal(t, data.Token, params.Get("token"))
 	require.Equal(t, data.VID, params.Get("vaspID"))
+	require.Equal(t, data.DirectoryID, params.Get("registered_directory"))
 }
 
 func TestAdminReviewURL(t *testing.T) {
@@ -158,7 +159,7 @@ func (suite *EmailTestSuite) TestSendVerifyContactEmail() {
 	email, err := emails.New(suite.conf)
 	require.NoError(err)
 
-	data := emails.VerifyContactData{Name: recipient.Name, Token: "Hk79ZIhCSrYJtSaaMECZZKI1BtsCY9zDLPq9c1amyK2zJY6T", VID: "9e069e01-8515-4d57-b9a5-e249f7ab4fca", BaseURL: "http://localhost:3000/verify-contact"}
+	data := emails.VerifyContactData{Name: recipient.Name, Token: "Hk79ZIhCSrYJtSaaMECZZKI1BtsCY9zDLPq9c1amyK2zJY6T", VID: "9e069e01-8515-4d57-b9a5-e249f7ab4fca", BaseURL: "http://localhost:3000/verify-contact", DirectoryID: "testnet.io"}
 	msg, err := emails.VerifyContactEmail(sender.Name, sender.Address, recipient.Name, recipient.Address, data)
 	require.NoError(err)
 	require.NoError(email.Send(msg))


### PR DESCRIPTION
Implements the initial verify email endpoint for the 1.4 GDS and BFF by directing the user to a URL that contains a `registered_directory` param so that the BFF can identify the directory to forward the request to. 

This PR contains both the endpoint implementation and the tests. The files and mechanisms changed should be similar to the Register endpoint. 

TODO:

- [x] change GDS verify contact email to include the additional param
- [x] test the GDS verify contact email change