### PR TITLE
SC-6903 BFF member details endpoint

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/trisacrypto/directory/pkg/bff/db/models/v1"
+	members "github.com/trisacrypto/directory/pkg/gds/members/v1alpha1"
 )
 
 //===========================================================================
@@ -27,6 +28,7 @@ type BFFClient interface {
 	Announcements(context.Context) (*AnnouncementsReply, error)
 	MakeAnnouncement(context.Context, *models.Announcement) error
 	Certificates(context.Context) (*CertificatesReply, error)
+	MemberDetails(context.Context, *MemberDetailsParams) (*MemberDetailsReply, error)
 }
 
 //===========================================================================
@@ -148,6 +150,20 @@ type Certificate struct {
 	ExpiresAt    string                 `json:"expires_at"`
 	Revoked      bool                   `json:"revoked"`
 	Details      map[string]interface{} `json:"details"`
+}
+
+// MemberDetailsParams contains details required to identify a VASP member for the
+// MembersDetails request.
+type MemberDetailsParams struct {
+	ID        string `url:"vaspID,omitempty" form:"vaspID"`
+	Directory string `url:"registered_directory,omitempty" form:"registered_directory"`
+}
+
+// MemberDetailsReply contains sensitive details about a VASP member.
+type MemberDetailsReply struct {
+	Summary     *members.VASPMember    `json:"summary"`
+	LegalPerson map[string]interface{} `json:"legal_person"`
+	Trixo       map[string]interface{} `json:"trixo"`
 }
 
 // NetworkError is populated when the BFF receives an error from a network endpoint,

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -278,6 +278,28 @@ func (s *APIv1) Certificates(ctx context.Context) (out *CertificatesReply, err e
 	return out, nil
 }
 
+// Details returns the sensitive details for a VASP member.
+func (s *APIv1) MemberDetails(ctx context.Context, in *MemberDetailsParams) (out *MemberDetailsReply, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if params, err = query.Values(in); err != nil {
+		return nil, fmt.Errorf("could not encode query params: %s", err)
+	}
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/details", nil, &params); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &MemberDetailsReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 //===========================================================================
 // Helper Methods
 //===========================================================================

--- a/pkg/bff/mock/members.go
+++ b/pkg/bff/mock/members.go
@@ -18,6 +18,7 @@ import (
 const (
 	ListRPC    = "List"
 	SummaryRPC = "Summary"
+	DetailsRPC = "Details"
 )
 
 func NewMembers(conf config.MembersConfig) (m *Members, err error) {
@@ -54,6 +55,7 @@ type Members struct {
 	Calls     map[string]int
 	OnList    func(context.Context, *members.ListRequest) (*members.ListReply, error)
 	OnSummary func(context.Context, *members.SummaryRequest) (*members.SummaryReply, error)
+	OnDetails func(context.Context, *members.DetailsRequest) (*members.MemberDetails, error)
 }
 
 func (g *Members) Client() (client members.TRISAMembersClient, err error) {
@@ -134,6 +136,14 @@ func (m *Members) UseFixture(rpc, path string) (err error) {
 		m.OnSummary = func(context.Context, *members.SummaryRequest) (*members.SummaryReply, error) {
 			return out, nil
 		}
+	case DetailsRPC:
+		out := &members.MemberDetails{}
+		if err = jsonpb.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("could not unmarshal json into %T: %s", out, err)
+		}
+		m.OnDetails = func(context.Context, *members.DetailsRequest) (*members.MemberDetails, error) {
+			return out, nil
+		}
 	default:
 		return fmt.Errorf("unknown rpc %q", rpc)
 	}
@@ -151,6 +161,10 @@ func (m *Members) UseError(rpc string, code codes.Code, msg string) error {
 		m.OnSummary = func(context.Context, *members.SummaryRequest) (*members.SummaryReply, error) {
 			return nil, status.Error(code, msg)
 		}
+	case DetailsRPC:
+		m.OnDetails = func(context.Context, *members.DetailsRequest) (*members.MemberDetails, error) {
+			return nil, status.Error(code, msg)
+		}
 	default:
 		return fmt.Errorf("unknown rpc %q", rpc)
 	}
@@ -165,4 +179,9 @@ func (m *Members) List(ctx context.Context, in *members.ListRequest) (*members.L
 func (m *Members) Summary(ctx context.Context, in *members.SummaryRequest) (*members.SummaryReply, error) {
 	m.Calls[SummaryRPC]++
 	return m.OnSummary(ctx, in)
+}
+
+func (m *Members) Details(ctx context.Context, in *members.DetailsRequest) (*members.MemberDetails, error) {
+	m.Calls[DetailsRPC]++
+	return m.OnDetails(ctx, in)
 }

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -338,6 +338,8 @@ func (s *Server) setupRoutes() (err error) {
 		v1.GET("/lookup", s.Lookup)
 		v1.GET("/verify", s.VerifyContact)
 		v1.POST("/users/login", userinfo, s.Login)
+
+		// Authenticated routes
 		v1.GET("/register", auth.Authorize("read:vasp"), s.LoadRegisterForm)
 		v1.POST("/register", auth.DoubleCookie(), auth.Authorize("update:vasp"), s.SaveRegisterForm)
 		v1.POST("/register/:network", auth.DoubleCookie(), auth.Authorize("update:vasp"), s.SubmitRegistration)
@@ -345,6 +347,7 @@ func (s *Server) setupRoutes() (err error) {
 		v1.GET("/announcements", auth.Authorize("read:vasp"), s.Announcements)
 		v1.POST("/announcements", auth.DoubleCookie(), auth.Authorize("create:announcements"), s.MakeAnnouncement)
 		v1.GET("/certificates", auth.Authorize("read:vasp"), s.Certificates)
+		v1.GET("/details", auth.Authorize("read:vasp"), s.MemberDetails)
 	}
 
 	// NotFound and NotAllowed routes

--- a/pkg/bff/testdata/mainnet/details_reply.json
+++ b/pkg/bff/testdata/mainnet/details_reply.json
@@ -1,0 +1,80 @@
+{
+    "summary": {
+        "id": "9e069e01-8515-4d57-b9a5-e249f7ab4fca",
+        "registered_directory": "trisatest.net",
+        "common_name": "api.bob.vaspbot.net",
+        "endpoint": "api.bob.vaspbot.net:443",
+        "name": "BobVASP",
+        "website": "https://bob.vaspbot.net/",
+        "country": "GB",
+        "business_category": "PRIVATE_ORGANIZATION",
+        "vasp_categories": [
+          "Exchange"
+        ],
+        "verified_on": "",
+        "status": "VERIFIED"
+      },
+      "legal_person": {
+        "name": {
+          "name_identifiers": [
+            {
+              "legal_person_name": "Bob's Discount VASP, PLC",
+              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
+            },
+            {
+              "legal_person_name": "BobVASP",
+              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
+            }
+          ],
+          "local_name_identifiers": [],
+          "phonetic_name_identifiers": []
+        },
+        "geographic_addresses": [
+          {
+            "address_type": "ADDRESS_TYPE_CODE_BIZZ",
+            "department": "",
+            "sub_department": "",
+            "street_name": "Grimsby Road",
+            "building_number": "762",
+            "building_name": "",
+            "floor": "",
+            "post_box": "",
+            "room": "",
+            "post_code": "OX8 U89",
+            "town_name": "Oxford",
+            "town_location_name": "",
+            "district_name": "",
+            "country_sub_division": "",
+            "address_line": [],
+            "country": "GB"
+          }
+        ],
+        "customer_number": "",
+        "national_identification": {
+          "national_identifier": "213800AQUAUP6I215N33",
+          "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
+          "country_of_issue": "GB",
+          "registration_authority": "RA000589"
+        },
+        "country_of_registration": "GB"
+      },
+      "trixo": {
+        "primary_national_jurisdiction": "GB",
+        "primary_regulator": "Financial Conduct Authority",
+        "financial_transfers_permitted": "yes",
+        "other_jurisdictions": [],
+        "has_required_regulatory_program": "yes",
+        "conducts_customer_kyc": true,
+        "kyc_threshold": 100,
+        "kyc_threshold_currency": "USD",
+        "must_comply_travel_rule": false,
+        "applicable_regulations": [
+          "Legal statement on cryptoassets and smart contracts",
+          "FCA Cryptoassets: AML / CTF regime"
+        ],
+        "compliance_threshold": 10000,
+        "compliance_threshold_currency": "USD",
+        "must_safeguard_pii": true,
+        "safeguards_pii": true
+      }
+}

--- a/pkg/bff/testdata/testnet/details_reply.json
+++ b/pkg/bff/testdata/testnet/details_reply.json
@@ -1,0 +1,84 @@
+{
+    "summary": {
+        "id": "7a96ca2c-2818-4106-932e-1bcfd743b04c",
+        "registered_directory": "trisatest.net",
+        "common_name": "api.alice.vaspbot.net",
+        "endpoint": "api.alice.vaspbot.net:443",
+        "name": "AliceCoin",
+        "website": "https://alice.vaspbot.net/",
+        "country": "US",
+        "business_category": "PRIVATE_ORGANIZATION",
+        "vasp_categories": [
+          "Exchange"
+        ],
+        "verified_on": "",
+        "status": "VERIFIED"
+      },
+      "legal_person": {
+        "name": {
+          "name_identifiers": [
+            {
+              "legal_person_name": "AliceCoin, Inc.",
+              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
+            },
+            {
+              "legal_person_name": "AliceVASP",
+              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
+            },
+            {
+              "legal_person_name": "AliceCoin",
+              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_TRAD"
+            }
+          ],
+          "local_name_identifiers": [],
+          "phonetic_name_identifiers": []
+        },
+        "geographic_addresses": [
+          {
+            "address_type": "ADDRESS_TYPE_CODE_BIZZ",
+            "department": "",
+            "sub_department": "",
+            "street_name": "Roosevelt Place",
+            "building_number": "23",
+            "building_name": "",
+            "floor": "",
+            "post_box": "",
+            "room": "",
+            "post_code": "02151",
+            "town_name": "Boston",
+            "town_location_name": "",
+            "district_name": "",
+            "country_sub_division": "MA",
+            "address_line": [],
+            "country": "US"
+          }
+        ],
+        "customer_number": "",
+        "national_identification": {
+          "national_identifier": "5493004YBI24IF4TIP92",
+          "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
+          "country_of_issue": "US",
+          "registration_authority": "RA000744"
+        },
+        "country_of_registration": "US"
+      },
+      "trixo": {
+        "primary_national_jurisdiction": "US",
+        "primary_regulator": "FinCEN",
+        "financial_transfers_permitted": "yes",
+        "other_jurisdictions": [],
+        "has_required_regulatory_program": "yes",
+        "conducts_customer_kyc": true,
+        "kyc_threshold": 10000,
+        "kyc_threshold_currency": "USD",
+        "must_comply_travel_rule": true,
+        "applicable_regulations": [
+          "BSA Travel Rule – 31 CFR 103.33(g)",
+          "FATF Travel Rule"
+        ],
+        "compliance_threshold": 10000,
+        "compliance_threshold_currency": "USD",
+        "must_safeguard_pii": false,
+        "safeguards_pii": true
+      }
+}

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -222,7 +222,7 @@ func (s *Admin) setupRoutes() (err error) {
 			vasps.GET("/:vaspID", s.RetrieveVASP)
 			vasps.PATCH("/:vaspID", csrf, s.UpdateVASP)
 			vasps.DELETE("/:vaspID", csrf, s.DeleteVASP)
-			vasps.GET("/:vaspID/certificates", csrf, s.ListCertificates)
+			vasps.GET("/:vaspID/certificates", s.ListCertificates)
 			vasps.GET("/:vaspID/review", s.ReviewToken)
 			vasps.POST("/:vaspID/review", csrf, s.Review)
 			vasps.POST("/:vaspID/resend", csrf, s.Resend)

--- a/pkg/gds/admin_test.go
+++ b/pkg/gds/admin_test.go
@@ -137,10 +137,10 @@ func (s *gdsTestSuite) TestMiddleware() {
 		{"listVASPs", http.MethodGet, "/v2/vasps", true, false},
 		{"retrieveVASP", http.MethodGet, "/v2/vasps/42", true, false},
 		{"listReviewNotes", http.MethodGet, "/v2/vasps/42/notes", true, false},
+		{"listCertificates", http.MethodGet, "/v2/vasps/42/certificates", true, false},
 		// Authenticated and CSRF protected endpoints
 		{"updateVASP", http.MethodPatch, "/v2/vasps/42", true, true},
 		{"deleteVASP", http.MethodDelete, "/v2/vasps/42", true, true},
-		{"listCertificates", http.MethodGet, "/v2/vasps/42/certificates", true, true},
 		{"replaceContact", http.MethodPut, "/v2/vasps/42/contacts/kind", true, true},
 		{"deleteContact", http.MethodDelete, "/v2/vasps/42/contacts/kind", true, true},
 		{"review", http.MethodPost, "/v2/vasps/42/review", true, true},


### PR DESCRIPTION
### Scope of changes

This adds an endpoint to the BFF to allow the frontend to retrieve details about a VASP member. This is mostly a pass-through request to the members endpoint, where the caller must specify the VASP ID and registered directory in the request.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

The tests should pass and the request/reply structure makes sense.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [x]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] The test coverage is sufficient
- [ ] It's understandable how to use the endpoint


