### PR TITLE
Fix trtl CLI bugs

### DIFF
--- a/cmd/reissuer/build.sh
+++ b/cmd/reissuer/build.sh
@@ -80,6 +80,6 @@ if [[ $# -eq 1 ]]; then
 fi
 
 echo "your k8s cluster context is $KUBECTX"
-GOOS=linux GOARCH=amd64 go build -o $PWD/reissuer $DIR
+GOOS=linux GOARCH=amd64 go build -ldflags="-X 'github.com/trisacrypto/directory/pkg.GitVersion=$(git rev-parse --short HEAD)'" -o $PWD/reissuer $DIR
 kubectl -n $NAMESPACE cp $PWD/reissuer gds-0:/usr/local/bin/reissuer
 rm $PWD/reissuer

--- a/cmd/trtl/main.go
+++ b/cmd/trtl/main.go
@@ -648,7 +648,7 @@ func dbDelete(c *cli.Context) (err error) {
 		return cli.Exit(fmt.Errorf("could not decode key: %s", err), 1)
 	}
 
-	// Execute the Put request
+	// Execute the Delete request
 	var resp *pb.DeleteReply
 	if resp, err = dbClient.Delete(ctx, req); err != nil {
 		return cli.Exit(err, 1)

--- a/cmd/trtl/main.go
+++ b/cmd/trtl/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	"github.com/rotationalio/honu"
 	opts "github.com/rotationalio/honu/options"
@@ -114,8 +115,8 @@ func main() {
 			Action:    dbGet,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:    "b64encode",
-					Aliases: []string{"b"},
+					Name:    "b64",
+					Aliases: []string{"b", "b64decode"},
 					Usage:   "specify the keys as base64 encoded values which must be decoded",
 				},
 				&cli.BoolFlag{
@@ -139,9 +140,10 @@ func main() {
 			Action:   dbPut,
 			Flags: []cli.Flag{
 				&cli.StringFlag{
-					Name:    "key",
-					Aliases: []string{"k"},
-					Usage:   "specify the key as a string",
+					Name:     "key",
+					Aliases:  []string{"k"},
+					Usage:    "specify the key as a string",
+					Required: true,
 				},
 				&cli.StringFlag{
 					Name:    "namespace",
@@ -157,6 +159,11 @@ func main() {
 					Name:    "meta",
 					Aliases: []string{"m"},
 					Usage:   "return the metadata along with the value",
+				},
+				&cli.BoolFlag{
+					Name:    "b64",
+					Aliases: []string{"b", "b64decode"},
+					Usage:   "specify the key and value as base64 encoded data which must be decoded",
 				},
 			},
 		},
@@ -181,6 +188,11 @@ func main() {
 					Name:    "meta",
 					Aliases: []string{"m"},
 					Usage:   "return the metadata along with the value",
+				},
+				&cli.BoolFlag{
+					Name:    "b64",
+					Aliases: []string{"b", "b64decode"},
+					Usage:   "specify the keys as base64 encoded values which must be decoded",
 				},
 			},
 		},
@@ -207,8 +219,8 @@ func main() {
 					Usage:   "specify a key to seek to before iterating (optional)",
 				},
 				&cli.BoolFlag{
-					Name:    "b64encode",
-					Aliases: []string{"b"},
+					Name:    "b64",
+					Aliases: []string{"b", "b64decode"},
 					Usage:   "specify the prefix/seek key as base64 encoded values which must be decoded",
 				},
 			},
@@ -355,6 +367,14 @@ func main() {
 					Usage:   "show changes that would occur, does not modify database",
 				},
 			},
+		},
+		{
+			Name:      "uuid-key",
+			Aliases:   []string{"uuid"},
+			Usage:     "convert a uuid into base64 encoded bytes",
+			ArgsUsage: "uuid [uuid ...]",
+			Category:  "utils",
+			Action:    uuidKey,
 		},
 		{
 			Name:      "profile",
@@ -532,7 +552,7 @@ func initPeersClient(c *cli.Context) (err error) {
 
 // dbGet prints values from the trtl database given a set of keys.
 func dbGet(c *cli.Context) (err error) {
-	b64decode := c.Bool("b64decode")
+	b64decode := c.Bool("b64")
 	ctx, cancel := profile.Context()
 	defer cancel()
 
@@ -566,28 +586,42 @@ func dbGet(c *cli.Context) (err error) {
 
 // dbPut puts a value to to a key in the trtl database
 func dbPut(c *cli.Context) (err error) {
+	b64decode := c.Bool("b64")
+
 	// Create the request context
 	ctx, cancel := profile.Context()
 	defer cancel()
 
-	// Execute the Put request
-	var resp *pb.PutReply
 	req := &pb.PutRequest{
-		Key:       []byte(c.String("key")),
-		Value:     []byte(c.String("value")),
 		Namespace: c.String("namespace"),
 		Options: &pb.Options{
 			ReturnMeta: c.Bool("meta"),
 		},
 	}
+
+	// Parse the key and the value into the request
+	key := c.String("key")
+	value := c.String("value")
+	if req.Key, err = wire.DecodeKey(key, b64decode); err != nil {
+		return cli.Exit(fmt.Errorf("could not encode key: %s", err), 1)
+	}
+
+	if req.Value, err = wire.DecodeKey(value, b64decode); err != nil {
+		return cli.Exit(fmt.Errorf("could not encode value: %s", err), 1)
+	}
+
+	// Execute the Put request
+	var resp *pb.PutReply
 	if resp, err = dbClient.Put(ctx, req); err != nil {
 		return cli.Exit(err, 1)
 	}
+
 	if resp.Success {
 		fmt.Printf("successfully put value %s to key %s\n", req.Value, req.Key)
 	} else {
 		fmt.Printf("could not put value %s to key %s\n", req.Value, req.Key)
 	}
+
 	if resp.Meta != nil {
 		// Print the response
 		if err = printJSON(resp); err != nil {
@@ -603,23 +637,29 @@ func dbDelete(c *cli.Context) (err error) {
 	ctx, cancel := profile.Context()
 	defer cancel()
 
-	// Execute the Put request
-	var resp *pb.DeleteReply
 	req := &pb.DeleteRequest{
-		Key:       []byte(c.String("key")),
 		Namespace: c.String("namespace"),
 		Options: &pb.Options{
 			ReturnMeta: c.Bool("meta"),
 		},
 	}
+
+	if req.Key, err = wire.DecodeKey(c.String("key"), c.Bool("b64")); err != nil {
+		return cli.Exit(fmt.Errorf("could not decode key: %s", err), 1)
+	}
+
+	// Execute the Put request
+	var resp *pb.DeleteReply
 	if resp, err = dbClient.Delete(ctx, req); err != nil {
 		return cli.Exit(err, 1)
 	}
+
 	if resp.Success {
 		fmt.Printf("successfully deleted key %s\n", req.Key)
 	} else {
 		fmt.Printf("could not delete key %s\n", req.Key)
 	}
+
 	if resp.Meta != nil {
 		// Print the protocol buffer response as JSON
 		if err = printJSON(resp); err != nil {
@@ -644,7 +684,7 @@ func dbList(c *cli.Context) (err error) {
 		},
 	}
 
-	b64decode := c.Bool("b64decode")
+	b64decode := c.Bool("b64")
 	if prefix := c.String("prefix"); prefix != "" {
 		if req.Prefix, err = wire.DecodeKey(prefix, b64decode); err != nil {
 			return cli.Exit(fmt.Errorf("could not decode prefix: %s", err), 1)
@@ -776,6 +816,21 @@ func gossip(c *cli.Context) (err error) {
 
 func gossipMigrate(c *cli.Context) (err error) {
 	return errors.New("honu object migration required")
+}
+
+//===========================================================================
+// Utility Functions
+//===========================================================================
+
+func uuidKey(c *cli.Context) (err error) {
+	for _, uuids := range c.Args().Slice() {
+		var uu uuid.UUID
+		if uu, err = uuid.Parse(uuids); err != nil {
+			return cli.Exit(err, 1)
+		}
+		fmt.Println(wire.EncodeKey(uu[:], true))
+	}
+	return nil
 }
 
 //===========================================================================


### PR DESCRIPTION
### Scope of changes

This PR is required for SC-9227. @masskoder created an account on production but asked me to delete it. It is straight forward to delete his user from Auth0 via their UI, but this leaves a disconnected `organization` in the trtl database that used to be associated with the user. In an effort to keep the BFF database clean, I wanted to delete the organization associated with the user account. Unfortunately, the `trtl` CLI program had some bugs in it that did not allow me to do this easily - this PR fixes those bugs. 

The primary issue is that the keys for the `organizations` are the UUID bytes (not a string) so you can't specify the key on the command line to delete it. The `trtl` command had utilities for base64 encoded keys, but they were not consistent (e.g. not on the `db:put` and `db:del` commands) and they were incorrectly named in a couple of cases so they were not used (e.g in the `db:list` command). This PR unifies the functionality and repairs the misnamed variables. It also adds a utility function `uuid-key` to get the base64 encoded uuid as the key for the organization.

I was able to successfully use this new command to list the organizations and delete the correct organization from the `gds-0` pod. 

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

You should be able to list the keys as base64 encoded strings:

```
$ trtl db:list -b -n organizations
```

You should also be able to get the data with a base64 encoded string:

```
$ trtl db:get -b -n organizations abcd1234
```

Finally, you should be able to convert a UUID into a base64 encoded string:

```
$ trtl uuid 33a7bd79-50d9-4136-9dcd-0f46024d3c73
```

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  ~I have updated the dependencies list~
- [ ]  ~I have recompiled and included new protocol buffers to reflect changes I made~
- [ ]  ~I have added new test fixtures as needed to support added tests~
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] The CLI program commands make sense and work as expected.


