### PR TITLE
certificate vasp state tests

### DIFF
--- a/pkg/gds/certs.go
+++ b/pkg/gds/certs.go
@@ -53,14 +53,14 @@ func (s *Service) CertManager(stop <-chan struct{}) {
 		case <-ticker.C:
 		}
 
-		if err := s.HandleCertifcateRequests(certDir); err != nil {
+		if err := s.HandleCertificateRequests(certDir); err != nil {
 			log.WithLevel(zerolog.PanicLevel).Err(err).Msg("could not handle certificate requests, certificate manager shutting down")
 			return
 		}
 	}
 }
 
-func (s *Service) HandleCertifcateRequests(certDir string) (err error) {
+func (s *Service) HandleCertificateRequests(certDir string) (err error) {
 	// Retrieve all certificate requests from the database
 	var (
 		nrequests int


### PR DESCRIPTION
### Scope of changes

This adds some tests to verify that the cert manager state checks implemented in SC-6508 correctly reject certificate requests when the VASP is in the wrong state.

SC-7518

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] test coverage

### Acceptance criteria

Unit tests should pass

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Is the test coverage sufficient? Do we need to make sure that no certificates are actually downloaded to the cert storage?


