### PR TITLE
change save registration endpoint to PUT

### DIFF
--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -174,7 +174,7 @@ func (s *APIv1) LoadRegistrationForm(ctx context.Context) (form *models.Registra
 func (s *APIv1) SaveRegistrationForm(ctx context.Context, form *models.RegistrationForm) (err error) {
 	// Make the HTTP request
 	var req *http.Request
-	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/register", form, nil); err != nil {
+	if req, err = s.NewRequest(ctx, http.MethodPut, "/v1/register", form, nil); err != nil {
 		return err
 	}
 

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -280,7 +280,7 @@ func TestSaveRegistrationForm(t *testing.T) {
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, http.MethodPut, r.Method)
 		require.Equal(t, "/v1/register", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -341,7 +341,7 @@ func (s *Server) setupRoutes() (err error) {
 
 		// Authenticated routes
 		v1.GET("/register", auth.Authorize("read:vasp"), s.LoadRegisterForm)
-		v1.POST("/register", auth.DoubleCookie(), auth.Authorize("update:vasp"), s.SaveRegisterForm)
+		v1.PUT("/register", auth.DoubleCookie(), auth.Authorize("update:vasp"), s.SaveRegisterForm)
 		v1.POST("/register/:network", auth.DoubleCookie(), auth.Authorize("update:vasp"), s.SubmitRegistration)
 		v1.GET("/overview", auth.Authorize("read:vasp"), s.Overview)
 		v1.GET("/announcements", auth.Authorize("read:vasp"), s.Announcements)


### PR DESCRIPTION
### Scope of changes

This changes the method on the save registration endpoint from POST to PUT to be more inline with what it does, since we use it to both create and update the form.

SC-7641

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Unit tests should pass.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


