### PR TITLE
Fix inconsistent overview response

### DIFF
--- a/pkg/bff/gds_test.go
+++ b/pkg/bff/gds_test.go
@@ -383,7 +383,6 @@ func (s *bffTestSuite) TestSubmitRegistration() {
 	// User metadata should be updated with the directory IDs
 	appdata := &auth.AppMetadata{}
 	require.NoError(appdata.Load(s.auth.GetUserAppMetadata()))
-	fmt.Println(appdata)
 	require.Equal("6041571e-09b4-47e7-870a-723f8032cd6c", appdata.VASPs.TestNet, "incorrect testnet directory id in user metadata")
 	require.Equal("5bafb054-5868-439e-9b3c-75db91810714", appdata.VASPs.MainNet, "incorrect mainnet directory id in user metadata")
 }

--- a/pkg/bff/members.go
+++ b/pkg/bff/members.go
@@ -15,7 +15,6 @@ import (
 	members "github.com/trisacrypto/directory/pkg/gds/members/v1alpha1"
 	"github.com/trisacrypto/directory/pkg/utils/wire"
 	gds "github.com/trisacrypto/trisa/pkg/trisa/gds/api/v1beta1"
-	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -167,10 +166,6 @@ func (s *Server) Overview(c *gin.Context) {
 				FirstListed: mainnet.MemberInfo.FirstListed,
 				VerifiedOn:  mainnet.MemberInfo.VerifiedOn,
 				LastUpdated: mainnet.MemberInfo.LastUpdated,
-			}
-		} else {
-			out.MainNet.MemberDetails = api.MemberDetails{
-				Status: pb.VerificationState_NO_VERIFICATION.String(),
 			}
 		}
 	}


### PR DESCRIPTION
### Scope of changes

This fixes a bug that existed in a code path that was untested in the bff overview handler. We were constructing a member details response for mainnet but not testnet which made the the response a bit inconsistent for the frontend. This removes some logic to make the response more consistent and adds a test case to make sure the code path is covered.

SC-9299

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

In the case where the user is not associated with a mainnet VASP, the overview endpoint should now return an empty string for the `status` field in the `MemberDetails` response for mainnet instead of `NO_VERIFICATION`.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


