### PR TITLE
sc-3986 prevent certreq fixture modification

### DIFF
--- a/pkg/gds/service_test.go
+++ b/pkg/gds/service_test.go
@@ -382,10 +382,13 @@ func (s *gdsTestSuite) CompareFixture(namespace, key string, obj interface{}, re
 
 	case certreqs:
 		var a *models.CertificateRequest
+		var data models.CertificateRequest
 		for _, f := range s.fixtures[namespace] {
 			ref := f.(*models.CertificateRequest)
 			if ref.Id == key {
-				a = ref
+				// Avoid modifying the object in the fixtures map
+				data = *ref
+				a = &data
 				break
 			}
 		}


### PR DESCRIPTION
In the GDS test suite `CompareFixture` method we are unintentionally overwriting the reference fixtures when we clear out the Modified and Created timestamps. Since the tests assume that the reference fixtures remain constant, this PR makes sure that we are only modifying a copy of the CertReq (and VASP, but that was done in a previous PR).