### PR TITLE
Fix masked error

### DIFF
--- a/pkg/gds/interceptor.go
+++ b/pkg/gds/interceptor.go
@@ -31,6 +31,7 @@ func (s *Service) unaryInterceptor(ctx context.Context, in interface{}, info *gr
 			service = "members"
 		default:
 			log.WithLevel(zerolog.PanicLevel).Err(fmt.Errorf("unknown service type: %T", info.Server))
+			panicked = false
 			return nil, status.Error(codes.Unimplemented, "unknown service type for request")
 		}
 		sentry.CurrentHub().Scope().SetTag("service", service)


### PR DESCRIPTION
### Scope of changes

This fixes a masked error that can occur due to the panic handling logic in the GDS unary interceptor. We use the `panicked` flag to determine if a panic has occurred in the gRPC handler, and there was a path in the interceptor where this flag was not getting set, which could result in a "false" panic being generated and the error not being captured.

SC-9632

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


