### PR TITLE
Add Auth0 Debugger to Docker Compose

### DIFF
--- a/containers/auth0-debug/Dockerfile
+++ b/containers/auth0-debug/Dockerfile
@@ -1,0 +1,10 @@
+# Dynamic Builds
+ARG PYTHON_IMAGE=python:3.10.5-slim-buster
+
+FROM ${PYTHON_IMAGE} as final
+
+WORKDIR /app
+
+COPY web/auth0-debug .
+
+CMD [ "python3", "serve.py" ]

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -365,3 +365,16 @@ services:
       - ui
       - mainnet
       - all
+
+  auth0-debug:
+    build:
+      context: ../
+      dockerfile: ./containers/auth0-debug/Dockerfile
+    image: trisa/auth0-debug
+    ports:
+      - 3003:3003
+    profiles:
+      - all
+      - api
+      - testnet
+      - auth0

--- a/web/auth0-debug/serve.py
+++ b/web/auth0-debug/serve.py
@@ -4,7 +4,7 @@ import functools
 import http.server
 import socketserver
 
-DEFAULT_PORT=3000
+DEFAULT_PORT=3003
 BASE_PATH=os.path.join(os.path.dirname(__file__), "htdocs")
 
 DirectoryHTTPRequestHandler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=BASE_PATH)


### PR DESCRIPTION
### Scope of changes

Adds the auth0-debug web application to docker compose to make it easier to get access tokens for development and testing. This included:

1. Updating the auth0 config from http://localhost:3000 to http://localhost:3003 to deconflict with other docker compose ports
2. Changing the default port in `serve.py` from 3000 to 30003
3. Creating a Dockerfile
4. Creating the service in our docker compose file. 

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Verify that I've included everything needed to run the auth0 debugger locally. To run it you can:

```
$ docker compose -f ./containers/docker-compose.yaml --profile=auth0 build
$ docker compose -f ./containers/docker-compose.yaml --profile=auth0 up
```

Then go to http://localhost:3003 -- and you should be able to use it. 

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  ~I have updated the dependencies list~
- [ ]  ~I have recompiled and included new protocol buffers to reflect changes I made~
- [ ] ~I have added new test fixtures as needed to support added tests~
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] I've ran the auth0 debug app successfully


