### PR TITLE
BFF Lookup Endpoint Refactor

### DIFF
--- a/containers/local.sh
+++ b/containers/local.sh
@@ -1,14 +1,53 @@
 #!/bin/bash
+# A helper for common docker compose operations to run GDS locally.
 
 # Print usage and exit
-help() {
-    echo "Usage $DIR/local.sh [clean|build|up]"
-    exit 2
+show_help() {
+cat << EOF
+Usage: ${0##*/} [-h] [-p PROFILE] [clean|build|up]
+A helper for common docker compose operations to run GDS
+services locally. Flags are as follows (getopt required):
+
+    -h          display this help and exit
+    -p PROFILE  specify the docker compose profile to use
+
+There are two ways to use this script. Run docker compose:
+
+    ${0##*/} up
+
+Build the images cleaning the docker cache first:
+
+    ${0##*/} clean
+    ${0##*/} build
+
+You can also specify the profile to run only some services.
+EOF
 }
+
+# Parse command line options with getopt
+PROFILE="all"
+OPTIND=1
+
+while getopts hp: opt; do
+    case $opt in
+        h)
+            show_help
+            exit 0
+            ;;
+        p)  PROFILE=$OPTARG
+            ;;
+        *)
+            show_help >&2
+            exit 2
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"
 
 # Ensure only zero or one arguments are passed to the script
 if [ $# -gt 1 ]; then
-    help
+    show_help >&2
+    exit 2
 fi
 
 # Set some helpful variables
@@ -24,14 +63,15 @@ if [[ $# -eq 1 ]]; then
         docker system prune --all
         exit 0
     elif [[ $1 == "build" ]]; then
-        docker compose -p gds -f $DIR/docker-compose.yaml --profile=all build
+        docker compose -p gds -f $DIR/docker-compose.yaml --profile=$PROFILE build
         exit 0
     elif [[ $1 == "up" ]]; then
-        echo "starting docker server"
+        echo "starting docker compose services"
     else
-        help
+        show_help >&2
+        exit 2
     fi
 fi
 
 # By default just bring docker compose up
-docker compose -p gds -f $DIR/docker-compose.yaml --profile=all up
+docker compose -p gds -f $DIR/docker-compose.yaml --profile=$PROFILE up

--- a/containers/local.sh
+++ b/containers/local.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Print usage and exit
+help() {
+    echo "Usage $DIR/local.sh [clean|build|up]"
+    exit 2
+}
+
+# Ensure only zero or one arguments are passed to the script
+if [ $# -gt 1 ]; then
+    help
+fi
+
+# Set some helpful variables
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Set environment for docker compose
+export GIT_REVISION=$(git rev-parse --short HEAD)
+export REACT_APP_GIT_REVISION=$GIT_REVISION
+
+# Check if the build or clean arguments are specified
+if [[ $# -eq 1 ]]; then
+    if [[ $1 == "clean" ]]; then
+        docker system prune --all
+        exit 0
+    elif [[ $1 == "build" ]]; then
+        docker compose -p gds -f $DIR/docker-compose.yaml --profile=all build
+        exit 0
+    elif [[ $1 == "up" ]]; then
+        echo "starting docker server"
+    else
+        help
+    fi
+fi
+
+# By default just bring docker compose up
+docker compose -p gds -f $DIR/docker-compose.yaml --profile=all up

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -118,7 +118,8 @@ type LookupParams struct {
 // also contain an "error" field - the BFF will handle this field by logging the error
 // but will exclude it from any results returned.
 type LookupReply struct {
-	Results []map[string]interface{} `json:"results"`
+	TestNet map[string]interface{} `json:"testnet"`
+	MainNet map[string]interface{} `json:"mainnet"`
 }
 
 // RegisterRequest is converted into a protocol buffer RegisterRequest to send to the

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -118,10 +118,8 @@ func TestStatus(t *testing.T) {
 
 func TestLookup(t *testing.T) {
 	fixture := &api.LookupReply{
-		Results: []map[string]interface{}{
-			{"foo": "1", "color": "red"},
-			{"foo": "2", "color": "blue"},
-		},
+		TestNet: map[string]interface{}{"foo": "2", "color": "blue"},
+		MainNet: map[string]interface{}{"foo": "1", "color": "red"},
 	}
 
 	// Create a Test Server
@@ -141,7 +139,8 @@ func TestLookup(t *testing.T) {
 
 	out, err := client.Lookup(context.TODO(), &api.LookupParams{CommonName: "example.com"})
 	require.NoError(t, err)
-	require.Equal(t, fixture.Results, out.Results)
+	require.Equal(t, fixture.TestNet, out.TestNet)
+	require.Equal(t, fixture.MainNet, out.MainNet)
 }
 
 func TestRegister(t *testing.T) {

--- a/pkg/bff/gds_test.go
+++ b/pkg/bff/gds_test.go
@@ -24,7 +24,7 @@ func (s *bffTestSuite) TestLookup() {
 	params.CommonName = "api.alice.vaspbot.net"
 
 	// Test NotFound returns a 404
-	require.NoError(s.testnet.gds.UseError(mock.LookupRPC, codes.NotFound, "tesnet not found"))
+	require.NoError(s.testnet.gds.UseError(mock.LookupRPC, codes.NotFound, "testnet not found"))
 	require.NoError(s.mainnet.gds.UseError(mock.LookupRPC, codes.NotFound, "mainnet not found"))
 	_, err = s.client.Lookup(context.TODO(), params)
 	require.EqualError(err, "[404] no results returned for query", "expected a 404 error when both GDSes return not found")
@@ -40,23 +40,26 @@ func (s *bffTestSuite) TestLookup() {
 	require.NoError(s.mainnet.gds.UseError(mock.LookupRPC, codes.NotFound, "mainnet not found"))
 	rep, err := s.client.Lookup(context.TODO(), params)
 	require.NoError(err, "could not fetch expected result from testnet")
-	require.Len(rep.Results, 1, "expected one result back from server")
-	require.Equal("6a57fea4-8fb7-42f3-bf0c-55fecccd2e53", rep.Results[0]["id"])
+	require.Nil(rep.MainNet, "expected no mainnet result back from server")
+	require.NotEmpty(rep.TestNet, "expected testnet result from server")
+	require.Equal("6a57fea4-8fb7-42f3-bf0c-55fecccd2e53", rep.TestNet["id"])
 
 	// Test one result from MainNet
 	require.NoError(s.testnet.gds.UseError(mock.LookupRPC, codes.NotFound, "testnet not found"))
 	require.NoError(s.mainnet.gds.UseFixture(mock.LookupRPC, "testdata/mainnet/lookup_reply.json"))
 	rep, err = s.client.Lookup(context.TODO(), params)
 	require.NoError(err, "could not fetch expected result from mainnet")
-	require.Len(rep.Results, 1, "expected one result back from server")
-	require.Equal("ca0cff66-719f-4a62-8086-be953699b27d", rep.Results[0]["id"])
+	require.Nil(rep.TestNet, "expected no testnet result back from server")
+	require.NotEmpty(rep.MainNet, "expected mainnet result from server")
+	require.Equal("ca0cff66-719f-4a62-8086-be953699b27d", rep.MainNet["id"])
 
 	// Test results from both TestNet and MainNet
 	require.NoError(s.testnet.gds.UseFixture(mock.LookupRPC, "testdata/testnet/lookup_reply.json"))
 	require.NoError(s.mainnet.gds.UseFixture(mock.LookupRPC, "testdata/mainnet/lookup_reply.json"))
 	rep, err = s.client.Lookup(context.TODO(), params)
 	require.NoError(err, "could not fetch expected result from mainnet and testnet")
-	require.Len(rep.Results, 2, "expected two results back from server")
+	require.NotEmpty(rep.MainNet, "expected mainnet result from server")
+	require.NotEmpty(rep.TestNet, "expected testnet result from server")
 }
 
 func (s *bffTestSuite) TestRegister() {


### PR DESCRIPTION
### Scope of changes

Modifies the LookupReply to an object `{"testnet": {}, "mainnet": {}}` rather than an array of results `{"results": []}` 

I also added a `containers/local.sh` script to make it easier to run docker compose. Usage is as follows:

Run `docker system prune --all`:

```
$ ./containers/local.sh clean
```

Build the containers:

```
$ ./containers/local.sh build
```

Run the containers:

```
$ ./containers/local.sh up
```

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (refactoring)

### Acceptance criteria

@masskoder will this enable you to do what you need to do?

@pdeziel can you think of any other places this change might have an effect?

I did try to run docker compose locally to get you a snapshot of what the data might look like, but I also need #611 to be merged to run docker compose. 

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  ~I have updated the dependencies list~
- [ ]  ~I have recompiled and included new protocol buffers to reflect changes I made~
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] This will allow the front-end to fix SC-6848
- [ ] No other changes in the code are necessary

