### PR TITLE
BFF CSRF Middleware

### DIFF
--- a/pkg/bff/auth/csrf.go
+++ b/pkg/bff/auth/csrf.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
+)
+
+// Parameters and headers for double-cookie submit CSRF protection
+const (
+	CSRFCookie          = "csrf_token"
+	CSRFReferenceCookie = "csrf_reference_token"
+	CSRFHeader          = "X-CSRF-TOKEN"
+)
+
+// DoubleCookie is a Cross-Site Request Forgery (CSR/XSRF) protection middleware that
+// checks the presence of an X-CSRF-TOKEN header containing a cryptographically random
+// token that matches a token contained in the CSRF-TOKEN cookie in the request.
+// Because of the same-origin poicy, an attacker cannot access the cookies or scripts
+// of the safe site, therefore the X-CSRF-TOKEN header cannot be forged, and if it is
+// omitted because it is being re-posted by an attacker site then the request will be
+// rejected with a 403 error. Note that this protection requires TLS to prevent MITM.
+func DoubleCookie() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		cookie, err := c.Cookie(CSRFReferenceCookie)
+		if err != nil {
+			c.Error(err)
+			c.AbortWithStatusJSON(http.StatusForbidden, api.ErrorResponse(ErrCSRFVerification))
+			return
+		}
+
+		header := c.GetHeader(CSRFHeader)
+		if header, err = url.QueryUnescape(header); err != nil {
+			c.Error(err)
+			c.AbortWithStatusJSON(http.StatusBadRequest, api.ErrorResponse(err))
+			return
+		}
+
+		if cookie == "" || header == "" {
+			log.Warn().Bool("header_exists", header != "").Bool("cookie_exists", cookie != "").Msg("missing either csrf token header or reference cookie")
+			c.AbortWithStatusJSON(http.StatusForbidden, api.ErrorResponse(ErrCSRFVerification))
+			return
+		}
+
+		if cookie != header {
+			log.Warn().Bool("header_exists", header != "").Bool("cookie_exists", cookie != "").Msg("csrf token cookie/header mismatch")
+			c.AbortWithStatusJSON(http.StatusForbidden, api.ErrorResponse(ErrCSRFVerification))
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// SetDoubleCookieToken is a helper function to set cookies on a gin request.
+func SetDoubleCookieToken(c *gin.Context, domain string, expires time.Time) error {
+	// Generate a secure token
+	token, err := GenerateCSRFToken()
+	if err != nil {
+		return err
+	}
+
+	// Set the reference cookie as http only but allow access to the csrf cookie so that the
+	// front-end can fetch it to add it to the X-CSRF-TOKEN header in the request.
+	maxAge := int((time.Until(expires)).Seconds()) + 60
+	c.SetCookie(CSRFReferenceCookie, token, maxAge, "/", domain, true, true)
+	c.SetCookie(CSRFCookie, token, maxAge, "/", domain, true, false)
+	return nil
+}
+
+// Random seed is an additional barrier to cryptanalysis and is unique to each BFF process.
+var (
+	seed     []byte
+	initseed sync.Once
+)
+
+func GenerateCSRFToken() (_ string, err error) {
+	// Ensure the seed is generated the first time this method is called
+	initseed.Do(func() {
+		seed = make([]byte, 16)
+		if _, err = rand.Read(seed); err != nil {
+			log.WithLevel(zerolog.FatalLevel).Err(err).Msg("could not set csrf token generator random seed")
+		}
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, 32)
+	if _, err = rand.Read(nonce); err != nil {
+		return "", err
+	}
+
+	sig := sha256.New()
+	sig.Write(seed)
+	sig.Write(nonce)
+
+	return base64.URLEncoding.EncodeToString(sig.Sum(nil)), nil
+}

--- a/pkg/bff/auth/csrf_test.go
+++ b/pkg/bff/auth/csrf_test.go
@@ -135,7 +135,7 @@ func readJSON(rep *http.Response) (gin.H, error) {
 }
 
 func TestGenerateCSRFToken(t *testing.T) {
-	// Generate 100 tokens and ensure that they do not equal the prevous tokens
+	// Generate 100 tokens and ensure that they do not equal the previous tokens
 	tokens := make([]string, 0, 100)
 	for i := 0; i < 100; i++ {
 		token, err := auth.GenerateCSRFToken()

--- a/pkg/bff/auth/csrf_test.go
+++ b/pkg/bff/auth/csrf_test.go
@@ -1,0 +1,153 @@
+package auth_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/bff/auth"
+)
+
+func TestDoubleCookies(t *testing.T) {
+	// Test both the DoubleCookie middleware and the SetDoubleCookieTokens handler
+	router := gin.New()
+
+	// Add a route that sets the cookies
+	router.GET("/protect", func(c *gin.Context) {
+		err := auth.SetDoubleCookieToken(c, "", time.Now().Add(10*time.Minute))
+		require.NoError(t, err)
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	// Add a route that requires double cookie submit
+	router.POST("/action", auth.DoubleCookie(), func(c *gin.Context) {
+		c.JSON(http.StatusCreated, gin.H{"success": true})
+	})
+
+	// Create a tls test server with the CSRF protected router
+	srv := httptest.NewTLSServer(router)
+	defer srv.Close()
+
+	// Create an https client with a cookie jar
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := srv.Client()
+	client.Jar = jar
+
+	// Atttempt to make a request that is not CSRF protected
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/action", nil)
+	require.NoError(t, err)
+
+	// Ensure the request is Forbidden
+	rep, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, rep.StatusCode)
+
+	// Check the data in the response
+	data, err := readJSON(rep)
+	require.NoError(t, err, "could not parse response")
+	require.Contains(t, data, "error")
+	require.Equal(t, auth.ErrCSRFVerification.Error(), data["error"].(string))
+
+	// Login and set the cookies
+	req, err = http.NewRequest(http.MethodGet, srv.URL+"/protect", nil)
+	require.NoError(t, err)
+
+	// Execute the protect request
+	rep, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rep.StatusCode)
+
+	// Check that we got back two cookies in the response
+	cookies := rep.Cookies()
+	require.Len(t, cookies, 2)
+
+	testCases := make([]*http.Request, 0, 3)
+
+	// Attempt to send a request with the cookies but no X-CSRF-TOKEN Header
+	reqa, err := http.NewRequest(http.MethodPost, srv.URL+"/action", nil)
+	require.NoError(t, err)
+	testCases = append(testCases, reqa)
+
+	// Send a request with the cookies but an empty X-CSRF-TOKEN Header
+	reqb, err := http.NewRequest(http.MethodPost, srv.URL+"/action", nil)
+	reqb.Header.Set(auth.CSRFHeader, "")
+	require.NoError(t, err)
+	testCases = append(testCases, reqb)
+
+	// Send a request with the cookies but an incorrect X-CSRF-TOKEN Header
+	reqc, err := http.NewRequest(http.MethodPost, srv.URL+"/action", nil)
+	reqc.Header.Set(auth.CSRFHeader, "not a valid csrf token")
+	require.NoError(t, err)
+	testCases = append(testCases, reqc)
+
+	for i, req := range testCases {
+		// Ensure the request is Forbidden
+		rep, err = client.Do(req)
+		require.NoError(t, err, "bad request %d failed", i)
+		require.Equal(t, http.StatusForbidden, rep.StatusCode, "bad request %d failed", i)
+
+		// Check data in the response
+		data, err = readJSON(rep)
+		require.NoError(t, err, "bad request %d failed", i)
+		require.Contains(t, data, "error", "bad request %d failed", i)
+		require.Equal(t, auth.ErrCSRFVerification.Error(), data["error"].(string), "bad request %d failed", i)
+
+	}
+
+	// Send a valid request with the double cookie protection intact
+	var cookieToken string
+	for _, cookie := range cookies {
+		if cookie.Name == auth.CSRFCookie {
+			cookieToken = cookie.Value
+		}
+	}
+
+	require.NotEmpty(t, cookieToken, "could not find cookie in response")
+	req, err = http.NewRequest(http.MethodPost, srv.URL+"/action", nil)
+	req.Header.Set(auth.CSRFHeader, cookieToken)
+	require.NoError(t, err)
+
+	rep, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rep.StatusCode)
+
+	data, err = readJSON(rep)
+	require.NoError(t, err)
+	require.NotContains(t, data, "error")
+	require.Contains(t, data, "success")
+	require.True(t, data["success"].(bool))
+
+}
+
+func readJSON(rep *http.Response) (gin.H, error) {
+	defer rep.Body.Close()
+	data := make(gin.H)
+	if err := json.NewDecoder(rep.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func TestGenerateCSRFToken(t *testing.T) {
+	// Generate 100 tokens and ensure that they do not equal the prevous tokens
+	tokens := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		token, err := auth.GenerateCSRFToken()
+		require.NoError(t, err, "could not generate CSRF token")
+		tokens = append(tokens, token)
+	}
+
+	for i, token := range tokens {
+		for j, other := range tokens {
+			if i != j {
+				require.NotEqual(t, token, other, "all tokens generated should be unique")
+			}
+		}
+	}
+}

--- a/pkg/bff/auth/errors.go
+++ b/pkg/bff/auth/errors.go
@@ -3,7 +3,14 @@ package auth
 import "errors"
 
 var (
-	ErrUnauthenticated = errors.New("request is unauthenticated")
-	ErrNoClaims        = errors.New("no claims found on the request context")
-	ErrNoUserInfo      = errors.New("no user info found on the request context")
+	ErrUnauthenticated  = errors.New("request is unauthenticated")
+	ErrNoClaims         = errors.New("no claims found on the request context")
+	ErrNoUserInfo       = errors.New("no user info found on the request context")
+	ErrInvalidAuthToken = errors.New("invalid authorization token")
+	ErrNoAuthorization  = errors.New("could not authorize request")
+	ErrAuthRequired     = errors.New("this endpoint requires authentication")
+	ErrNoPermission     = errors.New("user does not have permission to perform this operation")
+	ErrNoAuthUser       = errors.New("could not identify authenticated user in request")
+	ErrNoAuthUserData   = errors.New("could not retrieve user data")
+	ErrCSRFVerification = errors.New("csrf verification failed for request")
 )


### PR DESCRIPTION
### Scope of changes

Adds double cookie CSRF protection to the BFF middleware. The login endpoint also now sets double cookies that the UI must respect to prevent CSRF attacks. The CSRF protection will be applied to all `POST` endpoints to prevent malicious websites from cross-site forgery. 

We do have an implementation of this middleware for the Admin API - but this implementation is BFF-specific and is perhaps a bit stronger than the Admin implementation. It may be worth it to review the admin implementation at some point. 

SC-6407

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [x]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


