### PR TITLE
Reduce Test Logging Output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/rotationalio/honu v0.3.0
-	github.com/rs/zerolog v1.21.0
+	github.com/rs/zerolog v1.26.1
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sendgrid/rest v2.6.4+incompatible
 	github.com/sendgrid/sendgrid-go v3.10.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
@@ -206,6 +207,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
@@ -529,8 +531,10 @@ github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4
 github.com/rotationalio/honu v0.3.0 h1:uqFHtWrBHfT8Dg8ClIazACCPaWHl2Zehnjs+FONb68w=
 github.com/rotationalio/honu v0.3.0/go.mod h1:IOxTHyGbkTPqRw35hhEIMmPDK/rIL3cesVpGWUR4RhE=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.21.0 h1:Q3vdXlfLNT+OftyBHsU0Y445MD+8m8axjKgf2si0QcM=
+github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.21.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
+github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
+github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -615,6 +619,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -656,8 +661,9 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e h1:1SzTfNOXwIS2oWiMF+6qu0OUDKb0dauo6MoDUQyu+yU=
+golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190221220918-438050ddec5e/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -752,6 +758,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -848,6 +855,7 @@ golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210909193231-528a39cd75f3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
@@ -928,6 +936,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.8-0.20211029000441-d6a9af8af023 h1:0c3L82FDQ5rt1bjTBlchS8t6RQ6299/+5bWMnRLh+uI=
 golang.org/x/tools v0.1.8-0.20211029000441-d6a9af8af023/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/bff/server_test.go
+++ b/pkg/bff/server_test.go
@@ -45,6 +45,10 @@ func (s *bffTestSuite) SetupSuite() {
 	var err error
 	require := s.Require()
 
+	// Discard logging from the application to focus on test logs
+	// NOTE: ConsoleLog MUST be false otherwise this will be overriden
+	logger.Discard()
+
 	// This configuration will run the BFF as a fully functional server on an open port
 	// on the system for local loop-back only. It is also in test mode, so a Gin context
 	// can also be used to test endpoints. The BFF server runs for the duration of the
@@ -54,7 +58,7 @@ func (s *bffTestSuite) SetupSuite() {
 		BindAddr:     "127.0.0.1:0",
 		Mode:         gin.TestMode,
 		LogLevel:     logger.LevelDecoder(zerolog.DebugLevel),
-		ConsoleLog:   true,
+		ConsoleLog:   false,
 		AllowOrigins: []string{"http://localhost"},
 		CookieDomain: "localhost",
 		TestNet: config.DirectoryConfig{
@@ -111,6 +115,7 @@ func (s *bffTestSuite) TearDownSuite() {
 	require.NoError(s.bff.Shutdown(), "could not shutdown the BFF server after tests")
 	s.testnet.Shutdown()
 	s.mainnet.Shutdown()
+	logger.ResetLogger()
 }
 
 func TestBFF(t *testing.T) {

--- a/pkg/bff/status_test.go
+++ b/pkg/bff/status_test.go
@@ -117,6 +117,7 @@ func (s *bffTestSuite) TestMaintenanceMode() {
 	conf, err := config.Config{
 		Maintenance:  true,
 		Mode:         gin.TestMode,
+		ConsoleLog:   false,
 		AllowOrigins: []string{"http://localhost"},
 		CookieDomain: "localhost",
 		TestNet:      config.DirectoryConfig{Endpoint: "bufcon"},

--- a/pkg/gds/emails/emails_test.go
+++ b/pkg/gds/emails/emails_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trisacrypto/directory/pkg/gds/config"
 	"github.com/trisacrypto/directory/pkg/gds/emails"
+	"github.com/trisacrypto/directory/pkg/utils/logger"
 )
 
 // If the eyeball flag is set, then the tests will write MIME emails to the testdata directory.
@@ -131,6 +132,10 @@ type EmailTestSuite struct {
 }
 
 func (suite *EmailTestSuite) SetupSuite() {
+	// Discard logging from the application to focus on test logs
+	// NOTE: ConsoleLog MUST be false otherwise this will be overriden
+	logger.Discard()
+
 	suite.conf = config.EmailConfig{
 		Testing:      true,
 		ServiceEmail: "service@example.com",
@@ -145,6 +150,10 @@ func (suite *EmailTestSuite) BeforeTest(suiteName, testName string) {
 
 func (suite *EmailTestSuite) AfterTest(suiteName, testName string) {
 	emails.PurgeMockEmails()
+}
+
+func (suite *EmailTestSuite) TearDownSuite() {
+	logger.ResetLogger()
 }
 
 func (suite *EmailTestSuite) TestSendVerifyContactEmail() {

--- a/pkg/gds/mock.go
+++ b/pkg/gds/mock.go
@@ -100,7 +100,7 @@ func MockConfig() config.Config {
 		SecretKey:   "supersecretsquirrel",
 		Maintenance: false,
 		LogLevel:    logger.LevelDecoder(zerolog.WarnLevel),
-		ConsoleLog:  true,
+		ConsoleLog:  false,
 		GDS: config.GDSConfig{
 			Enabled:  false,
 			BindAddr: "",

--- a/pkg/gds/service_test.go
+++ b/pkg/gds/service_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/trisacrypto/directory/pkg/trtl"
 	"github.com/trisacrypto/directory/pkg/utils"
 	"github.com/trisacrypto/directory/pkg/utils/bufconn"
+	"github.com/trisacrypto/directory/pkg/utils/logger"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -85,6 +86,9 @@ func (s *gdsTestSuite) ResetConfig() {
 }
 
 func (s *gdsTestSuite) SetupSuite() {
+	// Discard logging from the application to focus on test logs
+	// NOTE: ConsoleLog MUST be false otherwise this will be overriden
+	logger.Discard()
 	gin.SetMode(gin.TestMode)
 
 	// Load the reference fixtures into memory for use in testing
@@ -177,6 +181,7 @@ func (s *gdsTestSuite) TearDownSuite() {
 
 	s.shutdownServers()
 	os.RemoveAll(dbPath)
+	logger.ResetLogger()
 }
 
 func TestGDSLevelDB(t *testing.T) {

--- a/pkg/gds/store/leveldb/leveldb_test.go
+++ b/pkg/gds/store/leveldb/leveldb_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/trisacrypto/directory/pkg/gds/models/v1"
 	storeerrors "github.com/trisacrypto/directory/pkg/gds/store/errors"
+	"github.com/trisacrypto/directory/pkg/utils/logger"
 	"github.com/trisacrypto/trisa/pkg/ivms101"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -23,6 +24,10 @@ type leveldbTestSuite struct {
 }
 
 func (s *leveldbTestSuite) SetupSuite() {
+	// Discard logging from the application to focus on test logs
+	// NOTE: ConsoleLog MUST be false otherwise this will be overriden
+	logger.Discard()
+
 	path, err := ioutil.TempDir("", "gdsldbstore-*")
 	s.NoError(err)
 
@@ -36,6 +41,7 @@ func (s *leveldbTestSuite) TearDownSuite() {
 	// Delete the temp directory when done
 	err := os.RemoveAll(s.path)
 	s.NoError(err)
+	logger.ResetLogger()
 }
 
 func TestLevelDB(t *testing.T) {

--- a/pkg/gds/store/trtl/trtl_test.go
+++ b/pkg/gds/store/trtl/trtl_test.go
@@ -41,6 +41,10 @@ type trtlStoreTestSuite struct {
 func (s *trtlStoreTestSuite) SetupSuite() {
 	require := s.Require()
 
+	// Discard logging from the application to focus on test logs
+	// NOTE: ConsoleLog MUST be false otherwise this will be overriden
+	logger.Discard()
+
 	var err error
 	s.tmpdb, err = ioutil.TempDir("../testdata", "db-*")
 	require.NoError(err)
@@ -49,7 +53,7 @@ func (s *trtlStoreTestSuite) SetupSuite() {
 		Maintenance: false,
 		BindAddr:    ":4436",
 		LogLevel:    logger.LevelDecoder(zerolog.WarnLevel),
-		ConsoleLog:  true,
+		ConsoleLog:  false,
 		Database: config.DatabaseConfig{
 			URL:           fmt.Sprintf("leveldb:///%s", s.tmpdb),
 			ReindexOnBoot: false,
@@ -101,6 +105,8 @@ func (s *trtlStoreTestSuite) TearDownSuite() {
 	s.tmpdb = ""
 	s.grpc = nil
 	s.trtl = nil
+
+	logger.ResetLogger()
 }
 
 func TestTrtlStore(t *testing.T) {

--- a/pkg/gds/tokens/tokens_test.go
+++ b/pkg/gds/tokens/tokens_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	"github.com/trisacrypto/directory/pkg/gds/tokens"
+	"github.com/trisacrypto/directory/pkg/utils/logger"
 )
 
 type TokenTestSuite struct {
@@ -19,10 +20,18 @@ type TokenTestSuite struct {
 }
 
 func (s *TokenTestSuite) SetupSuite() {
+	// Discard logging from the application to focus on test logs
+	// NOTE: ConsoleLog MUST be false otherwise this will be overriden
+	logger.Discard()
+
 	// Create the keys map from the testdata directory to create new token managers.
 	s.testdata = make(map[string]string)
 	s.testdata["1yAwhf28bXi3IWP6FYcGa0dcrfq"] = "testdata/1yAwhf28bXi3IWP6FYcGa0dcrfq.pem"
 	s.testdata["1yAxs5vPqCrg433fPrFENevvzen"] = "testdata/1yAxs5vPqCrg433fPrFENevvzen.pem"
+}
+
+func (s *TokenTestSuite) TearDownSuite() {
+	logger.ResetLogger()
 }
 
 func (s *TokenTestSuite) TestTokenManager() {

--- a/pkg/trtl/mock.go
+++ b/pkg/trtl/mock.go
@@ -20,7 +20,7 @@ func MockConfig() config.Config {
 		Maintenance: false,
 		BindAddr:    ":4436",
 		LogLevel:    logger.LevelDecoder(zerolog.DebugLevel),
-		ConsoleLog:  true,
+		ConsoleLog:  false,
 		Database: config.DatabaseConfig{
 			URL:           "leveldb:///testdata/db",
 			ReindexOnBoot: false,

--- a/pkg/trtl/server_test.go
+++ b/pkg/trtl/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"github.com/trisacrypto/directory/pkg/utils"
 	"github.com/trisacrypto/directory/pkg/utils/bufconn"
+	"github.com/trisacrypto/directory/pkg/utils/logger"
 
 	"google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -63,6 +64,10 @@ type trtlTestSuite struct {
 func (s *trtlTestSuite) SetupSuite() {
 	require := s.Require()
 
+	// Discard logging from the application to focus on test logs
+	// NOTE: ConsoleLog MUST be false otherwise this will be overriden
+	logger.Discard()
+
 	// Load the fixtures then regenerate the test database if requested or required.
 	require.NoError(s.loadFixtures())
 	if _, err := os.Stat(dbtgz); *update || os.IsNotExist(err) {
@@ -78,6 +83,7 @@ func (s *trtlTestSuite) SetupSuite() {
 func (s *trtlTestSuite) TearDownSuite() {
 	require := s.Require()
 	require.NoError(s.cleanup())
+	logger.ResetLogger()
 }
 
 //===========================================================================

--- a/pkg/utils/logger/testing.go
+++ b/pkg/utils/logger/testing.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"io/ioutil"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	mu   sync.Mutex
+	orig *zerolog.Logger
+)
+
+func ResetLogger() {
+	mu.Lock()
+	defer mu.Unlock()
+	if orig != nil {
+		log.Logger = *orig
+	}
+}
+
+func Testing(tb testing.TB) {
+	mu.Lock()
+	defer mu.Unlock()
+	orig = &log.Logger
+	log.Logger = log.Output(zerolog.NewTestWriter(tb))
+}
+
+func Discard() {
+	mu.Lock()
+	defer mu.Unlock()
+	orig = &log.Logger
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: ioutil.Discard})
+}


### PR DESCRIPTION
This PR adds two utilities to our `pkg/util/logger` package:

1. `Testing` - sets the logger to use the `testing.T` logger
2. `Discard` - sets the logger to discard all output 

The logger package tracks the original logger and has a `Reset` functionality to cleanup after the test. 

Right now I've updated the test suites to use `Discard` in `SetupSuite` and to `Reset` in `TearDownSuite` -- for this `ConsoleLog` _must_ be false, otherwise the discard logger is overridden. This significantly reduces the amount of logging output during tests and will hopefully make it easier for us to figure out where tests are failing and handle them. 