### PR TITLE
Cleanup GDS replica config

### DIFF
--- a/pkg/gds/backup.go
+++ b/pkg/gds/backup.go
@@ -17,9 +17,6 @@ import (
 // compressed backup location, either locally on disk or to a cloud location. The
 // manager may also encrypt the storage with provided keys. The manager is started when
 // the server is started; but if it is not able to run, it will exit before continuing.
-//
-// TODO: allow storage to cloud storage rather than to disk
-// TODO: encrypt the backup storage file
 func (s *Service) BackupManager(stop <-chan bool) {
 	if !s.conf.Backup.Enabled {
 		log.Warn().Msg("backup manager is not enabled")
@@ -28,7 +25,8 @@ func (s *Service) BackupManager(stop <-chan bool) {
 
 	// Test that the store is backupable
 	if _, ok := s.db.(store.Backup); !ok {
-		log.Fatal().Msg("currently configured store cannot be backed up")
+		log.Error().Msg("currently configured store cannot be backed up, mark as disabled or use different store")
+		return
 	}
 
 	// Check backup directory

--- a/pkg/gds/store/store.go
+++ b/pkg/gds/store/store.go
@@ -1,10 +1,10 @@
 /*
 Package store provides an interface to multiple types of embedded storage across
-multiple objects. Unlike a SQL interface, the TRISA directory service relies on embedded
-databases (e.g. like LevelDB) and replication using anti-entropy. It also manages
-multiple namespaces (object types) - VASP records, CertificateRequests, Peers, etc. In
-general an object store interface provides accesses to the objects, with one interface
-per namespace as follows:
+multiple objects. Unlike a SQL interface, the TRISA directory service relies on document
+databases or key/value stores such as leveldb or trtl. It also manages multiple
+namespaces (object types) - VASP records, CertificateRequests, Peers, etc. In general an
+object store interface provides accesses to the objects, with one interface per
+namespace as follows:
 
 	type ObjectStore interface {
 		List() *Iterator                               // Iterate over all objects
@@ -18,15 +18,6 @@ per namespace as follows:
 Ideally there would be a store per namespace, but in order to generalize the store to
 multiple embedded databases, the store interface affixes the object store methods with
 the namespace. E.g. ListVASPs, CreateCertReq, etc.
-
-For Replication, the replica needs special access to the store to list all objects
-including tombstones and to place objects without updating their metadata. For a
-namespace that can be replicated the interface is:
-
-	type ReplicatedObjectStore interface {
-		Scan(ns string) *Iterator          // Lists all objects including tombstones in the namespace
-		Place(ns string, o *Object) error  // Puts an object into the namespace without metadata changes
-	}
 */
 package store
 

--- a/pkg/trtl/backup.go
+++ b/pkg/trtl/backup.go
@@ -19,7 +19,12 @@ import (
 )
 
 // BackupManager runs as an independent service which periodically copies the trtl
-// storage to a compressed backup location on disk.
+// storage to a compressed backup location on disk. The backup manager is started when
+// the trtl service is started, but if it is not able to run it will force the database
+// to exit before continuing.
+//
+// TODO: allow storage to cloud storage rather than to disk
+// TODO: encrypt the backup storage file
 type BackupManager struct {
 	conf config.BackupConfig
 	db   *honu.DB


### PR DESCRIPTION
This PR resolves some minor technical debt from our shift to using trtl - it cleans up vestiges of backup and replication in GDS. There aren't very many code changes required, but part of this PR was to go through the code base and verify that configuration references to GDS replication has been removed.