### PR TITLE
Sc-7570:  add missing N/A value for a null testnet response

### DIFF
--- a/web/gds-user-ui/src/components/Section/SearchDirectory.tsx
+++ b/web/gds-user-ui/src/components/Section/SearchDirectory.tsx
@@ -179,31 +179,31 @@ const SearchDirectory: React.FC<TSearchDirectory> = ({
                             <Td>
                               <Trans id="Organization Name">Organization Name</Trans>
                             </Td>
-                            <Td colSpan={2}>{result?.testnet?.name}</Td>
+                            <Td colSpan={2}>{result?.testnet?.name || 'N/A'}</Td>
                           </Tr>
                           <Tr>
                             <Td>
                               <Trans id="Common Name">Common Name</Trans>
                             </Td>
-                            <Td>{result?.testnet?.common_name}</Td>
+                            <Td>{result?.testnet?.common_name || 'N/A'}</Td>
                           </Tr>
                           <Tr>
                             <Td>
                               <Trans id="TRISA Service Endpoint">TRISA Service Endpoint</Trans>
                             </Td>
-                            <Td>{result?.testnet?.endpoint}</Td>
+                            <Td>{result?.testnet?.endpoint || 'N/A'}</Td>
                           </Tr>
                           <Tr>
                             <Td>
                               <Trans id="Registered Directory">Registered Directory</Trans>
                             </Td>
-                            <Td>{result?.testnet?.registered_directory}</Td>
+                            <Td>{result?.testnet?.registered_directory || 'N/A'}</Td>
                           </Tr>
                           <Tr>
                             <Td>
                               <Trans id="TRISA Member ID">TRISA Member ID</Trans>
                             </Td>
-                            <Td>{result?.testnet?.id}</Td>
+                            <Td>{result?.testnet?.id || 'N/A'}</Td>
                           </Tr>
                           <Tr>
                             <Td>


### PR DESCRIPTION
### Scope of changes

Sc-7570:  add missing N/A value for a null testnet response

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Sc-7570:  add missing N/A value for a null testnet response

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


