### PR TITLE
sc-7566 GDS User UI : Hide other languages that don't have translation content yet

### DIFF
--- a/web/gds-user-ui/src/components/LanguagesDropdown/index.tsx
+++ b/web/gds-user-ui/src/components/LanguagesDropdown/index.tsx
@@ -10,19 +10,19 @@ const languages = {
   fr: {
     flag: '🇫🇷',
     title: 'Française'
-  },
-  de: {
-    flag: '🇩🇪',
-    title: 'Deutsch'
-  },
-  zh: {
-    flag: '🇨🇳',
-    title: '中文'
-  },
-  ja: {
-    flag: '🇯🇵',
-    title: '日本語'
   }
+  // de: {
+  //   flag: '🇩🇪',
+  //   title: 'Deutsch'
+  // },
+  // zh: {
+  //   flag: '🇨🇳',
+  //   title: '中文'
+  // },
+  // ja: {
+  //   flag: '🇯🇵',
+  //   title: '日本語'
+  // }
 };
 
 const LanguageOptions = () => {


### PR DESCRIPTION
### Scope of changes
sc-7566 GDS User UI : Hide other languages that don't have translation content yet

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria
Until we get the other content, we only need to keep the language that has full translations.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


