### PR TITLE
Hotfix: 500 errors and website uniqueness

### DIFF
--- a/pkg/gds/store/leveldb/leveldb.go
+++ b/pkg/gds/store/leveldb/leveldb.go
@@ -119,11 +119,8 @@ func (s *Store) CreateVASP(v *pb.VASP) (id string, err error) {
 	defer s.Unlock()
 
 	// Check the uniqueness constraints
+	// NOTE: website removed as uniqueness constraint in SC-4483
 	if id, ok := s.names.Find(v.CommonName); ok && id != v.Id {
-		return "", storeerrors.ErrDuplicateEntity
-	}
-
-	if id, ok := s.websites.Find(v.Website); ok && id != v.Id {
 		return "", storeerrors.ErrDuplicateEntity
 	}
 
@@ -204,11 +201,8 @@ func (s *Store) UpdateVASP(v *pb.VASP) (err error) {
 	}
 
 	// Check the uniqueness constraints
+	// NOTE: website removed as uniqueness constraint in SC-4483
 	if id, ok := s.names.Find(v.CommonName); ok && id != v.Id {
-		return storeerrors.ErrDuplicateEntity
-	}
-
-	if id, ok := s.websites.Find(v.Website); ok && id != v.Id {
 		return storeerrors.ErrDuplicateEntity
 	}
 

--- a/pkg/gds/store/trtl/trtl.go
+++ b/pkg/gds/store/trtl/trtl.go
@@ -199,11 +199,8 @@ func (s *Store) CreateVASP(v *gds.VASP) (id string, err error) {
 	defer s.Unlock()
 
 	// Check the uniqueness constraints
+	// NOTE: website removed as uniqueness constraint in SC-4483
 	if _, ok := s.names.Find(v.CommonName); ok {
-		return "", storeerrors.ErrDuplicateEntity
-	}
-
-	if _, ok := s.websites.Find(v.Website); ok {
 		return "", storeerrors.ErrDuplicateEntity
 	}
 
@@ -299,11 +296,8 @@ func (s *Store) UpdateVASP(v *gds.VASP) (err error) {
 	}
 
 	// Check the uniqueness constraints
+	// NOTE: website removed as uniqueness constraint in SC-4483
 	if id, ok := s.names.Find(v.CommonName); ok && id != v.Id {
-		return storeerrors.ErrDuplicateEntity
-	}
-
-	if id, ok := s.websites.Find(v.Website); ok && id != v.Id {
 		return storeerrors.ErrDuplicateEntity
 	}
 


### PR DESCRIPTION
This PR fixes some v1.3.1 constraint issues and 500 error handling that are needed in order to do some VASP-specific certificate management before the release.

Tasks performed:

- [x] searched for all `c.JSON` calls in `pkg/gds/admin.go` to ensure they were followed by a `return` or end of function
- [x] ensured that before a `c.JSON(http.StatusInternalServerError)` we're logging a `log.Error()` instead of `log.Warn()`
- [x] removed website unique constraint in leveldb CreateVASP and UpdateVASP  
- [x] removed website unique constraint in trtl CreateVASP and UpdateVASP