### PR TITLE
sc-5268 Create two columns in Details cards on "Submit & Review" page

### DIFF
--- a/web/gds-user-ui/src/components/CertificateReview/BasicDetailsReview.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/BasicDetailsReview.tsx
@@ -51,8 +51,8 @@ const BasicDetailsReview = (props: BasicDetailsReviewProps) => {
       p={5}
       px={5}>
       <Stack width={'100%'}>
-        <Box display={'flex'} justifyContent="space-between" pt={4} ml={5}>
-          <Heading fontSize={20} fontFamily="Open Sans">
+        <Box display={'flex'} justifyContent="space-between" pt={4} ml={0}>
+          <Heading fontSize={20} mb="2rem">
             Section 1: Basic Details
           </Heading>
           <Button
@@ -67,7 +67,18 @@ const BasicDetailsReview = (props: BasicDetailsReviewProps) => {
           </Button>
         </Box>
         <Stack fontSize={18}>
-          <Table sx={{ 'td:nth-child(2),td:nth-child(3)': { fontWeight: 'bold' } }}>
+          <Table
+            sx={{
+              'td:nth-child(2),td:nth-child(3)': { fontWeight: 'bold' },
+              'td:first-child': {
+                width: '50%'
+              },
+              td: {
+                borderBottom: 'none',
+                paddingInlineStart: 0,
+                paddingY: 2.5
+              }
+            }}>
             <Tbody
               sx={{
                 '*': {
@@ -76,33 +87,43 @@ const BasicDetailsReview = (props: BasicDetailsReviewProps) => {
               }}>
               <Tr>
                 <Td borderBottom={'none'}>Website</Td>
-                <Td borderBottom={'none'}>
-                  <Link href={basicDetail.website} isExternal>
-                    {basicDetail.website}
-                  </Link>
+                <Td borderBottom={'none'} whiteSpace="break-spaces" lineHeight={1.5}>
+                  {basicDetail.website ? (
+                    <Link href={basicDetail.website} isExternal>
+                      {basicDetail.website}
+                    </Link>
+                  ) : (
+                    'N/A'
+                  )}
                 </Td>
                 <Td></Td>
               </Tr>
               <Tr>
                 <Td>Business Category</Td>
-                <Td>{(BUSINESS_CATEGORY as any)[basicDetail.business_category]}</Td>
+                <Td>{(BUSINESS_CATEGORY as any)[basicDetail.business_category] || 'N/A'}</Td>
                 <Td></Td>
               </Tr>
               <Tr borderStyle={'hidden'}>
-                <Td>Date of Incorporation/ Establishment</Td>
-                <Td>{basicDetail.established_on}</Td>
+                <Td whiteSpace="break-spaces" lineHeight={1.5}>
+                  Date of Incorporation/ Establishment
+                </Td>
+                <Td>{basicDetail.established_on || 'N/A'}</Td>
                 <Td></Td>
               </Tr>
               <Tr borderStyle={'hidden'}>
-                <Td>VASP Category</Td>
+                <Td whiteSpace="break-spaces" lineHeight={1.5}>
+                  VASP Category
+                </Td>
                 <Td>
-                  {basicDetail?.vasp_categories?.map((categ: any) => {
-                    return (
-                      <Tag key={categ} color={'white'} bg={'blue.400'} mr={2} mb={1}>
-                        {getBusinessCategiryLabel(categ)}
-                      </Tag>
-                    );
-                  })}
+                  {basicDetail?.vasp_categories && basicDetail?.vasp_categories.length
+                    ? basicDetail?.vasp_categories?.map((categ: any) => {
+                        return (
+                          <Tag key={categ} color={'white'} bg={'blue.400'} mr={2} mb={1}>
+                            {getBusinessCategiryLabel(categ)}
+                          </Tag>
+                        );
+                      })
+                    : 'N/A'}
                 </Td>
                 <Td></Td>
               </Tr>

--- a/web/gds-user-ui/src/components/CertificateReview/ContactsReview.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/ContactsReview.tsx
@@ -31,8 +31,10 @@ const ContactsReview = (props: ContactsProps) => {
       p={5}
       px={5}>
       <Stack>
-        <Box display={'flex'} justifyContent="space-between" pt={4} ml={5}>
-          <Heading fontSize={20}>Section 3: Contacts</Heading>
+        <Box display={'flex'} justifyContent="space-between" pt={4} ml={0}>
+          <Heading fontSize={20} mb="2rem">
+            Section 3: Contacts
+          </Heading>
           <Button
             bg={colors.system.blue}
             color={'white'}
@@ -48,7 +50,15 @@ const ContactsReview = (props: ContactsProps) => {
           <Table
             sx={{
               'td:nth-child(2),td:nth-child(3)': { fontWeight: 'bold' },
-              Tr: { borderStyle: 'hidden' }
+              Tr: { borderStyle: 'hidden' },
+              'td:first-child': {
+                width: '50%'
+              },
+              td: {
+                borderBottom: 'none',
+                paddingInlineStart: 0,
+                paddingY: 2.5
+              }
             }}>
             <Tbody>
               {['technical', 'legal', 'administrative', 'billing'].map((contact, index) => (

--- a/web/gds-user-ui/src/components/CertificateReview/LegalPersonReview.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/LegalPersonReview.tsx
@@ -46,8 +46,10 @@ const LegalPersonReview: React.FC<LegalReviewProps> = (props) => {
       p={5}
       px={5}>
       <Stack>
-        <Box display={'flex'} justifyContent="space-between" pt={4} ml={5}>
-          <Heading fontSize={20}>Section 2: Legal Person</Heading>
+        <Box display={'flex'} justifyContent="space-between" pt={4} ml={0}>
+          <Heading fontSize={20} mb="2rem">
+            Section 2: Legal Person
+          </Heading>
           <Button
             bg={colors.system.blue}
             color={'white'}
@@ -56,15 +58,22 @@ const LegalPersonReview: React.FC<LegalReviewProps> = (props) => {
             _hover={{
               bg: '#10aaed'
             }}>
-            {' '}
-            Edit{' '}
+            Edit
           </Button>
         </Box>
         <Stack fontSize={18}>
           <Table
             sx={{
               'td:nth-child(2),td:nth-child(3)': { fontWeight: 'bold', paddingLeft: 0 },
-              Tr: { borderStyle: 'hidden' }
+              Tr: { borderStyle: 'hidden' },
+              'td:first-child': {
+                width: '50%'
+              },
+              td: {
+                borderBottom: 'none',
+                paddingInlineStart: 0,
+                paddingY: 2.5
+              }
             }}>
             <Tbody
               sx={{
@@ -73,9 +82,13 @@ const LegalPersonReview: React.FC<LegalReviewProps> = (props) => {
                 }
               }}>
               <Tr>
-                <Td fontSize={'1rem'} fontWeight="bold" colSpan={3}>
-                  <Text mb={1}>Name Identifiers</Text>
-                  <Divider />
+                <Td
+                  fontSize={'1rem'}
+                  fontWeight="bold"
+                  colSpan={3}
+                  background="#E5EDF1"
+                  pl={'1rem !important'}>
+                  Name Identifiers
                 </Td>
               </Tr>
               <Tr>
@@ -164,10 +177,21 @@ const LegalPersonReview: React.FC<LegalReviewProps> = (props) => {
                 </Td>
               </Tr>
               <Tr>
-                <Td fontSize={'1rem'} fontWeight="bold" colSpan={3}>
+                <Td></Td>
+              </Tr>
+              <Tr>
+                <Td
+                  fontSize={'1rem'}
+                  pt={'2rem'}
+                  fontWeight="bold"
+                  colSpan={3}
+                  background="#E5EDF1"
+                  pl={'1rem !important'}>
                   <Text mb={1}>National Identification</Text>
-                  <Divider />
                 </Td>
+              </Tr>
+              <Tr>
+                <Td></Td>
               </Tr>
               <Tr>
                 <Td pt={0}>Identification Number</Td>

--- a/web/gds-user-ui/src/components/CertificateReview/TrisaImplementationReview.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/TrisaImplementationReview.tsx
@@ -25,13 +25,14 @@ const TrisaImplementationReview = (props: TrisaImplementationReviewProps) => {
       border="1px solid #DFE0EB"
       fontFamily={'Open Sans'}
       color={'#252733'}
-      maxHeight={367}
       bg={'white'}
       fontSize={'1rem'}
       p={5}>
       <Stack>
-        <Box display={'flex'} justifyContent="space-between" pt={4} ml={5}>
-          <Heading fontSize={20}>Section 4: TRISA Implementation</Heading>
+        <Box display={'flex'} justifyContent="space-between" pt={4} ml={0}>
+          <Heading fontSize={20} mb="2rem">
+            Section 4: TRISA Implementation
+          </Heading>
           <Button
             bg={colors.system.blue}
             color={'white'}
@@ -40,8 +41,7 @@ const TrisaImplementationReview = (props: TrisaImplementationReviewProps) => {
             _hover={{
               bg: '#10aaed'
             }}>
-            {' '}
-            Edit{' '}
+            Edit
           </Button>
         </Box>
         <Stack fontSize={'1rem'}>
@@ -54,10 +54,23 @@ const TrisaImplementationReview = (props: TrisaImplementationReviewProps) => {
               sx={{
                 ' td': {
                   fontSize: '1rem'
+                },
+                'td:first-child': {
+                  width: '50%'
+                },
+                td: {
+                  borderBottom: 'none',
+                  paddingInlineStart: 0,
+                  paddingY: 2.5
                 }
               }}>
               <Tr>
-                <Td>TestNet TRISA Endpoint</Td>
+                <Td colSpan={2} background="#E5EDF1" fontWeight="bold" pl={'1rem !important'}>
+                  TestNet
+                </Td>
+              </Tr>
+              <Tr>
+                <Td pt={'1rem !important'}>TestNet TRISA Endpoint</Td>
                 <Td pl={0}>{trisa?.testnet?.endpoint || 'N/A'}</Td>
               </Tr>
               <Tr>
@@ -65,7 +78,15 @@ const TrisaImplementationReview = (props: TrisaImplementationReviewProps) => {
                 <Td pl={0}>{trisa?.testnet?.common_name || 'N/A'}</Td>
               </Tr>
               <Tr>
-                <Td>MainNet TRISA Endpoint</Td>
+                <Td colSpan={2}></Td>
+              </Tr>
+              <Tr>
+                <Td colSpan={2} background="#E5EDF1" fontWeight="bold" pl={'1rem !important'}>
+                  MainNet
+                </Td>
+              </Tr>
+              <Tr>
+                <Td pt={'1rem !important'}>MainNet TRISA Endpoint</Td>
                 <Td pl={0}>{trisa?.mainnet?.endpoint || 'N/A'}</Td>
               </Tr>
               <Tr>

--- a/web/gds-user-ui/src/components/CertificateReview/TrixoReview.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/TrixoReview.tsx
@@ -14,17 +14,24 @@ import {
 } from '@chakra-ui/react';
 import { colors } from 'utils/theme';
 import { useSelector, RootStateOrAny } from 'react-redux';
-import { getColorScheme } from 'utils/utils';
 import { loadDefaultValueFromLocalStorage, TStep } from 'utils/localStorageHelper';
 import useCertificateStepper from 'hooks/useCertificateStepper';
 import { COUNTRIES } from 'constants/countries';
+import { currencyFormatter } from 'utils/utils';
 interface TrixoReviewProps {}
 
 const TrixoReview: React.FC<TrixoReviewProps> = (props) => {
   const { jumpToStep } = useCertificateStepper();
   const steps: TStep[] = useSelector((state: RootStateOrAny) => state.stepper.steps);
   const [trixo, setTrixo] = React.useState<any>({});
-
+  const getColorScheme = (status: string | boolean) => {
+    console.log('[getColorScheme] status', status);
+    if (status === 'yes' || status === true) {
+      return 'green';
+    } else {
+      return 'orange';
+    }
+  };
   useEffect(() => {
     const getStepperData = loadDefaultValueFromLocalStorage();
     const stepData = {
@@ -32,6 +39,7 @@ const TrixoReview: React.FC<TrixoReviewProps> = (props) => {
     };
     setTrixo(stepData);
   }, [steps]);
+
   return (
     <Box
       border="1px solid #DFE0EB"
@@ -42,8 +50,10 @@ const TrixoReview: React.FC<TrixoReviewProps> = (props) => {
       p={5}
       px={5}>
       <Stack>
-        <Box display={'flex'} justifyContent="space-between" pt={4} ml={5}>
-          <Heading fontSize={20}>Section 5: TRIXO Questionnaire</Heading>
+        <Box display={'flex'} justifyContent="space-between" pt={4} ml={0}>
+          <Heading fontSize={20} mb="2rem">
+            Section 5: TRIXO Questionnaire
+          </Heading>
           <Button
             bg={colors.system.blue}
             color={'white'}
@@ -61,7 +71,15 @@ const TrixoReview: React.FC<TrixoReviewProps> = (props) => {
             sx={{
               'td:nth-child(2),td:nth-child(3)': { fontWeight: 'bold' },
               'td:nth-child(2)': { maxWidth: '75%' },
-              Tr: { borderStyle: 'hidden' }
+              Tr: { borderStyle: 'hidden' },
+              'td:first-child': {
+                width: '50%'
+              },
+              td: {
+                borderBottom: 'none',
+                paddingInlineStart: 0,
+                paddingY: 2.5
+              }
             }}>
             <Tbody>
               <Tr>
@@ -103,13 +121,21 @@ const TrixoReview: React.FC<TrixoReviewProps> = (props) => {
                     variant="subtle"
                     colorScheme={getColorScheme(trixo.financial_transfers_permitted)}>
                     <TagLabel fontWeight={'bold'}>
-                      {trixo.financial_transfers_permitted ? 'YES' : 'NO'}
+                      {trixo?.financial_transfers_permitted?.toUpperCase()}
                     </TagLabel>
                   </Tag>
                 </Td>
               </Tr>
               <Tr>
-                <Td fontWeight={'semibold'}>CDD & Travel Rule Policies</Td>
+                <Td></Td>
+              </Tr>
+              <Tr>
+                <Td colSpan={2} background="#E5EDF1" fontWeight="bold" pl={'1rem !important'}>
+                  CDD & Travel Rule Policies
+                </Td>
+              </Tr>
+              <Tr>
+                <Td></Td>
               </Tr>
               <Tr>
                 <Td>
@@ -140,17 +166,23 @@ const TrixoReview: React.FC<TrixoReviewProps> = (props) => {
                     size={'sm'}
                     key={'sm'}
                     variant="subtle"
-                    colorScheme={getColorScheme(trixo.financial_transfers_permitted)}>
-                    <TagLabel fontWeight={'bold'}>{trixo?.financial_transfers_permitted}</TagLabel>
+                    colorScheme={getColorScheme(trixo?.financial_transfers_permitted)}>
+                    <TagLabel fontWeight={'bold'}>
+                      {trixo?.financial_transfers_permitted?.toUpperCase()}
+                    </TagLabel>
                   </Tag>
                 </Td>
                 <Td></Td>
-              </Tr>{' '}
+              </Tr>
               <Tr>
                 <Td>At what threshold and currency does your organization conduct KYC?</Td>
                 <Td pl={0}>
                   <Tr>
-                    <Td>{trixo.kyc_threshold || 'N/A'}</Td>
+                    <Td>
+                      {currencyFormatter(trixo.kyc_threshold, {
+                        currency: trixo.kyc_threshold_currency
+                      }) || 'N/A'}
+                    </Td>
                     <Td pl={0}>{trixo.kyc_threshold_currency || 'N/A'}</Td>
                   </Tr>
                 </Td>
@@ -196,16 +228,26 @@ const TrixoReview: React.FC<TrixoReviewProps> = (props) => {
                 <Td>What is the minimum threshold for Travel Rule compliance?</Td>
                 <Td pl={0}>
                   <Tr>
-                    <Td>{trixo.compliance_threshold || 'N/A'}</Td>
+                    <Td>
+                      {currencyFormatter(trixo.compliance_threshold, {
+                        currency: trixo.compliance_threshold_currency
+                      }) || 'N/A'}
+                    </Td>
                     <Td pl={0}>{trixo.compliance_threshold_currency || 'N/A'}</Td>
                   </Tr>
                 </Td>
                 <Td></Td>
               </Tr>
               <Tr>
-                <Td fontWeight={'semibold'} colSpan={3}>
+                <Td></Td>
+              </Tr>
+              <Tr>
+                <Td colSpan={2} background="#E5EDF1" fontWeight="bold" pl={'1rem !important'}>
                   Data Protection Policies
                 </Td>
+              </Tr>
+              <Tr>
+                <Td></Td>
               </Tr>
               <Tr>
                 <Td>Is your organization required by law to safeguard PII?</Td>

--- a/web/gds-user-ui/src/index.css
+++ b/web/gds-user-ui/src/index.css
@@ -11,18 +11,7 @@
   /* color: #221f1f; */
 }
 
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+.heading {
   font-family: 'Roboto Slab', serif !important;
 }
 

--- a/web/gds-user-ui/src/modules/dashboard/certificate/registration.tsx
+++ b/web/gds-user-ui/src/modules/dashboard/certificate/registration.tsx
@@ -119,7 +119,7 @@ const Certificate: React.FC = () => {
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(handleNextStepClick)}>
             <Flex justifyContent={'space-between'}>
-              <Heading size="lg" mb="24px">
+              <Heading size="lg" mb="24px" className="heading">
                 Certificate Registration
               </Heading>
               <Box>


### PR DESCRIPTION
### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Scope of changes
Create two columns in Details cards on "Submit & Review" page
This needs to be two uniform columns. We want the same column width across all cards so that when the user scrolls down, the information does not "zig zag" back and forth (along with the user's eyes).

### Acceptance criteria
After filling each steps of certificate registration, you can see on Review page that all columns are now uniform

### Author checklist

- [x] I have manually tested the change
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated ShortCut or Jira ticket to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


