### PR TITLE
remove certreq references on rejected registration

### DIFF
--- a/pkg/gds/admin_test.go
+++ b/pkg/gds/admin_test.go
@@ -1682,6 +1682,11 @@ func (s *gdsTestSuite) TestReviewReject() {
 	require.Equal(pb.VerificationState_REJECTED, log[3].CurrentState)
 	require.Equal(request.claims.Email, log[3].Source)
 
+	// Certificate request should be deleted from the VASP extra
+	ids, err := models.GetCertReqIDs(v)
+	require.NoError(err)
+	require.Len(ids, 0)
+
 	// Certificate request should be deleted
 	_, err = s.svc.GetStore().RetrieveCertReq(xrayID)
 	require.Error(err)

--- a/pkg/gds/models/v1/models_test.go
+++ b/pkg/gds/models/v1/models_test.go
@@ -96,6 +96,9 @@ func TestVASPExtra(t *testing.T) {
 	require.Equal(t, "", notes["boats"].Editor)
 	require.Equal(t, "boats are cool", notes["boats"].Text)
 
+	// Deleting certificate request IDs from an empty slice should not error
+	require.NoError(t, DeleteCertReqID(vasp, "b5841869-105f-411c-8722-4045aad72717"))
+
 	// Attempt to append certificate request IDs
 	certReqs := []string{
 		"b5841869-105f-411c-8722-4045aad72717",
@@ -112,6 +115,25 @@ func TestVASPExtra(t *testing.T) {
 	require.Len(t, ids, 2)
 	require.Equal(t, certReqs[0], ids[0])
 	require.Equal(t, certReqs[1], ids[1])
+
+	// Should be able to delete a certificate request ID
+	require.NoError(t, DeleteCertReqID(vasp, certReqs[0]))
+	ids, err = GetCertReqIDs(vasp)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	require.Equal(t, certReqs[1], ids[0])
+
+	// Deleting the certificate request ID again should not error
+	require.NoError(t, DeleteCertReqID(vasp, certReqs[0]))
+
+	// Deleting a non-existent certificate request ID should not error
+	require.NoError(t, DeleteCertReqID(vasp, "does-not-exist"))
+
+	// Certificate request IDs should be unchanged
+	ids, err = GetCertReqIDs(vasp)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	require.Equal(t, certReqs[1], ids[0])
 
 	// Attempt to append certificate IDs
 	certs := []string{


### PR DESCRIPTION
### Scope of changes

This removes the certreq references on the VASP extra when a certificate request is deleted, which happens when a VASP registration is rejected on `Review`. This also happens on `DeleteVASP`, but since the VASP object is being deleted anyway there's no point doing it on that endpoint.

SC-7517

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This change is not visible to the user, but I've updated the `TestReviewReject` test to account for this fix.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] The logging/error logic makes sense in `rejectRegistration`.
- [ ] There are no other places where we need to account for deleted certificate requests.

