### PR TITLE
sc-6823 GDS UI : make the stepper component label responsive on a small screen

### DIFF
--- a/web/gds-user-ui/src/components/SectionStatus/SavedSectionStatus.tsx
+++ b/web/gds-user-ui/src/components/SectionStatus/SavedSectionStatus.tsx
@@ -1,11 +1,11 @@
 import Icon from '@chakra-ui/icon';
 import { CheckCircleIcon } from '@chakra-ui/icons';
-import { Box, Text } from '@chakra-ui/react';
+import { HStack, Text } from '@chakra-ui/react';
 import { Trans } from '@lingui/react';
 
 const SavedSectionStatus: React.FC = () => {
   return (
-    <Box>
+    <HStack>
       <Icon
         as={CheckCircleIcon}
         w={5}
@@ -17,9 +17,9 @@ const SavedSectionStatus: React.FC = () => {
         }}
       />{' '}
       <Text as={'span'} fontSize={'sm'} pl={1}>
-        <Trans id="(Saved)"> (Saved)</Trans>
+        <Trans id="(Saved)">(Saved)</Trans>
       </Text>
-    </Box>
+    </HStack>
   );
 };
 

--- a/web/gds-user-ui/src/components/TestnetProgress/CertificateStepLabel.tsx
+++ b/web/gds-user-ui/src/components/TestnetProgress/CertificateStepLabel.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 import {
   Box,
   Icon,
@@ -7,7 +7,9 @@ import {
   Stack,
   Tooltip,
   Flex,
-  useColorModeValue
+  useColorModeValue,
+  useDisclosure,
+  Link
 } from '@chakra-ui/react';
 import { FaCheckCircle, FaDotCircle, FaRegCircle } from 'react-icons/fa';
 import { useSelector, RootStateOrAny } from 'react-redux';
@@ -15,6 +17,9 @@ import { TStep } from 'application/store/stepper.slice';
 import { findStepKey } from 'utils/utils';
 import { Trans } from '@lingui/react';
 import { t } from '@lingui/macro';
+import { useFormContext } from 'react-hook-form';
+import useCertificateStepper from 'hooks/useCertificateStepper';
+import InvalidFormPrompt from './InvalidFormPrompt';
 
 export enum LCOLOR {
   'COMPLETE' = '#34A853',
@@ -42,6 +47,16 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
   const currentStep: number = useSelector((state: RootStateOrAny) => state.stepper.currentStep);
   const steps: TStep[] = useSelector((state: RootStateOrAny) => state.stepper.steps);
   const textColor = useColorModeValue('#3C4257', '#F7F8FC');
+  const { jumpToStep } = useCertificateStepper();
+  const { isOpen, onClose, onOpen } = useDisclosure();
+  const formContext = useFormContext();
+  const [selectedStep, setSelectedStep] = useState<number>(currentStep);
+  const [initialFormValues, setInitialFormValues] = useState<Record<string, any>>();
+
+  useEffect(() => {
+    setInitialFormValues(formContext.getValues());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // this function need some clean up
   const getLabel = (step: number): TStepLabel | undefined => {
@@ -99,6 +114,21 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
   };
   const isActiveStep = (step: number) => step === currentStep;
 
+  const handleStepClick = (step: number) => () => {
+    setSelectedStep(step);
+    if (formContext.formState.isDirty) {
+      onOpen();
+    } else {
+      jumpToStep(step);
+    }
+  };
+
+  const handleContinueClick = () => {
+    formContext.reset(initialFormValues);
+    jumpToStep(selectedStep);
+    onClose();
+  };
+
   return (
     <>
       <Stack
@@ -116,168 +146,185 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
           </Heading>
         </Box>
         <Flex gap={2}>
-          <Tooltip
-            label={getLabel(1)?.hasError && t`Missing required element`}
-            placement="top"
-            bg={'red'}>
+          <Link display="block" width="100%" onClick={handleStepClick(1)}>
+            <Tooltip
+              label={getLabel(1)?.hasError && t`Missing required element`}
+              placement="top"
+              bg={'red'}>
+              <Stack spacing={1} width="100%">
+                <Box h="1" borderRadius={'50px'} bg={getLabel(1)?.color} width={'100%'} key={1} />
+                <Stack
+                  direction={{ base: 'column', md: 'row' }}
+                  alignItems={['center']}
+                  spacing={{ base: 0, md: 1 }}>
+                  <Box>
+                    <Icon
+                      as={getLabel(1)?.icon}
+                      sx={{
+                        path: {
+                          fill: getLabel(1)?.color
+                        }
+                      }}
+                    />
+                  </Box>
+                  <Text
+                    color={textColor}
+                    fontWeight={isActiveStep(1) ? 'bold' : 'normal'}
+                    fontSize={'sm'}
+                    textAlign="center">
+                    1 <Trans id="Basic Details">Basic Details</Trans>
+                  </Text>
+                </Stack>
+              </Stack>
+            </Tooltip>
+          </Link>
+
+          <Link display="block" width="100%" onClick={handleStepClick(2)}>
             <Stack spacing={1} width="100%">
-              <Box h="1" borderRadius={'50px'} bg={getLabel(1)?.color} width={'100%'} key={1} />
+              <Box h="1" bg={getLabel(2)?.color} borderRadius={'50px'} width={'100%'} />
+              <Stack
+                direction={{ base: 'column', md: 'row' }}
+                alignItems={'center'}
+                spacing={{ base: 0, md: 1 }}>
+                <Box>
+                  <Icon
+                    as={getLabel(2)?.icon}
+                    sx={{
+                      path: {
+                        fill: getLabel(2)?.color
+                      },
+                      verticalAlign: 'middle'
+                    }}
+                  />
+                </Box>
+                <Text
+                  color={textColor}
+                  fontSize={'sm'}
+                  fontWeight={isActiveStep(2) ? 'bold' : 'normal'}
+                  textAlign="center">
+                  2 <Trans id="Legal Person">Legal Person</Trans>
+                </Text>
+              </Stack>
+            </Stack>
+          </Link>
+
+          <Link display="block" width="100%" onClick={handleStepClick(3)}>
+            <Stack spacing={1} width="100%">
+              <Box h="1" bg={getLabel(3)?.color} width={'100%'} borderRadius={'50px'} />
               <Stack
                 direction={{ base: 'column', md: 'row' }}
                 alignItems={['center']}
                 spacing={{ base: 0, md: 1 }}>
                 <Box>
                   <Icon
-                    as={getLabel(1)?.icon}
+                    as={getLabel(3)?.icon}
                     sx={{
                       path: {
-                        fill: getLabel(1)?.color
+                        fill: getLabel(3)?.color
                       }
                     }}
                   />
                 </Box>
                 <Text
                   color={textColor}
-                  fontWeight={isActiveStep(1) ? 'bold' : 'normal'}
                   fontSize={'sm'}
+                  fontWeight={isActiveStep(3) ? 'bold' : 'normal'}
                   textAlign="center">
-                  1 <Trans id="Basic Details">Basic Details</Trans>
+                  3 <Trans id="Contacts">Contacts</Trans>
                 </Text>
               </Stack>
             </Stack>
-          </Tooltip>
+          </Link>
 
-          <Stack spacing={1} width="100%">
-            <Box h="1" bg={getLabel(2)?.color} borderRadius={'50px'} width={'100%'} />
-            <Stack
-              direction={{ base: 'column', md: 'row' }}
-              alignItems={'center'}
-              spacing={{ base: 0, md: 1 }}>
-              <Box>
-                <Icon
-                  as={getLabel(2)?.icon}
-                  sx={{
-                    path: {
-                      fill: getLabel(2)?.color
-                    },
-                    verticalAlign: 'middle'
-                  }}
-                />
-              </Box>
-              <Text
-                color={textColor}
-                fontSize={'sm'}
-                fontWeight={isActiveStep(2) ? 'bold' : 'normal'}
-                textAlign="center">
-                2 <Trans id="Legal Person">Legal Person</Trans>
-              </Text>
+          <Link display="block" width="100%" onClick={handleStepClick(4)}>
+            <Stack spacing={1} width="100%">
+              <Box h="1" bg={getLabel(4)?.color} width={'100%'} borderRadius={'50px'} />
+              <Stack
+                direction={{ base: 'column', md: 'row' }}
+                alignItems={['center']}
+                spacing={{ base: 0, md: 1 }}>
+                <Box>
+                  <Icon
+                    as={getLabel(4)?.icon}
+                    sx={{
+                      path: {
+                        fill: getLabel(4)?.color
+                      }
+                    }}
+                  />
+                </Box>
+                <Text
+                  color={textColor}
+                  fontSize={'sm'}
+                  fontWeight={isActiveStep(4) ? 'bold' : 'normal'}
+                  textAlign="center">
+                  4 <Trans id="TRISA implementation">TRISA implementation</Trans>
+                </Text>
+              </Stack>
             </Stack>
-          </Stack>
+          </Link>
 
-          <Stack spacing={1} width="100%">
-            <Box h="1" bg={getLabel(3)?.color} width={'100%'} borderRadius={'50px'} />
-            <Stack
-              direction={{ base: 'column', md: 'row' }}
-              alignItems={['center']}
-              spacing={{ base: 0, md: 1 }}>
-              <Box>
-                <Icon
-                  as={getLabel(3)?.icon}
-                  sx={{
-                    path: {
-                      fill: getLabel(3)?.color
-                    }
-                  }}
-                />
-              </Box>
-              <Text
-                color={textColor}
-                fontSize={'sm'}
-                fontWeight={isActiveStep(3) ? 'bold' : 'normal'}
-                textAlign="center">
-                3 <Trans id="Contacts">Contacts</Trans>
-              </Text>
+          <Link display="block" width="100%" onClick={handleStepClick(5)}>
+            <Stack spacing={1} width="100%">
+              <Box h="1" bg={getLabel(5)?.color} width={'100%'} borderRadius={'50px'} />
+              <Stack
+                direction={{ base: 'column', md: 'row' }}
+                alignItems={['center']}
+                spacing={{ base: 0, md: 1 }}>
+                <Box>
+                  <Icon
+                    as={getLabel(5)?.icon}
+                    sx={{
+                      path: {
+                        fill: getLabel(5)?.color
+                      }
+                    }}
+                  />
+                </Box>
+                <Text
+                  color={textColor}
+                  fontSize={'sm'}
+                  fontWeight={isActiveStep(5) ? 'bold' : 'normal'}
+                  textAlign="center">
+                  5 <Trans id="TRIXO Questionnaire">TRIXO Questionnaire</Trans>
+                </Text>
+              </Stack>
             </Stack>
-          </Stack>
+          </Link>
 
-          <Stack spacing={1} width="100%">
-            <Box h="1" bg={getLabel(4)?.color} width={'100%'} borderRadius={'50px'} />
-            <Stack
-              direction={{ base: 'column', md: 'row' }}
-              alignItems={['center']}
-              spacing={{ base: 0, md: 1 }}>
-              <Box>
-                <Icon
-                  as={getLabel(4)?.icon}
-                  sx={{
-                    path: {
-                      fill: getLabel(4)?.color
-                    }
-                  }}
-                />
-              </Box>
-              <Text
-                color={textColor}
-                fontSize={'sm'}
-                fontWeight={isActiveStep(4) ? 'bold' : 'normal'}
-                textAlign="center">
-                4 <Trans id="TRISA implementation">TRISA implementation</Trans>
-              </Text>
+          <Link display="block" width="100%" onClick={handleStepClick(6)}>
+            <Stack spacing={1} width="100%">
+              <Box h="1" bg={getLabel(6)?.color} width={'100%'} borderRadius={'50px'} />
+              <Stack
+                direction={{ base: 'column', md: 'row' }}
+                alignItems={['center']}
+                spacing={{ base: 0, md: 1 }}>
+                <Box>
+                  <Icon
+                    as={getLabel(6)?.icon}
+                    sx={{
+                      path: {
+                        fill: getLabel(6)?.color
+                      }
+                    }}
+                  />
+                </Box>
+                <Text
+                  color={textColor}
+                  fontSize={'sm'}
+                  fontWeight={isActiveStep(6) ? 'bold' : 'normal'}
+                  textAlign="center">
+                  6 <Trans id="Review">Review</Trans>
+                </Text>
+              </Stack>
             </Stack>
-          </Stack>
-
-          <Stack spacing={1} width="100%">
-            <Box h="1" bg={getLabel(5)?.color} width={'100%'} borderRadius={'50px'} />
-            <Stack
-              direction={{ base: 'column', md: 'row' }}
-              alignItems={['center']}
-              spacing={{ base: 0, md: 1 }}>
-              <Box>
-                <Icon
-                  as={getLabel(5)?.icon}
-                  sx={{
-                    path: {
-                      fill: getLabel(5)?.color
-                    }
-                  }}
-                />
-              </Box>
-              <Text
-                color={textColor}
-                fontSize={'sm'}
-                fontWeight={isActiveStep(5) ? 'bold' : 'normal'}
-                textAlign="center">
-                5 <Trans id="TRIXO Questionnaire">TRIXO Questionnaire</Trans>
-              </Text>
-            </Stack>
-          </Stack>
-
-          <Stack spacing={1} width="100%">
-            <Box h="1" bg={getLabel(6)?.color} width={'100%'} borderRadius={'50px'} />
-            <Stack
-              direction={{ base: 'column', md: 'row' }}
-              alignItems={['center']}
-              spacing={{ base: 0, md: 1 }}>
-              <Box>
-                <Icon
-                  as={getLabel(6)?.icon}
-                  sx={{
-                    path: {
-                      fill: getLabel(6)?.color
-                    }
-                  }}
-                />
-              </Box>
-              <Text
-                color={textColor}
-                fontSize={'sm'}
-                fontWeight={isActiveStep(6) ? 'bold' : 'normal'}
-                textAlign="center">
-                6 <Trans id="Review">Review</Trans>
-              </Text>
-            </Stack>
-          </Stack>
+          </Link>
         </Flex>
+        <InvalidFormPrompt
+          isOpen={isOpen}
+          onClose={onClose}
+          handleContinueClick={handleContinueClick}
+        />
       </Stack>
     </>
   );

--- a/web/gds-user-ui/src/components/TestnetProgress/CertificateStepLabel.tsx
+++ b/web/gds-user-ui/src/components/TestnetProgress/CertificateStepLabel.tsx
@@ -5,18 +5,18 @@ import {
   Text,
   Heading,
   Stack,
-  Tooltip,
-  Flex,
+  // Flex,
   useColorModeValue,
   useDisclosure,
-  Link
+  Link,
+  SimpleGrid,
+  Tooltip
 } from '@chakra-ui/react';
 import { FaCheckCircle, FaDotCircle, FaRegCircle } from 'react-icons/fa';
 import { useSelector, RootStateOrAny } from 'react-redux';
 import { TStep } from 'application/store/stepper.slice';
 import { findStepKey } from 'utils/utils';
 import { Trans } from '@lingui/react';
-import { t } from '@lingui/macro';
 import { useFormContext } from 'react-hook-form';
 import useCertificateStepper from 'hooks/useCertificateStepper';
 import InvalidFormPrompt from './InvalidFormPrompt';
@@ -145,12 +145,9 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
             <Trans id="Certificate Progress">Certificate Progress</Trans>{' '}
           </Heading>
         </Box>
-        <Flex gap={2}>
-          <Link display="block" width="100%" onClick={handleStepClick(1)}>
-            <Tooltip
-              label={getLabel(1)?.hasError && t`Missing required element`}
-              placement="top"
-              bg={'red'}>
+        <SimpleGrid columns={6} spacing={1}>
+          <Tooltip label={<Trans id="Basic Details">Basic Details</Trans>} gutter={0} hasArrow>
+            <Link display="block" width="100%" onClick={handleStepClick(1)}>
               <Stack spacing={1} width="100%">
                 <Box h="1" borderRadius={'50px'} bg={getLabel(1)?.color} width={'100%'} key={1} />
                 <Stack
@@ -165,48 +162,61 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
                           fill: getLabel(1)?.color
                         }
                       }}
+                      verticalAlign={{ base: 'baseline', lg: 'middle' }}
                     />
                   </Box>
                   <Text
+                    noOfLines={2}
                     color={textColor}
                     fontWeight={isActiveStep(1) ? 'bold' : 'normal'}
                     fontSize={'sm'}
                     textAlign="center">
-                    1 <Trans id="Basic Details">Basic Details</Trans>
+                    <Text display={{ base: 'block', md: 'inline' }} mr={2}>
+                      1
+                    </Text>
+                    <Trans id="Basic Details">Basic Details</Trans>
                   </Text>
                 </Stack>
               </Stack>
-            </Tooltip>
-          </Link>
+            </Link>
+          </Tooltip>
 
-          <Link display="block" width="100%" onClick={handleStepClick(2)}>
-            <Stack spacing={1} width="100%">
-              <Box h="1" bg={getLabel(2)?.color} borderRadius={'50px'} width={'100%'} />
-              <Stack
-                direction={{ base: 'column', md: 'row' }}
-                alignItems={'center'}
-                spacing={{ base: 0, md: 1 }}>
-                <Box>
-                  <Icon
-                    as={getLabel(2)?.icon}
-                    sx={{
-                      path: {
-                        fill: getLabel(2)?.color
-                      },
-                      verticalAlign: 'middle'
-                    }}
-                  />
-                </Box>
-                <Text
-                  color={textColor}
-                  fontSize={'sm'}
-                  fontWeight={isActiveStep(2) ? 'bold' : 'normal'}
-                  textAlign="center">
-                  2 <Trans id="Legal Person">Legal Person</Trans>
-                </Text>
+          <Tooltip label={<Trans id="Legal Person">Legal Person</Trans>} gutter={0} hasArrow>
+            <Link display="block" width="100%" onClick={handleStepClick(2)}>
+              <Stack spacing={1} width="100%">
+                <Box h="1" bg={getLabel(2)?.color} borderRadius={'50px'} width={'100%'} />
+                <Stack
+                  direction={{ base: 'column', md: 'row' }}
+                  alignItems={'center'}
+                  spacing={{ base: 0, md: 1 }}>
+                  <Box>
+                    <Icon
+                      as={getLabel(2)?.icon}
+                      sx={{
+                        path: {
+                          fill: getLabel(2)?.color
+                        }
+                      }}
+                      verticalAlign={{ base: 'baseline', lg: 'middle' }}
+                    />
+                  </Box>
+                  <Text
+                    noOfLines={2}
+                    color={textColor}
+                    fontSize={'sm'}
+                    fontWeight={isActiveStep(2) ? 'bold' : 'normal'}
+                    textAlign="center">
+                    <Text as="span" display={{ base: 'block', md: 'inline' }} mr={2}>
+                      2
+                    </Text>
+                    <Text as="span">
+                      <Trans id="Legal Person">Legal Person</Trans>
+                    </Text>
+                  </Text>
+                </Stack>
               </Stack>
-            </Stack>
-          </Link>
+            </Link>
+          </Tooltip>
 
           <Link display="block" width="100%" onClick={handleStepClick(3)}>
             <Stack spacing={1} width="100%">
@@ -223,6 +233,7 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
                         fill: getLabel(3)?.color
                       }
                     }}
+                    verticalAlign={{ base: 'baseline', lg: 'middle' }}
                   />
                 </Box>
                 <Text
@@ -230,67 +241,96 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
                   fontSize={'sm'}
                   fontWeight={isActiveStep(3) ? 'bold' : 'normal'}
                   textAlign="center">
-                  3 <Trans id="Contacts">Contacts</Trans>
+                  <Text as="span" display={{ base: 'block', md: 'inline' }} mr={2}>
+                    3
+                  </Text>
+                  <Text as="span">
+                    <Trans id="Contacts">Contacts</Trans>
+                  </Text>
                 </Text>
               </Stack>
             </Stack>
           </Link>
 
-          <Link display="block" width="100%" onClick={handleStepClick(4)}>
-            <Stack spacing={1} width="100%">
-              <Box h="1" bg={getLabel(4)?.color} width={'100%'} borderRadius={'50px'} />
-              <Stack
-                direction={{ base: 'column', md: 'row' }}
-                alignItems={['center']}
-                spacing={{ base: 0, md: 1 }}>
-                <Box>
-                  <Icon
-                    as={getLabel(4)?.icon}
-                    sx={{
-                      path: {
-                        fill: getLabel(4)?.color
-                      }
-                    }}
-                  />
-                </Box>
-                <Text
-                  color={textColor}
-                  fontSize={'sm'}
-                  fontWeight={isActiveStep(4) ? 'bold' : 'normal'}
-                  textAlign="center">
-                  4 <Trans id="TRISA implementation">TRISA implementation</Trans>
-                </Text>
+          <Tooltip
+            label={<Trans id="TRISA Implemntation">TRISA Implemntation</Trans>}
+            gutter={0}
+            hasArrow>
+            <Link display="block" width="100%" onClick={handleStepClick(4)}>
+              <Stack spacing={1} width="100%">
+                <Box h="1" bg={getLabel(4)?.color} width={'100%'} borderRadius={'50px'} />
+                <Stack
+                  direction={{ base: 'column', md: 'row' }}
+                  alignItems={['center']}
+                  spacing={{ base: 0, md: 1 }}>
+                  <Box>
+                    <Icon
+                      as={getLabel(4)?.icon}
+                      sx={{
+                        path: {
+                          fill: getLabel(4)?.color
+                        }
+                      }}
+                      verticalAlign={{ base: 'baseline', lg: 'middle' }}
+                    />
+                  </Box>
+                  <Text
+                    noOfLines={2}
+                    color={textColor}
+                    fontSize={'sm'}
+                    fontWeight={isActiveStep(4) ? 'bold' : 'normal'}
+                    textAlign="center">
+                    <Text as="span" display={{ base: 'block', md: 'inline' }} mr={2}>
+                      4
+                    </Text>
+                    <Text as="span">
+                      <Trans id="TRISA implementation">TRISA implementation</Trans>
+                    </Text>
+                  </Text>
+                </Stack>
               </Stack>
-            </Stack>
-          </Link>
+            </Link>
+          </Tooltip>
 
-          <Link display="block" width="100%" onClick={handleStepClick(5)}>
-            <Stack spacing={1} width="100%">
-              <Box h="1" bg={getLabel(5)?.color} width={'100%'} borderRadius={'50px'} />
-              <Stack
-                direction={{ base: 'column', md: 'row' }}
-                alignItems={['center']}
-                spacing={{ base: 0, md: 1 }}>
-                <Box>
-                  <Icon
-                    as={getLabel(5)?.icon}
-                    sx={{
-                      path: {
-                        fill: getLabel(5)?.color
-                      }
-                    }}
-                  />
-                </Box>
-                <Text
-                  color={textColor}
-                  fontSize={'sm'}
-                  fontWeight={isActiveStep(5) ? 'bold' : 'normal'}
-                  textAlign="center">
-                  5 <Trans id="TRIXO Questionnaire">TRIXO Questionnaire</Trans>
-                </Text>
+          <Tooltip
+            label={<Trans id="TRIXO Questionnaire">TRIXO Questionnaire</Trans>}
+            gutter={0}
+            hasArrow>
+            <Link display="block" width="100%" onClick={handleStepClick(5)}>
+              <Stack spacing={1} width="100%">
+                <Box h="1" bg={getLabel(5)?.color} width={'100%'} borderRadius={'50px'} />
+                <Stack
+                  direction={{ base: 'column', md: 'row' }}
+                  alignItems={['center']}
+                  spacing={{ base: 0, md: 1 }}>
+                  <Box>
+                    <Icon
+                      as={getLabel(5)?.icon}
+                      sx={{
+                        path: {
+                          fill: getLabel(5)?.color
+                        }
+                      }}
+                      verticalAlign={{ base: 'baseline', lg: 'middle' }}
+                    />
+                  </Box>
+                  <Text
+                    noOfLines={2}
+                    color={textColor}
+                    fontSize={'sm'}
+                    fontWeight={isActiveStep(5) ? 'bold' : 'normal'}
+                    textAlign="center">
+                    <Text as="span" display={{ base: 'block', md: 'inline' }} mr={2}>
+                      5
+                    </Text>
+                    <Text as="span" maxInlineSize={{ base: '1ch' }}>
+                      <Trans id="TRIXO Questionnaire">TRIXO Questionnaire</Trans>
+                    </Text>
+                  </Text>
+                </Stack>
               </Stack>
-            </Stack>
-          </Link>
+            </Link>
+          </Tooltip>
 
           <Link display="block" width="100%" onClick={handleStepClick(6)}>
             <Stack spacing={1} width="100%">
@@ -307,6 +347,7 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
                         fill: getLabel(6)?.color
                       }
                     }}
+                    verticalAlign={{ base: 'baseline', lg: 'middle' }}
                   />
                 </Box>
                 <Text
@@ -314,12 +355,17 @@ const CertificateStepLabel: FC<StepLabelProps> = () => {
                   fontSize={'sm'}
                   fontWeight={isActiveStep(6) ? 'bold' : 'normal'}
                   textAlign="center">
-                  6 <Trans id="Review">Review</Trans>
+                  <Text as="span" display={{ base: 'block', md: 'inline' }} mr={2}>
+                    6
+                  </Text>
+                  <Text as="span">
+                    <Trans id="Review">Review</Trans>
+                  </Text>
                 </Text>
               </Stack>
             </Stack>
           </Link>
-        </Flex>
+        </SimpleGrid>
         <InvalidFormPrompt
           isOpen={isOpen}
           onClose={onClose}

--- a/web/gds-user-ui/src/components/TestnetProgress/InvalidFormPrompt.tsx
+++ b/web/gds-user-ui/src/components/TestnetProgress/InvalidFormPrompt.tsx
@@ -1,0 +1,39 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  ModalHeader
+} from '@chakra-ui/react';
+
+type InvalidFormPromptProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  handleContinueClick: () => void;
+};
+
+function InvalidFormPrompt({ isOpen, onClose, handleContinueClick }: InvalidFormPromptProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>&nbsp;</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>You are about to lose your changes</ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="blue" onClick={handleContinueClick}>
+            Continue
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default InvalidFormPrompt;

--- a/web/gds-user-ui/src/components/TestnetProgress/__tests__/InvalidFormPrompt.spec.tsx
+++ b/web/gds-user-ui/src/components/TestnetProgress/__tests__/InvalidFormPrompt.spec.tsx
@@ -1,0 +1,32 @@
+import userEvent from '@testing-library/user-event';
+import { dynamicActivate } from 'utils/i18nLoaderHelper';
+import { render, act, screen } from 'utils/test-utils';
+import InvalidFormPrompt from '../InvalidFormPrompt';
+
+describe('<InvalidFormPrompt />', () => {
+  beforeAll(() => {
+    act(() => {
+      dynamicActivate('en');
+    });
+  });
+
+  it('should', () => {
+    const handleContinueClick = jest.fn();
+    const handleClose = jest.fn();
+    const isOpen = true;
+
+    render(
+      <InvalidFormPrompt
+        isOpen={isOpen}
+        onClose={handleClose}
+        handleContinueClick={handleContinueClick}
+      />
+    );
+
+    const continueButton = screen.getByRole('button', { name: /continue/i });
+
+    userEvent.click(continueButton);
+
+    expect(handleContinueClick).toHaveBeenCalled();
+  });
+});

--- a/web/gds-user-ui/src/modules/dashboard/certificate/registration.tsx
+++ b/web/gds-user-ui/src/modules/dashboard/certificate/registration.tsx
@@ -276,7 +276,9 @@ const Certificate: React.FC = () => {
                     direction={'row'}
                     spacing={8}
                     justifyContent={'center'}
-                    py={6}>
+                    py={6}
+                    wrap="wrap"
+                    rowGap={2}>
                     {!hasReachSubmitStep && (
                       <StepButtons
                         currentStep={currentStep}


### PR DESCRIPTION
### Scope of changes

sc-6823 GDS UI : make the stepper component label responsive on a small screen

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria
<img width="1679" alt="image" src="https://user-images.githubusercontent.com/54010836/195147629-91d2821f-cc7d-410e-9be1-b51b02821ab8.png">

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


