### PR TITLE
Fixes panic when trtl becomes unavailable and adds panic recovery

### DIFF
--- a/cmd/gds/main.go
+++ b/cmd/gds/main.go
@@ -1420,6 +1420,9 @@ func loadProfile(c *cli.Context) (err error) {
 
 // helper function to create the GRPC client with default options
 func initClient(c *cli.Context) (err error) {
+	if profile.Directory == nil {
+		return cli.Exit("current profile does not contain directory configuration", 1)
+	}
 	if client, err = profile.Directory.Connect(); err != nil {
 		return cli.Exit(err, 1)
 	}
@@ -1427,6 +1430,9 @@ func initClient(c *cli.Context) (err error) {
 }
 
 func initAdminClient(c *cli.Context) (err error) {
+	if profile.Admin == nil {
+		return cli.Exit("current profile does not contain admin configuration", 1)
+	}
 	if adminClient, err = profile.Admin.Connect(); err != nil {
 		return cli.Exit(err, 1)
 	}
@@ -1434,6 +1440,9 @@ func initAdminClient(c *cli.Context) (err error) {
 }
 
 func initMembersClient(c *cli.Context) (err error) {
+	if profile.Members == nil {
+		return cli.Exit("current profile does not contain members configuration", 1)
+	}
 	if membersClient, err = profile.Members.Connect(); err != nil {
 		return cli.Exit(err, 1)
 	}
@@ -1442,7 +1451,6 @@ func initMembersClient(c *cli.Context) (err error) {
 
 // helper function to print JSON response and exit
 func printJSON(msg interface{}) (err error) {
-
 	var data []byte
 	switch m := msg.(type) {
 	case proto.Message:

--- a/pkg/gds/interceptor.go
+++ b/pkg/gds/interceptor.go
@@ -2,8 +2,11 @@ package gds
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -13,6 +16,19 @@ import (
 func (s *Service) serverInterceptor(ctx context.Context, in interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (out interface{}, err error) {
 	// Track how long the method takes to execute.
 	start := time.Now()
+	panicked := true
+
+	// Recover from panics in the handler.
+	// See: https://github.com/grpc-ecosystem/go-grpc-middleware/blob/4705cb37b9857ad51b4c96ff5a2f3c60afe442cf/recovery/interceptors.go#L21-L37
+	defer func() {
+		if r := recover(); r != nil || panicked {
+			log.WithLevel(zerolog.PanicLevel).
+				Err(fmt.Errorf("%v", r)).
+				Str("stack_trace", string(debug.Stack())).
+				Msg("grpc server has recovered from a panic")
+			err = status.Error(codes.Internal, "an unhandled exception occurred")
+		}
+	}()
 
 	// Check if we're in maintenance mode - status method should still return a full response.
 	if s.conf.Maintenance && info.FullMethod != "/trisa.gds.api.v1beta1.TRISADirectory/Status" {
@@ -21,6 +37,7 @@ func (s *Service) serverInterceptor(ctx context.Context, in interface{}, info *g
 
 	// Call the handler to finalize the request and get the response.
 	out, err = handler(ctx, in)
+	panicked = false
 
 	// Log with zerolog - checkout grpclog.LoggerV2 for default logging.
 	// TODO: add remote peer information if using mTLS

--- a/pkg/gds/store/trtl/iterator.go
+++ b/pkg/gds/store/trtl/iterator.go
@@ -279,7 +279,12 @@ func (i *trtlStreamingIterator) Error() error {
 }
 
 func (i *trtlStreamingIterator) Release() {
-	i.cursor.CloseSend()
+	// If the cursor is nil it's likely that the connection erred and i.err is not nil.
+	// Release() should be called safely before Error() to ensure any resources are
+	// cleaned up (e.g. canceling the context).
+	if i.cursor != nil {
+		i.cursor.CloseSend()
+	}
 	i.cancel()
 }
 


### PR DESCRIPTION
Fixes a panic that occurred when `trtl` was running when the `gds` server started, but came down after bootup. Adds tests for the panic case and also adds panic recovery so that the node doesn't come down even when it panics. 