### PR TITLE
sc-9268 Remove Shaded Line on Overview page

### DIFF
--- a/web/gds-user-ui/src/components/BasicDetail/index.tsx
+++ b/web/gds-user-ui/src/components/BasicDetail/index.tsx
@@ -66,7 +66,7 @@ const BasicDetails: React.FC<BasicDetailProps> = ({ onChangeRegistrationState })
     reader.readAsText(file);
   };
   return (
-    <Stack spacing={7} mt="2rem" bg={bg}>
+    <Stack spacing={7} mt="2rem">
       <HStack justifyContent={'space-between'}>
         <Box display={'flex'}>
           <Heading size="md" pr={3} ml={2}>

--- a/web/gds-user-ui/src/components/TestnetProgress/CertificateStepLabel.tsx
+++ b/web/gds-user-ui/src/components/TestnetProgress/CertificateStepLabel.tsx
@@ -105,7 +105,7 @@ const CertificateStepLabel: FC<StepLabelProps> = (props) => {
   return (
     <>
       <Stack
-        boxShadow="0 24px 50px rgba(55,65, 81, 0.05) "
+        boxShadow="0px 10px 15px -3px rgba(0,0,0,0.1)"
         borderColor={'#C1C9D2'}
         borderRadius={8}
         borderWidth={1}


### PR DESCRIPTION
### Scope of changes
sc-9268 Remove Shaded Line on Overview page

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria
https://app.shortcut.com/rotational/story/9268/remove-shaded-line-on-overview-page

<img width="1679" alt="Capture d’écran 2022-09-14 à 11 19 58" src="https://user-images.githubusercontent.com/54010836/190140403-4e8fcb11-4b9f-4c6c-8e21-d7bd0e04dd8d.png">

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


