### PR TITLE
allow FormHelperText prop to display jsx element

### DIFF
--- a/web/gds-user-ui/src/components/NameIdentification/index.tsx
+++ b/web/gds-user-ui/src/components/NameIdentification/index.tsx
@@ -130,8 +130,21 @@ const NationalIdentification: React.FC<NationalIdentificationProps> = () => {
                 isInvalid={!!errors?.entity?.national_identification?.registration_authority}
                 isDisabled={NationalIdentificationType === 'NATIONAL_IDENTIFIER_TYPE_CODE_LEIX'}
                 formHelperText={
-                  errors?.entity?.national_identification?.registration_authority?.message ||
-                  'For identifiers other than LEI specify the registration authority from the following list. See <a href="https://www.gleif.org/en/about-lei/code-lists/gleif-registration-authorities-list">GLEIF Registration Authorities</a> for more details on how to look up a registration authority. If in doubt, use RA777777 - "General Government Entities" which specifies the default registration authority for your country of registration..'
+                  errors?.entity?.national_identification?.registration_authority?.message || (
+                    <Text>
+                      For identifiers other than LEI specify the registration authority from the
+                      following list. See for more details on how to look up a registration
+                      authority. If in doubt, use RA777777 - "General Government Entities" which
+                      specifies the default registration authority for your country of
+                      registration..'
+                      <Link
+                        href="https://www.gleif.org/en/about-lei/code-lists/gleif-registration-authorities-list"
+                        color="blue.500"
+                        isExternal>
+                        GLEIF Registration Authorities
+                      </Link>
+                    </Text>
+                  )
                 }
               />
             )}

--- a/web/gds-user-ui/src/components/NameIdentification/index.tsx
+++ b/web/gds-user-ui/src/components/NameIdentification/index.tsx
@@ -133,16 +133,16 @@ const NationalIdentification: React.FC<NationalIdentificationProps> = () => {
                   errors?.entity?.national_identification?.registration_authority?.message || (
                     <Text>
                       For identifiers other than LEI specify the registration authority from the
-                      following list. See for more details on how to look up a registration
-                      authority. If in doubt, use RA777777 - "General Government Entities" which
-                      specifies the default registration authority for your country of
-                      registration..'
+                      following list. See{' '}
                       <Link
                         href="https://www.gleif.org/en/about-lei/code-lists/gleif-registration-authorities-list"
                         color="blue.500"
                         isExternal>
                         GLEIF Registration Authorities
-                      </Link>
+                      </Link>{' '}
+                      for more details on how to look up a registration authority. If in doubt, use
+                      RA777777 - "General Government Entities" which specifies the default
+                      registration authority for your country of registration..'
                     </Text>
                   )
                 }

--- a/web/gds-user-ui/src/components/ui/SelectFormControl/index.tsx
+++ b/web/gds-user-ui/src/components/ui/SelectFormControl/index.tsx
@@ -9,7 +9,7 @@ import { ChakraStylesConfig, GroupBase, OptionsOrGroups, Select, Props } from 'c
 import React from 'react';
 
 interface _FormControlProps extends Props {
-  formHelperText?: string;
+  formHelperText?: any;
   controlId: string;
   label?: string;
   name?: string;


### PR DESCRIPTION
### Type of change

- [x] bug fix

### Scope of changes

Allow FormHelperText prop on SelectFormControl component to display JSX Element rather than a String and format the content to display the link 



