### PR TITLE
GDS BFF Network Announcement Endpoint

### DIFF
--- a/pkg/bff/announcements.go
+++ b/pkg/bff/announcements.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	maxAnnouncements    = 10
-	announcementsWindow = -1 * 31 * 24 * time.Hour
+	maxAnnouncements = 10
+	subMonths        = -1
 )
 
 func (s *Server) Announcements(c *gin.Context) {
-	// Only fetch the previous 10 announcements from the last 30 days
-	nbf := time.Now().Add(announcementsWindow)
+	// Only fetch the previous 10 announcements from the last month
+	nbf := time.Now().AddDate(0, subMonths, 0)
 	out, err := s.db.Announcements().Recent(c.Request.Context(), maxAnnouncements, nbf)
 	if err != nil {
 		log.Error().Err(err).Msg("could not fetch recent announcements")

--- a/pkg/bff/announcements.go
+++ b/pkg/bff/announcements.go
@@ -60,7 +60,7 @@ func (s *Server) MakeAnnouncement(c *gin.Context) {
 	}
 
 	if claims.Email == "" {
-		log.Warn().Msg("missing email on claims cannot set author of network announcement")
+		log.Warn().Msg("missing email on claims, cannot set author of network announcement")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("user claims are not correctly configured"))
 		return
 	}

--- a/pkg/bff/announcements.go
+++ b/pkg/bff/announcements.go
@@ -1,13 +1,81 @@
 package bff
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
+	"github.com/trisacrypto/directory/pkg/bff/auth"
+)
+
+const (
+	maxAnnouncements    = 10
+	announcementsWindow = -1 * 31 * 24 * time.Hour
 )
 
 func (s *Server) Announcements(c *gin.Context) {
+	// Only fetch the previous 10 announcements from the last 30 days
+	nbf := time.Now().Add(announcementsWindow)
+	out, err := s.db.Announcements().Recent(c.Request.Context(), maxAnnouncements, nbf)
+	if err != nil {
+		log.Error().Err(err).Msg("could not fetch recent announcements")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("unable to fetch recent announcements"))
+		return
+	}
 
+	// If the database is empty, set the last updated timestamp to now.
+	if len(out.Announcements) == 0 && out.LastUpdated == "" {
+		out.LastUpdated = time.Now().Format(time.RFC3339)
+	}
+
+	// Return the results
+	c.JSON(http.StatusOK, out)
 }
 
 func (s *Server) MakeAnnouncement(c *gin.Context) {
+	var (
+		id     string
+		err    error
+		claims *auth.Claims
+		post   *api.Announcement
+	)
 
+	if err = c.BindJSON(&post); err != nil {
+		log.Warn().Err(err).Msg("could not parse announcement post data")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse announcement JSON data"))
+		return
+	}
+
+	if post.PostDate != "" || post.Author != "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("cannot set the post_date or author fields on the post"))
+		return
+	}
+
+	if claims, err = auth.GetClaims(c); err != nil {
+		log.Error().Err(err).Msg("could not fetch claims from request")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not save announcement"))
+		return
+	}
+
+	if claims.Email == "" {
+		log.Warn().Msg("missing email on claims cannot set author of network announcement")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("user claims are not correctly configured"))
+		return
+	}
+
+	// Set the post date and the author
+	post.PostDate = time.Now().Format("2006-01-02")
+	post.Author = claims.Email
+
+	if id, err = s.db.Announcements().Post(c.Request.Context(), post); err != nil {
+		log.Error().Err(err).Msg("could not put announcement to trtl database")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not save announcement"))
+		return
+	}
+
+	// Return a 204 No Content to indicate the post happened successfully
+	log.Info().Str("id", id).Str("title", post.Title).Str("author", post.Author).Msg("network announcement added")
+	c.JSON(http.StatusNoContent, nil)
 }

--- a/pkg/bff/announcements.go
+++ b/pkg/bff/announcements.go
@@ -1,0 +1,13 @@
+package bff
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) Announcements(c *gin.Context) {
+
+}
+
+func (s *Server) MakeAnnouncement(c *gin.Context) {
+
+}

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -9,12 +9,14 @@ import (
 //===========================================================================
 
 type BFFClient interface {
-	Status(ctx context.Context, in *StatusParams) (out *StatusReply, err error)
-	Overview(ctx context.Context) (out *OverviewReply, err error)
-	Certificates(ctx context.Context) (out *CertificatesReply, err error)
-	Lookup(ctx context.Context, in *LookupParams) (out *LookupReply, err error)
-	Register(ctx context.Context, in *RegisterRequest) (out *RegisterReply, err error)
-	VerifyContact(ctx context.Context, in *VerifyContactParams) (out *VerifyContactReply, err error)
+	Status(context.Context, *StatusParams) (*StatusReply, error)
+	Overview(context.Context) (*OverviewReply, error)
+	Announcements(context.Context) (*AnnouncementsReply, error)
+	MakeAnnouncement(context.Context, *Announcement) error
+	Certificates(context.Context) (*CertificatesReply, error)
+	Lookup(context.Context, *LookupParams) (*LookupReply, error)
+	Register(context.Context, *RegisterRequest) (*RegisterReply, error)
+	VerifyContact(context.Context, *VerifyContactParams) (*VerifyContactReply, error)
 }
 
 //===========================================================================
@@ -67,6 +69,22 @@ type MemberDetails struct {
 	Status      string                 `json:"status"`
 	CountryCode string                 `json:"country_code"`
 	Certificate map[string]interface{} `json:"certificate"`
+}
+
+// AnnouncementsReply contains up to the last 10 network announcements that were made in
+// the past month. It does not require pagination since only relevant results are returned.
+type AnnouncementsReply struct {
+	Announcements []*Announcement `json:"announcements"`
+	LastUpdated   string          `json:"last_updated,omitempty"`
+}
+
+// Announcement represents a single network announcementthat can be posted to the
+// endpoint or returned in the announcements reply.
+type Announcement struct {
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	PostDate string `json:"post_date,omitempty"` // Ignored on POST only available on GET
+	Author   string `json:"author,omitempty"`    // Ignored on POST only available on GET
 }
 
 // CertificatesReply is returned on certificates requests.

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -165,6 +165,41 @@ func (s *APIv1) Overview(ctx context.Context) (out *OverviewReply, err error) {
 	return out, nil
 }
 
+func (s *APIv1) Announcements(ctx context.Context) (out *AnnouncementsReply, err error) {
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/announcements", nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &AnnouncementsReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *APIv1) MakeAnnouncement(ctx context.Context, in *Announcement) (err error) {
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/announcements", in, nil); err != nil {
+		return err
+	}
+
+	// Execute the request and get a response, ensuring to check that a 200 response is returned.
+	var rep *http.Response
+	if rep, err = s.Do(req, nil, true); err != nil {
+		return err
+	}
+
+	// If this endpoint does not return a 204 then return an error since data is unhandled.
+	if rep.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("expected no content, received %s", rep.Status)
+	}
+	return nil
+}
+
 func (s *APIv1) Certificates(ctx context.Context) (out *CertificatesReply, err error) {
 	// Make the HTTP request
 	var req *http.Request
@@ -249,13 +284,13 @@ func (s *APIv1) Do(req *http.Request, data interface{}, checkStatus bool) (rep *
 		}
 	}
 
-	// Check the content type to ensure data deserialization is possible
-	if ct := rep.Header.Get("Content-Type"); ct != contentType {
-		return rep, fmt.Errorf("unexpected content type: %q", ct)
-	}
-
 	// Deserialize the JSON data from the body
 	if data != nil && rep.StatusCode >= 200 && rep.StatusCode < 300 {
+		// Check the content type to ensure data deserialization is possible
+		if ct := rep.Header.Get("Content-Type"); ct != contentType {
+			return rep, fmt.Errorf("unexpected content type: %q", ct)
+		}
+
 		if err = json.NewDecoder(rep.Body).Decode(data); err != nil {
 			return nil, fmt.Errorf("could not deserialize response data: %s", err)
 		}

--- a/pkg/bff/db/announcements.go
+++ b/pkg/bff/db/announcements.go
@@ -1,0 +1,179 @@
+package db
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
+	trtl "github.com/trisacrypto/directory/pkg/trtl/pb/v1"
+)
+
+const (
+	NamespaceAnnouncements = "announcements"
+)
+
+var (
+	lastUpdatedKey = []byte("last_updated")
+)
+
+// The Announcements type exposes methods for interacting with Network Announcements
+// in the database. Announcements are stored as compact, compressed JSON to minimize the
+// network requests and reduce storage requirements. This struct performs all necessary
+// serialization on the announcements before storing and retrieving the model object. The
+// announcement keys are ksuids - timestamp ordered unique IDs so that it is easy to scan
+// the trtl database to find the most recent announcements.
+//
+// Announcements implements the Collection interface
+type Announcements struct {
+	db        *DB
+	namespace string
+}
+
+// Ensure that Announcements implements the Collection interface.
+var _ Collection = &Announcements{}
+
+// Announcements constructs the collection type for interactions with network
+// announcement objects. This method is intended to be used with chaining, e.g. as
+// db.Announcements().Recent(), so to reduce the number of allocations a singleton
+// intermediate struct is used. Method calls to the collection are thread-safe.
+func (db *DB) Announcements() *Announcements {
+	db.muMakeAC.Do(func() {
+		db.announcements = &Announcements{
+			db:        db,
+			namespace: NamespaceAnnouncements,
+		}
+	})
+	return db.announcements
+}
+
+// Recent returns the set of results whose post date is after the not before timestamp,
+// limited to the maximum number of results. Last updated returns the timestamp that
+// any announcement was added or changed.
+func (a *Announcements) Recent(ctx context.Context, maxResults int, notBefore time.Time) (out *api.AnnouncementsReply, err error) {
+	out = &api.AnnouncementsReply{
+		Announcements: make([]*api.Announcement, 0, maxResults),
+	}
+
+	// Get the last updated value from the index key in the collection.
+	var value []byte
+	if value, err = a.db.Get(ctx, lastUpdatedKey, a.namespace); err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, fmt.Errorf("could not fetch last updated: %s", err)
+	}
+
+	if len(value) > 0 {
+		if err = json.Unmarshal(value, &out.LastUpdated); err != nil {
+			return nil, fmt.Errorf("could not unmarshal last updated: %s", err)
+		}
+	}
+
+	var cursor trtl.Trtl_CursorClient
+	if cursor, err = a.db.trtl.Cursor(ctx, &trtl.CursorRequest{Namespace: a.namespace}); err != nil {
+		return nil, fmt.Errorf("could not connect to trtl cursor: %s", err)
+	}
+	defer cursor.CloseSend()
+
+	// Consume the cursor
+	// TODO: add max results and not before filtering
+	for {
+		var pair *trtl.KVPair
+		if pair, err = cursor.Recv(); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("could not read message from cursor: %s", err)
+		}
+
+		if bytes.Equal(pair.Key, lastUpdatedKey) {
+			continue
+		}
+
+		var post *api.Announcement
+		if post, err = a.Decode(pair.Value); err != nil {
+			return nil, fmt.Errorf("could not decode announcement from database: %s", err)
+		}
+
+		out.Announcements = append(out.Announcements, post)
+	}
+
+	return out, nil
+}
+
+// Post an announcement, putting it to the trtl database. This method does no
+// verification of duplicate announcements or any content verification except for a
+// check that an empty announcement is not being put to the database.
+func (a *Announcements) Post(ctx context.Context, in *api.Announcement) (_ string, err error) {
+	// Make sure we don't post empty announcements
+	if in.Title == "" && in.Body == "" && in.PostDate == "" && in.Author == "" {
+		return "", ErrEmptyAnnouncement
+	}
+
+	// Encode the Post to bytes for storage
+	var value []byte
+	if value, err = a.Encode(in); err != nil {
+		return "", fmt.Errorf("could not encode announcement: %s", err)
+	}
+
+	// Create a ksuid for the post
+	key := ksuid.New()
+
+	if err = a.db.Put(ctx, key.Bytes(), value, a.namespace); err != nil {
+		return "", fmt.Errorf("could not put announcement to db: %s", err)
+	}
+
+	// Set the last updated timestamp on the database
+	var updated []byte
+	if updated, err = json.Marshal(time.Now()); err != nil {
+		return "", fmt.Errorf("could not create last updated timestamp value: %s", err)
+	}
+
+	if err = a.db.Put(ctx, lastUpdatedKey, updated, a.namespace); err != nil {
+		return "", fmt.Errorf("could not put last updated index: %s", err)
+	}
+
+	return key.String(), nil
+}
+
+// Namespace implements the collection interface
+func (a *Announcements) Namespace() string {
+	return a.namespace
+}
+
+// Encode an announcement for storage in the database.
+// HACK: the api definition is probably not the right place to store a database model,
+// should we just create protocol buffer model definitions instead of using this?
+func (a *Announcements) Encode(in *api.Announcement) (_ []byte, err error) {
+	buf := &bytes.Buffer{}
+	w := gzip.NewWriter(buf)
+
+	if err = json.NewEncoder(w).Encode(in); err != nil {
+		return nil, err
+	}
+	w.Close()
+
+	return buf.Bytes(), nil
+}
+
+// Decode an annoucement from storage in the database.
+// HACK: the api definition is probably not the right place to store a database model,
+// should we just create protocol buffer model definitions instead of using this?
+func (a *Announcements) Decode(data []byte) (out *api.Announcement, err error) {
+	buf := bytes.NewBuffer(data)
+
+	var r *gzip.Reader
+	if r, err = gzip.NewReader(buf); err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	if err = json.NewDecoder(r).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/bff/db/announcements_test.go
+++ b/pkg/bff/db/announcements_test.go
@@ -1,0 +1,114 @@
+package db_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/bff/api/v1"
+	"github.com/trisacrypto/directory/pkg/bff/db"
+	. "github.com/trisacrypto/directory/pkg/bff/db"
+)
+
+func (s *dbTestSuite) TestAnnouncements() {
+	// Test creating and retrieving announcements
+	var err error
+	require := s.Require()
+
+	// Announcements should implement the Collection interface
+	require.Equal(db.NamespaceAnnouncements, s.db.Announcements().Namespace())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// There should be nothing in the database at the start of the test.
+	recent, err := s.db.Announcements().Recent(ctx, 10000, time.Time{})
+	require.NoError(err, "could not fetch recent announcements")
+	require.Len(recent.Announcements, 0, "expected no announcements returned")
+	require.Empty(recent.LastUpdated, "expected last updated to be zero-valued")
+
+	// Load announcements fixtures
+	fixture, err := loadAnnouncements()
+	require.NoError(err, "could not load announcement fixtures")
+	require.Len(fixture, 10, "fixtures have changed without test update")
+
+	// Post each fixture one at a time and ensure that we can fetch them all
+	ids := make([]string, 0, 10)
+	for i, post := range fixture {
+		id, err := s.db.Announcements().Post(ctx, post)
+		require.NoError(err, "could not post announcement %d", i)
+		require.NotEmpty(id, "expected an ordered kid to be assigned")
+		ids = append(ids, id)
+
+		// Ensure there is at least 1 second between each post or the ksuid will
+		// identify the posts as concurrent and produce an incorrect ordering.
+		// Normally posts won't be published within the same second, but this is a bad
+		// situation for tests because it means that this test will take a min of 10
+		// seconds to run, which adds up in CI and beyond ...
+		time.Sleep(1 * time.Second)
+	}
+
+	// Ensure all IDs assigned are unique
+	for i, id := range ids {
+		for j, jd := range ids {
+			if i == j {
+				continue
+			}
+			require.NotEqual(id, jd, "expected assigned IDs to be unique in database")
+		}
+	}
+
+	// Should be able to retrieve all recent announcements
+	recent, err = s.db.Announcements().Recent(ctx, 10000, time.Time{})
+	require.NoError(err, "could not fetch recent announcements")
+	require.Len(recent.Announcements, 10, "expected 10 announcements returned")
+	require.NotEmpty(recent.LastUpdated, "expected last updated to be set")
+
+	// The Posts should be returned in the expected order
+	// NOTE: we will get a random order of our posts if we don't sleep 1 second between Post
+	for i, post := range recent.Announcements {
+		expected := fmt.Sprintf("Post %d", i+1)
+		require.Equal(expected, post.Title, "posts seem to be out of order")
+	}
+}
+
+func TestAnnouncementsSerialization(t *testing.T) {
+	// Should be able to encode and decode an announcement to and from bytes.
+	announcement := &api.Announcement{
+		Title:    "It is the Solstice!",
+		Body:     "Today is the longest day of the year, make sure it's a grilling day!",
+		PostDate: "2022-06-21",
+		Author:   "summer@solstice.ninja",
+	}
+
+	// Technically an empty collection should be able to encode and decode the model.
+	// The only reason these methods are attached to the collection is for namespacing.
+	collection := &Announcements{}
+	data, err := collection.Encode(announcement)
+	require.NoError(t, err, "could not encode announcement into bytes")
+	require.NotEmpty(t, data, "expected some data returned from encoding")
+	require.Len(t, data, 158, "encoding compression has changed")
+
+	// Decode the announcement
+	decoded, err := collection.Decode(data)
+	require.NoError(t, err, "could not decode announcement from bytes")
+	require.Equal(t, announcement, decoded, "the decoded announcement did not match the original")
+}
+
+func loadAnnouncements() (fixture []*api.Announcement, err error) {
+	var f *os.File
+	if f, err = os.Open("testdata/announcements.json"); err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fixture = make([]*api.Announcement, 0, 10)
+	if err = json.NewDecoder(f).Decode(&fixture); err != nil {
+		return nil, err
+	}
+	return fixture, nil
+}

--- a/pkg/bff/db/db.go
+++ b/pkg/bff/db/db.go
@@ -1,17 +1,21 @@
 package db
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net/url"
+	"sync"
 
 	"github.com/trisacrypto/directory/pkg/bff/config"
 	trtl "github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"github.com/trisacrypto/trisa/pkg/trust"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 func Connect(conf config.DatabaseConfig) (db *DB, err error) {
@@ -76,10 +80,89 @@ func DirectConnect(cc *grpc.ClientConn) (db *DB, err error) {
 
 // DB is a wrapper around a trtl client to provide BFF-specific database interactions
 type DB struct {
+	// Connection to the Trtl Database
 	cc   *grpc.ClientConn
 	trtl trtl.TrtlClient
+
+	// Announcements collection and singleton helper
+	announcements *Announcements
+	muMakeAC      sync.Once
+}
+
+// Collection is an interface that identifies utilities that manage specific namespaces.
+type Collection interface {
+	Namespace() string
 }
 
 func (db *DB) Close() error {
+	defer func() {
+		db.cc = nil
+		db.trtl = nil
+	}()
 	return db.cc.Close()
+}
+
+// Get is a high-level method for executing a fetch key request to a namespace in trtl.
+func (db *DB) Get(ctx context.Context, key []byte, namespace string) (value []byte, err error) {
+	req := &trtl.GetRequest{
+		Key:       key,
+		Namespace: namespace,
+		Options: &trtl.Options{
+			ReturnMeta: false,
+		},
+	}
+
+	var rep *trtl.GetReply
+	if rep, err = db.trtl.Get(ctx, req); err != nil {
+		if serr, ok := status.FromError(err); ok {
+			if serr.Code() == codes.NotFound {
+				return nil, ErrNotFound
+			}
+		}
+		return nil, err
+	}
+	return rep.Value, nil
+}
+
+// Put is a high-level method for executing a put value to key request to a namespace in trtl.
+func (db *DB) Put(ctx context.Context, key, value []byte, namespace string) (err error) {
+	req := &trtl.PutRequest{
+		Key:       key,
+		Value:     value,
+		Namespace: namespace,
+		Options: &trtl.Options{
+			ReturnMeta: false,
+		},
+	}
+
+	var rep *trtl.PutReply
+	if rep, err = db.trtl.Put(ctx, req); err != nil {
+		return err
+	}
+
+	if !rep.Success {
+		return ErrUnsuccessfulPut
+	}
+	return nil
+}
+
+// Delete is a high-level method for executing a delete key-value request to a namespace in trtl.
+func (db *DB) Delete(ctx context.Context, key []byte, namespace string) (err error) {
+	req := &trtl.DeleteRequest{
+		Key:       key,
+		Namespace: namespace,
+		Options: &trtl.Options{
+			ReturnMeta: false,
+		},
+	}
+
+	var rep *trtl.DeleteReply
+	if rep, err = db.trtl.Delete(ctx, req); err != nil {
+		return err
+	}
+
+	if !rep.Success {
+		return ErrUnsuccessfulDelete
+	}
+	return nil
 }

--- a/pkg/bff/db/db_test.go
+++ b/pkg/bff/db/db_test.go
@@ -1,0 +1,106 @@
+package db_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trisacrypto/directory/pkg/bff/db"
+	"github.com/trisacrypto/directory/pkg/trtl"
+	"github.com/trisacrypto/directory/pkg/utils/bufconn"
+)
+
+const (
+	bufsize = 1024 * 1024
+)
+
+// The DB Test Suite creates a running trtl process in memory and a database connection
+// to it through bufconn, allowing us to test the BFF interactions with a live trtl db.
+// This suite is intended to specifically test the database code in this package.
+type dbTestSuite struct {
+	suite.Suite
+	db   *db.DB
+	trtl *trtl.Server
+	conn *bufconn.GRPCListener
+}
+
+func TestDatabaseSuite(t *testing.T) {
+	s := new(dbTestSuite)
+	suite.Run(t, s)
+}
+
+func (s *dbTestSuite) SetupSuite() {
+	var err error
+	require := s.Require()
+
+	// Create a trtl config that points trtl to a temporary directory for storage
+	conf := trtl.MockConfig()
+	conf.Database.URL = "leveldb:///" + s.T().TempDir()
+	conf, err = conf.Mark()
+	require.NoError(err, "could not mark config as processed")
+
+	// Create a bufconn to connect to the trtl server on
+	s.conn = bufconn.New(bufsize)
+	err = s.conn.Connect()
+	require.NoError(err, "could not dial the bufconn")
+
+	// Start the Trtl server
+	s.trtl, err = trtl.New(conf)
+	require.NoError(err, "could not create the trtl server")
+	go s.trtl.Run(s.conn.Listener)
+
+	// Connect our database to the running Trtl server
+	s.db, err = db.DirectConnect(s.conn.Conn)
+	require.NoError(err, "could not connect the database to the trtl server")
+}
+
+func (s *dbTestSuite) TearDownSuite() {
+	var err error
+	require := s.Require()
+
+	err = s.db.Close()
+	require.NoError(err, "could not close database")
+
+	err = s.trtl.Shutdown()
+	require.NoError(err, "could not shutdown trtl in-memory process")
+
+	s.conn.Release()
+}
+
+func (s *dbTestSuite) TestBasicOperations() {
+	// Test Put, Get, and Delete against the database
+	var err error
+	require := s.Require()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	key := []byte("thisisthetestkey")
+	value := []byte("thisisthetestvaluehawtness")
+	namespace := "thisisthetestnamespace"
+
+	// Expect a not found error when the key is not there
+	_, err = s.db.Get(ctx, key, namespace)
+	require.ErrorIs(err, db.ErrNotFound, "expected not found error before Put")
+
+	// Should be able to successfully Put the key-value pair
+	err = s.db.Put(ctx, key, value, namespace)
+	require.NoError(err, "could not Put to the database")
+
+	retrieved, err := s.db.Get(ctx, key, namespace)
+	require.NoError(err, "could not fetch key just put to db")
+	require.True(bytes.Equal(value, retrieved), "retrieved value not identical to original")
+
+	// Should have been put to the correct namespace
+	_, err = s.db.Get(ctx, key, "thisisnotthetestnamespace")
+	require.ErrorIs(err, db.ErrNotFound, "expected not found error on wrong namespace")
+
+	// Should be able to Delete the key-value pair
+	err = s.db.Delete(ctx, key, namespace)
+	require.NoError(err, "could not Delete key from the database")
+
+	_, err = s.db.Get(ctx, key, namespace)
+	require.ErrorIs(err, db.ErrNotFound, "expected not found error after Delete")
+}

--- a/pkg/bff/db/errors.go
+++ b/pkg/bff/db/errors.go
@@ -1,0 +1,10 @@
+package db
+
+import "errors"
+
+var (
+	ErrNotFound           = errors.New("key not found in database")
+	ErrUnsuccessfulPut    = errors.New("unable to successfully make Put request to trtl")
+	ErrUnsuccessfulDelete = errors.New("unable to successfully make Delete request to trtl")
+	ErrEmptyAnnouncement  = errors.New("cannot post a zero-valued announcement")
+)

--- a/pkg/bff/db/testdata/announcements.json
+++ b/pkg/bff/db/testdata/announcements.json
@@ -1,0 +1,62 @@
+[
+  {
+    "title": "Post 1",
+    "body": "Maecenas nec dolor leo. Curabitur a est facilisis, aliquet mi vitae, vehicula enim. Nunc pulvinar varius auctor. Etiam sollicitudin convallis venenatis. Donec posuere blandit dui ut lobortis. Pellentesque blandit faucibus sollicitudin. Duis malesuada, nisl et elementum accumsan, justo arcu auctor orci, luctus faucibus turpis mi ac sem.",
+    "post_date": "2022-01-14",
+    "author": "admin@trisa.io"
+  },
+  {
+    "title": "Post 2",
+    "body": "Pellentesque fringilla, lorem et ultrices vehicula, est urna mattis lacus, ac pulvinar tortor sapien in lacus. Aliquam sed imperdiet sem, in feugiat erat. Pellentesque id tempus tellus. Nulla et sagittis nisl, efficitur consectetur risus. Nulla vel purus vestibulum, venenatis massa vel, pretium arcu. Integer luctus augue enim, sed eleifend massa auctor ac. Vivamus neque lacus, egestas in mauris non, finibus lacinia odio.",
+    "post_date": "2022-01-29",
+    "author": "admin@trisa.io"
+  },
+  {
+    "title": "Post 3",
+    "body": "Curabitur nec elementum ligula. Nam quis venenatis diam. Etiam vitae pretium velit. Maecenas tristique diam eu nibh rhoncus, a dignissim nibh volutpat. Nunc lobortis lectus ut tempus facilisis. Aliquam dictum, tellus placerat eleifend aliquam, justo mi suscipit dolor, eget gravida ante lectus non ligula. Vivamus lectus tellus, ornare sit amet tellus id, cursus volutpat nisl.",
+    "post_date": "2022-02-08",
+    "author": "support@rotational.io"
+  },
+  {
+    "title": "Post 4",
+    "body": "Sed rutrum venenatis neque, non vestibulum ante lobortis eget. Etiam sed sem in ante placerat fermentum in a mi. Sed non viverra turpis, non porta ex. Quisque vitae eros finibus, auctor ipsum id, fringilla turpis. Duis ac neque est. Mauris in malesuada neque, sed congue dolor. Fusce lectus quam, venenatis a sapien quis, fermentum cursus sapien.",
+    "post_date": "2022-02-19",
+    "author": "admin@trisa.io"
+  },
+  {
+    "title": "Post 5",
+    "body": "Pellentesque arcu augue, vehicula non ultrices vel, convallis sed tellus. Vestibulum rhoncus felis quis ex pulvinar semper ut vitae libero. Aliquam at suscipit est, et scelerisque justo. In eget felis dignissim, placerat metus quis, tristique ipsum. Integer vitae diam sed justo auctor convallis. Duis venenatis nisi nibh, et lacinia lacus congue id. In congue volutpat nulla, at bibendum purus blandit in. Cras laoreet iaculis viverra.",
+    "post_date": "2022-03-04",
+    "author": "admin@trisa.io"
+  },
+  {
+    "title": "Post 6",
+    "body": "Cras blandit, ex sit amet tempus efficitur, elit neque egestas quam, non tincidunt massa diam fermentum magna. Aliquam eget congue dui. Etiam non sodales nulla. Ut et tincidunt ipsum. Pellentesque ultrices, libero nec ultrices mollis, turpis dolor eleifend mi, eget tincidunt felis nisi et tellus. Morbi ornare ipsum quam, porta scelerisque quam ultrices ac. Morbi vestibulum dapibus ultricies. Duis metus tortor, pellentesque nec nulla eget, lobortis viverra erat. Sed quis enim ante. Etiam suscipit tellus mollis tristique lobortis.",
+    "post_date": "2022-03-16",
+    "author": "admin@trisa.io"
+  },
+  {
+    "title": "Post 7",
+    "body": "Mauris tincidunt volutpat neque, nec malesuada diam viverra ac. Nam ac mi quis est dignissim faucibus at ut sem. Praesent fermentum velit a nibh egestas, quis viverra lacus pretium. Aliquam aliquet velit ut felis consectetur, quis sagittis orci rhoncus. Cras laoreet lobortis felis, ut ultricies est mattis posuere. Etiam justo ex, ultricies vel cursus quis, scelerisque in nisl. Vestibulum vulputate est vitae ligula eleifend, et euismod magna vulputate. Aliquam pretium semper ipsum a commodo. Morbi sapien dui, tempus nec laoreet vel, hendrerit et eros.",
+    "post_date": "2022-03-30",
+    "author": "support@rotational.io"
+  },
+  {
+    "title": "Post 8",
+    "body": "Pellentesque in lectus pretium nisl placerat volutpat vel ac nisl. Donec sagittis congue augue vitae mattis. Morbi at turpis a elit ullamcorper ullamcorper. Nam rutrum scelerisque magna ac sollicitudin. Suspendisse pretium eu dui id vestibulum. Sed volutpat leo non diam tristique sodales. Ut aliquam consectetur lobortis. Proin vel justo eros. Etiam enim enim, lacinia in cursus a, fermentum nec elit. Proin a quam lorem. Vivamus ornare elementum convallis. Cras ullamcorper urna nec purus blandit feugiat.",
+    "post_date": "2022-04-14",
+    "author": "support@rotational.io"
+  },
+  {
+    "title": "Post 9",
+    "body": "Proin lacus elit, semper id justo ac, condimentum finibus arcu. Quisque id enim id nulla tincidunt suscipit. Phasellus eu sapien felis. Aenean aliquet id nisi non ornare. Nulla pretium vitae elit at varius. In scelerisque nunc vel lacus condimentum pulvinar. Nullam efficitur neque at neque ullamcorper cursus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.",
+    "post_date": "2022-04-19",
+    "author": "admin@trisa.io"
+  },
+  {
+    "title": "Post 10",
+    "body": "Ut gravida id lectus quis varius. Praesent vitae ipsum consequat nulla luctus auctor. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Quisque nec blandit justo. Fusce in velit congue, aliquam neque elementum, vestibulum massa. Donec non magna lacus. Mauris ex erat, condimentum non nunc lobortis, luctus elementum nisi. Pellentesque interdum pretium urna, eu euismod erat sollicitudin ac.",
+    "post_date": "2022-04-26",
+    "author": "admin@trisa.io"
+  }
+]

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -318,6 +318,8 @@ func (s *Server) setupRoutes() (err error) {
 		v1.GET("/verify", s.VerifyContact)
 		v1.POST("/users/login", userinfo, s.Login)
 		v1.GET("/overview", auth.Authorize("read:vasp"), s.Overview)
+		v1.GET("/announcements", auth.Authorize("read:vasp"), s.Announcements)
+		v1.POST("/announcements", auth.Authorize("create:announcements"), s.MakeAnnouncement)
 		v1.GET("/certificates", auth.Authorize("read:vasp"), s.Certificates)
 	}
 

--- a/pkg/gds/members/v1alpha1/members.pb.go
+++ b/pkg/gds/members/v1alpha1/members.pb.go
@@ -140,6 +140,8 @@ func (x *ListReply) GetNextPageToken() string {
 
 // VASPMember is a lightweight data structure containing enough information to
 // facilitate p2p exchanges or more detailed lookups against the Directory Service.
+// Note: This should not contain any sensitive VASP information since it is returned on
+// the publicly accessible List and Summary APIs.
 type VASPMember struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/pkg/trtl/pb/v1/trtl.pb.go
+++ b/pkg/trtl/pb/v1/trtl.pb.go
@@ -1182,8 +1182,8 @@ type Options struct {
 	unknownFields protoimpl.UnknownFields
 
 	ReturnMeta   bool   `protobuf:"varint,1,opt,name=return_meta,json=returnMeta,proto3" json:"return_meta,omitempty"`         // generally, return the version information for the object in the response
-	IterNoKeys   bool   `protobuf:"varint,2,opt,name=iter_no_keys,json=iterNoKeys,proto3" json:"iter_no_keys,omitempty"`       // do not include keys in an Iter or Batch response, to reduce data transfer load
-	IterNoValues bool   `protobuf:"varint,3,opt,name=iter_no_values,json=iterNoValues,proto3" json:"iter_no_values,omitempty"` // do not include values in an Iter or Batch response, to reduce data transfer load
+	IterNoKeys   bool   `protobuf:"varint,2,opt,name=iter_no_keys,json=iterNoKeys,proto3" json:"iter_no_keys,omitempty"`       // do not include keys in an Iter or Cursor response, to reduce data transfer load
+	IterNoValues bool   `protobuf:"varint,3,opt,name=iter_no_values,json=iterNoValues,proto3" json:"iter_no_values,omitempty"` // do not include values in an Iter or Cursor response, to reduce data transfer load
 	PageToken    string `protobuf:"bytes,4,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`             // specify the page token to fetch the next page of results
 	PageSize     int32  `protobuf:"varint,5,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`               // specify the number of results per page, cannot change between page requests
 }

--- a/proto/trtl/v1/trtl.proto
+++ b/proto/trtl/v1/trtl.proto
@@ -146,8 +146,8 @@ message ReplicaStatus {
 // Get vs Put options. The semantics of each option depends on the type of request.
 message Options {
     bool return_meta = 1;     // generally, return the version information for the object in the response
-    bool iter_no_keys = 2;    // do not include keys in an Iter or Batch response, to reduce data transfer load
-    bool iter_no_values = 3;  // do not include values in an Iter or Batch response, to reduce data transfer load
+    bool iter_no_keys = 2;    // do not include keys in an Iter or Cursor response, to reduce data transfer load
+    bool iter_no_values = 3;  // do not include values in an Iter or Cursor response, to reduce data transfer load
     string page_token = 4;    // specify the page token to fetch the next page of results
     int32 page_size = 5;      // specify the number of results per page, cannot change between page requests
 }


### PR DESCRIPTION
### Scope of changes

This goal of this PR was to add a `GET /v1/announcements` endpoint to return network announcements for the dashboard. The design requested that we store these announcements in the BFF database. I extended the work for this to include a `POST /v1/announcements` endpoint to allow TRISA admins to create network announcements to display on the dashboard. This further required me to create the `create:announcements` permission in Auth0 and the "TRISA Admins` role so that only admins can create announcements. 

As I got into the code I realized that we aren't fully using the database module quite yet, so I had to put in some effort to exploring how we utilize the database. 

I came up with the idea of "Collections" which are like the GDS `Store` object that allow you to interact with a specific namespace and load and save specific models. 

The "model" for this task is the `Announcement` struct which is defined in `api/v1` -- this is not really the right place to define models and if the reviewer thinks I should create a protocol buffer for this I'm happy to. The shortcut allowed us to return exactly what the endpoint expects, but may cause problems in the future. Since I didn't use a protocol buffer, I decided to serialize the Announcement object using gzip compressed json. 

The `Announcements` collection can be fetched off of the db and operated on using chained methods, e.g.  `db.Announcements().Post()` or `db.Announcements().Recent()`. There is a `sync.Once` that ensures that the collection is only instantiated once, but is not instantiated if the code is never used. The collection object is thread-safe. 

I created a database test suite modeled off of our GDS test suite - running a `trtl` server with a leveldb in a temp dir and connecting to it via bufconn. I implemented tests to extend the coverage of the database. 

Now for the last problem: my idea for database storage was to create time ordered keys using ksuids. This causes two problems:

1. In order to effectively query this data structure we need to seek in reverse order since the keys are stored in ascending time order … but `trtl` doesn't offer this functionality. 
2. ksuids seem to be concurrent within 1 second granularity, so to load 10 ordered announcements into the database we need to sleep 1 second between each … causing a 10 second long test. Not ideal. 

Right now the entire set of announcements is loaded into memory, but this is _far_ from ideal. We need to figure out if we should use a different data structure, implement reverse cursor in trtl, or what. Much discussion is required. 

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

- [ ] Is announcement spelled correctly? I did do a spell check … but I got it wrong every time I typed it 
- [ ] What do we do about the recent query in trtl? Add trtl reverse cursor, some other data structure?
- [ ] Do we need to go to a protobuf or is the API "model" shortcut ok
- [ ] What do we think about cursors for the BFF database interaction?
- [ ] How will admins create announcements, should we create a CLI util for it? Something in the Admin UI? 

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"


