### PR TITLE
sc-9037 GDS User UI : disallow users to select a future date on Date of Incorporation / Establishment

### DIFF
--- a/web/gds-user-ui/src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts
+++ b/web/gds-user-ui/src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts
@@ -1,9 +1,12 @@
 import { setupI18n } from '@lingui/core';
 import { t } from '@lingui/macro';
+import { format2ShortDate } from 'utils/utils';
 
 import * as yup from 'yup';
 
 const _i18n = setupI18n();
+const minDate = new Date('01/01/1800');
+const maxDate = new Date();
 
 export const basicDetailsValidationSchema = yup.object().shape({
   website: yup
@@ -13,6 +16,20 @@ export const basicDetailsValidationSchema = yup.object().shape({
     .required(_i18n._(t`Website is a required field`)),
   established_on: yup
     .date()
+    .min(
+      minDate,
+      t`Date of incorporation / establishment must be later than ${new Intl.DateTimeFormat([
+        'ban',
+        'id'
+      ]).format(minDate)}`
+    )
+    .max(
+      new Date(),
+      t`Date of incorporation / establishment must be at earlier than ${new Intl.DateTimeFormat([
+        'ban',
+        'id'
+      ]).format(maxDate)}`
+    )
     .nullable()
     .transform((curr, orig) => (orig === '' ? null : curr))
     .required(_i18n._(t`Invalid date`))


### PR DESCRIPTION
### Scope of changes
sc-9037 GDS User UI : disallow users to select a future date on Date of Incorporation / Establishment

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria
https://app.shortcut.com/rotational/story/9037/gds-user-ui-disallow-users-to-select-a-future-date-on-date-of-incorporation-establishment

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


