### PR TITLE
Connect BFF to Trtl

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -43,7 +43,7 @@ GDS_MEMBERS_CERTS=
 GDS_MEMBERS_CERT_POOL=
 
 # GDS Database Configuration
-GDS_DATABASE_URL=trtl:///fixtures/db/
+GDS_DATABASE_URL=trtl://localhost:4436/
 GDS_DATABASE_REINDEX_ON_BOOT=false
 GDS_DATABASE_INSECURE=true
 GDS_DATABASE_CERT_PATH=
@@ -137,6 +137,11 @@ GDS_BFF_TESTNET_TIMEOUT=5s
 GDS_BFF_MAINNET_INSECURE=true
 GDS_BFF_MAINNET_ENDPOINT=localhost:8436
 GDS_BFF_MAINNET_TIMEOUT=5s
+GDS_BFF_DATABASE_URL=trtl://localhost:4436/
+GDS_BFF_DATABASE_REINDEX_ON_BOOT=false
+GDS_BFF_DATABASE_INSECURE=true
+GDS_BFF_DATABASE_CERT_PATH=
+GDS_BFF_DATABASE_POOL_PATH=
 
 ######################################################################################
 ## React App Build Environment

--- a/cmd/certs/main.go
+++ b/cmd/certs/main.go
@@ -210,13 +210,13 @@ func initCA(c *cli.Context) (err error) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(1942),
 		Subject: pkix.Name{
-			CommonName:    "trisatest.net",
-			Organization:  []string{"TRISA", "CipherTrace"},
+			CommonName:    "trisa.dev",
+			Organization:  []string{"TRISA", "Rotational Labs"},
 			Country:       []string{"USA"},
-			Province:      []string{"CA"},
-			Locality:      []string{"Menlo Park"},
-			StreetAddress: []string{"68 Willow Road"},
-			PostalCode:    []string{"94025"},
+			Province:      []string{"MD"},
+			Locality:      []string{"Queenstown"},
+			StreetAddress: []string{"215 Alynn Way"},
+			PostalCode:    []string{"21658"},
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(10, 0, 0),
@@ -224,6 +224,7 @@ func initCA(c *cli.Context) (err error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
+		DNSNames:              []string{"trisa.dev"},
 	}
 
 	// Create private key
@@ -312,6 +313,7 @@ func issue(c *cli.Context) (err error) {
 		SubjectKeyId: []byte{1, 2, 3, 4, 5, 6},
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
+		DNSNames:     []string{c.String("name")},
 	}
 
 	// Create private key

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -144,6 +144,11 @@ services:
       - GDS_BFF_MAINNET_INSECURE=true
       - GDS_BFF_MAINNET_ENDPOINT=gds-mainnet:8433
       - GDS_BFF_MAINNET_TIMEOUT=5s
+      - GDS_BFF_DATABASE_URL=trtl://trtl:4436/
+      - GDS_BFF_DATABASE_REINDEX_ON_BOOT="false"
+      - GDS_BFF_DATABASE_INSECURE="true"
+      - GDS_BFF_DATABASE_CERT_PATH
+      - GDS_BFF_DATABASE_POOL_PATH
     profiles:
       - bff
       - api

--- a/pkg/bff/config/config.go
+++ b/pkg/bff/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -22,6 +23,7 @@ type Config struct {
 	CookieDomain string              `split_words:"true"`
 	TestNet      DirectoryConfig
 	MainNet      DirectoryConfig
+	Database     DatabaseConfig
 	processed    bool
 }
 
@@ -30,6 +32,14 @@ type DirectoryConfig struct {
 	Insecure bool          `split_words:"true" default:"true"`
 	Endpoint string        `split_words:"true" required:"true"`
 	Timeout  time.Duration `split_words:"true" default:"10s"`
+}
+
+type DatabaseConfig struct {
+	URL           string `split_words:"true" required:"true"`
+	ReindexOnBoot bool   `split_words:"true" default:"false"`
+	Insecure      bool   `split_words:"true" default:"false"`
+	CertPath      string `split_words:"true"`
+	PoolPath      string `split_words:"true"`
 }
 
 // New creates a new Config object from environment variables prefixed with GDS_BFF.
@@ -65,9 +75,24 @@ func (c Config) Mark() (Config, error) {
 }
 
 // Validate the config to make sure that it is usable to run the GDS BFF server.
-func (c Config) Validate() error {
+func (c Config) Validate() (err error) {
 	if c.Mode != gin.ReleaseMode && c.Mode != gin.DebugMode && c.Mode != gin.TestMode {
 		return fmt.Errorf("%q is not a valid gin mode", c.Mode)
+	}
+
+	if err = c.Database.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c DatabaseConfig) Validate() error {
+	// If the insecure flag isn't set then we must have certs when connecting to trtl.
+	if !c.Insecure {
+		if c.CertPath == "" || c.PoolPath == "" {
+			return errors.New("invalid configuration: connecting to trtl over mTLS requires certs and cert pool")
+		}
 	}
 	return nil
 }

--- a/pkg/bff/config/config_test.go
+++ b/pkg/bff/config/config_test.go
@@ -11,19 +11,24 @@ import (
 )
 
 var testEnv = map[string]string{
-	"GDS_BFF_MAINTENANCE":      "false",
-	"GDS_BFF_BIND_ADDR":        "8080",
-	"GDS_BFF_MODE":             "debug",
-	"GDS_BFF_LOG_LEVEL":        "debug",
-	"GDS_BFF_CONSOLE_LOG":      "true",
-	"GDS_BFF_ALLOW_ORIGINS":    "https://vaspdirectory.net",
-	"GDS_BFF_COOKIE_DOMAIN":    "vaspdirectory.net",
-	"GDS_BFF_TESTNET_INSECURE": "true",
-	"GDS_BFF_TESTNET_ENDPOINT": "localhost:8443",
-	"GDS_BFF_TESTNET_TIMEOUT":  "5s",
-	"GDS_BFF_MAINNET_INSECURE": "true",
-	"GDS_BFF_MAINNET_ENDPOINT": "localhost:8444",
-	"GDS_BFF_MAINNET_TIMEOUT":  "3s",
+	"GDS_BFF_MAINTENANCE":              "false",
+	"GDS_BFF_BIND_ADDR":                "8080",
+	"GDS_BFF_MODE":                     "debug",
+	"GDS_BFF_LOG_LEVEL":                "debug",
+	"GDS_BFF_CONSOLE_LOG":              "true",
+	"GDS_BFF_ALLOW_ORIGINS":            "https://vaspdirectory.net",
+	"GDS_BFF_COOKIE_DOMAIN":            "vaspdirectory.net",
+	"GDS_BFF_TESTNET_INSECURE":         "true",
+	"GDS_BFF_TESTNET_ENDPOINT":         "localhost:8443",
+	"GDS_BFF_TESTNET_TIMEOUT":          "5s",
+	"GDS_BFF_MAINNET_INSECURE":         "true",
+	"GDS_BFF_MAINNET_ENDPOINT":         "localhost:8444",
+	"GDS_BFF_MAINNET_TIMEOUT":          "3s",
+	"GDS_BFF_DATABASE_URL":             "trtl://trtl.test:4436",
+	"GDS_BFF_DATABASE_REINDEX_ON_BOOT": "false",
+	"GDS_BFF_DATABASE_INSECURE":        "true",
+	"GDS_BFF_DATABASE_CERT_PATH":       "fixtures/creds/certs.pem",
+	"GDS_BFF_DATABASE_POOL_PATH":       "fixtures/creds/pool.zip",
 }
 
 func TestConfig(t *testing.T) {
@@ -57,6 +62,84 @@ func TestConfig(t *testing.T) {
 	require.True(t, conf.MainNet.Insecure)
 	require.Equal(t, testEnv["GDS_BFF_MAINNET_ENDPOINT"], conf.MainNet.Endpoint)
 	require.Equal(t, 3*time.Second, conf.MainNet.Timeout)
+	require.Equal(t, testEnv["GDS_BFF_DATABASE_URL"], conf.Database.URL)
+	require.Equal(t, false, conf.Database.ReindexOnBoot)
+	require.Equal(t, true, conf.Database.Insecure)
+	require.Equal(t, testEnv["GDS_BFF_DATABASE_CERT_PATH"], conf.Database.CertPath)
+	require.Equal(t, testEnv["GDS_BFF_DATABASE_POOL_PATH"], conf.Database.PoolPath)
+}
+
+func TestRequiredConfig(t *testing.T) {
+	required := []string{
+		"GDS_BFF_TESTNET_ENDPOINT",
+		"GDS_BFF_MAINNET_ENDPOINT",
+		"GDS_BFF_DATABASE_URL",
+		"GDS_BFF_DATABASE_CERT_PATH",
+		"GDS_BFF_DATABASE_POOL_PATH",
+	}
+
+	// Collect required environment variables and cleanup after
+	prevEnv := curEnv(required...)
+	cleanup := func() {
+		for key, val := range prevEnv {
+			if val != "" {
+				os.Setenv(key, val)
+			} else {
+				os.Unsetenv(key)
+			}
+		}
+	}
+	t.Cleanup(cleanup)
+
+	// Ensure that we've captured the complete set of required environment variables
+	setEnv(required...)
+	conf, err := config.New()
+	require.NoError(t, err)
+
+	// Ensure that each environment variable is required
+	for _, envvar := range required {
+		// Add all environment variables but the current one
+		for _, key := range required {
+			if key == envvar {
+				os.Unsetenv(key)
+			} else {
+				setEnv(key)
+			}
+		}
+
+		_, err := config.New()
+		require.Errorf(t, err, "expected %q to be required but no error occurred", envvar)
+	}
+
+	// Test required configuration
+	require.Equal(t, testEnv["GDS_BFF_DATABASE_URL"], conf.Database.URL)
+}
+
+func TestDatabaseConfigValidation(t *testing.T) {
+	conf := config.DatabaseConfig{
+		URL:           "trtl://trtl.test.net:443",
+		ReindexOnBoot: false,
+		Insecure:      false,
+		CertPath:      "",
+		PoolPath:      "",
+	}
+
+	conf.Insecure = true
+	err := conf.Validate()
+	require.NoError(t, err)
+
+	// If Insecure is false, then the certs and cert pool are required.
+	conf.Insecure = false
+	err = conf.Validate()
+	require.EqualError(t, err, "invalid configuration: connecting to trtl over mTLS requires certs and cert pool")
+
+	conf.CertPath = "fixtures/certs.pem"
+	err = conf.Validate()
+	require.EqualError(t, err, "invalid configuration: connecting to trtl over mTLS requires certs and cert pool")
+
+	conf.PoolPath = "fixtures/pool.zip"
+	err = conf.Validate()
+	require.NoError(t, err, "expected valid configuration")
 }
 
 // Returns the current environment for the specified keys, or if no keys are specified

--- a/pkg/bff/server_test.go
+++ b/pkg/bff/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/trisacrypto/directory/pkg/bff"
 	"github.com/trisacrypto/directory/pkg/bff/api/v1"
 	"github.com/trisacrypto/directory/pkg/bff/config"
+	"github.com/trisacrypto/directory/pkg/bff/db"
 	"github.com/trisacrypto/directory/pkg/bff/mock"
 	"github.com/trisacrypto/directory/pkg/trtl"
 	"github.com/trisacrypto/directory/pkg/utils/bufconn"
@@ -99,6 +100,11 @@ func (s *bffTestSuite) SetupSuite() {
 	mnClient, err := s.mainnet.Client()
 	require.NoError(err, "could not create mainnet GDS client")
 	s.bff.SetClients(tnClient, mnClient)
+
+	// Direct connect the BFF server to the database
+	db, err := db.DirectConnect(s.trtlsock.Conn)
+	require.NoError(err, "could not direct connect db to the BFF server")
+	s.bff.SetDB(db)
 
 	// Start the BFF server - the goal of the BFF tests is to have the server run for
 	// the entire duration of the tests. Implement reset methods to ensure the server

--- a/pkg/bff/status_test.go
+++ b/pkg/bff/status_test.go
@@ -121,6 +121,10 @@ func (s *bffTestSuite) TestMaintenanceMode() {
 		CookieDomain: "localhost",
 		TestNet:      config.DirectoryConfig{Endpoint: "bufcon"},
 		MainNet:      config.DirectoryConfig{Endpoint: "bufcon"},
+		Database: config.DatabaseConfig{
+			URL:      "trtl:///",
+			Insecure: true,
+		},
 	}.Mark()
 	require.NoError(err, "configuration is not valid")
 

--- a/pkg/gds/backup.go
+++ b/pkg/gds/backup.go
@@ -29,7 +29,7 @@ func (s *Service) BackupManager(stop <-chan bool) {
 		return
 	}
 
-	// Check backup directory
+	// Check backup directory, creating it as necessary
 	backupDir, err := s.getBackupStorage()
 	if err != nil {
 		log.Fatal().Err(err).Msg("backup manager cannot access backup directory")
@@ -38,7 +38,6 @@ func (s *Service) BackupManager(stop <-chan bool) {
 	ticker := time.NewTicker(s.conf.Backup.Interval)
 	log.Info().Dur("interval", s.conf.Backup.Interval).Str("store", backupDir).Msg("backup manager started")
 
-backups:
 	for {
 		// Wait for next tick or a stop message
 		select {
@@ -51,40 +50,61 @@ backups:
 		case <-ticker.C:
 		}
 
-		// Begin the backup process
-		start := time.Now()
-		log.Debug().Msg("starting backup")
+		// Execute the backup - error messages are logged in the Backup function so they
+		// are ignored here and are only returned from Backup for testing purposes.
+		s.Backup(backupDir)
+	}
+}
 
-		// Conduct the backup, logging errors if needed
-		if err := s.db.(store.Backup).Backup(backupDir); err != nil {
-			// Do not continue if there was a backup error; all code in the rest of the
-			// loop should expect that the backup was successful.
-			// NOTE: using WithLevel and Fatal does not Exit the program like log.Fatal()
-			// this ensures that we issue a CRITICAL severity without stopping the server.
-			log.WithLevel(zerolog.FatalLevel).Err(err).Msg("could not backup database")
-			continue backups
-		} else {
-			log.Info().Dur("duration", time.Since(start)).Msg("backup complete")
-		}
+// Backup performs a backup on behalf of the service. BackupManager calls this function
+// at a periodic interval to take a snapshot of the store to disk and to keep only the
+// configured number of archives.
+func (s *Service) Backup(path string) (err error) {
+	// Begin the backup process
+	start := time.Now()
+	log.Debug().Msg("starting backup")
 
-		// Remove any previous backups that may be in the directory
-		// NOTE: this requires the backup to write filenames as gdsdb-200601021504.*
-		var archives []string
-		if archives, err = listArchives(backupDir); err != nil {
-			log.Error().Err(err).Msg("could not list backup directory")
-		} else {
-			if len(archives) > s.conf.Backup.Keep {
-				var removed int
-				for _, archive := range archives[:len(archives)-s.conf.Backup.Keep] {
-					log.Debug().Str("archive", archive).Msg("deleting archive")
-					if err = os.Remove(archive); err == nil {
-						removed++
-					}
-				}
-				log.Debug().Int("kept", s.conf.Backup.Keep).Int("removed", removed).Msg("backup directory cleaned up")
-			}
+	// Primarily a testing helper, if the path is empty, attempt to resolve or create
+	// the backup directory from the configuration. Passing empty string for the path
+	// can also be used for one off backups for utilities that want to call this func.
+	if path == "" {
+		if path, err = s.getBackupStorage(); err != nil {
+			log.WithLevel(zerolog.FatalLevel).Err(err).Msg("could not get backup storage")
+			return err
 		}
 	}
+
+	// Conduct the backup, logging errors if needed
+	if err = s.db.(store.Backup).Backup(path); err != nil {
+		// Do not continue if there was a backup error; all code in the rest of the
+		// loop should expect that the backup was successful.
+		// NOTE: using WithLevel and Fatal does not Exit the program like log.Fatal()
+		// this ensures that we issue a CRITICAL severity without stopping the server.
+		log.WithLevel(zerolog.FatalLevel).Err(err).Msg("could not backup database")
+		return err
+	}
+
+	log.Info().Dur("duration", time.Since(start)).Msg("backup complete")
+
+	// Remove any previous backups that may be in the directory
+	// NOTE: this requires the backup to write filenames as gdsdb-200601021504.*
+	var archives []string
+	if archives, err = listArchives(path); err != nil {
+		log.Error().Err(err).Msg("could not list backup directory")
+		return err
+	}
+
+	if len(archives) > s.conf.Backup.Keep {
+		var removed int
+		for _, archive := range archives[:len(archives)-s.conf.Backup.Keep] {
+			log.Debug().Str("archive", archive).Msg("deleting archive")
+			if err = os.Remove(archive); err == nil {
+				removed++
+			}
+		}
+		log.Debug().Int("kept", s.conf.Backup.Keep).Int("removed", removed).Msg("backup directory cleaned up")
+	}
+	return nil
 }
 
 // get the configured backup directory storage or return an error

--- a/pkg/gds/backup_test.go
+++ b/pkg/gds/backup_test.go
@@ -49,7 +49,7 @@ func (s *gdsTestSuite) TestBackupManager() {
 	conf := gds.MockConfig()
 	conf.Backup = config.BackupConfig{
 		Enabled:  true,
-		Interval: time.Millisecond,
+		Interval: 100 * time.Millisecond,
 		Storage:  "testdata/backups",
 		Keep:     1,
 	}
@@ -59,22 +59,11 @@ func (s *gdsTestSuite) TestBackupManager() {
 	defer os.RemoveAll(s.svc.GetConf().Backup.Storage)
 	require := s.Require()
 
-	// Start the backup manager
-	stop := make(chan bool)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		s.svc.BackupManager(stop)
-	}()
-
-	// Wait for the backup manager to run through its loop. The shutdown check is at
-	// the beginning so there is a timing window here.
-	time.Sleep(s.svc.GetConf().Backup.Interval * 3)
-
-	// Make sure that the backup manager is stopped before we proceed
-	stop <- true
-	wg.Wait()
+	// Execute a single Backup; testing the looping functionality of the BackupManager
+	// will result in a race condition, so we assume that any runtime errors will
+	// primarily occur in the Backup function and that the BackupManager routine is ok.
+	err := s.svc.Backup("")
+	require.NoError(err, "could not execute backup")
 
 	// Backup should be created
 	backupDir := s.svc.GetConf().Backup.Storage


### PR DESCRIPTION
This PR implements a database configuration for BFF to connect to trtl, implements a stub `bff/db` package for the BFF to interact with trtl, and implements a mock trtl connecting to a temporary directory leveldb for testing. 