### PR TITLE
sc-9893 Lighten Background Color of Notification Component on Overview page

### DIFF
--- a/web/gds-user-ui/src/components/NeedsAttention/AttentionAlert.tsx
+++ b/web/gds-user-ui/src/components/NeedsAttention/AttentionAlert.tsx
@@ -32,7 +32,7 @@ const AttentionAlert = ({ severity, message, action, onClick }: AttentionAlertPr
       case AttentionAction.START_REGISTRATION:
         return (
           <>
-            <Alert status={severity.toLowerCase()} borderRadius={'10px'}>
+            <Alert bg="#D8EAF6" status={severity.toLowerCase()} borderRadius={'10px'}>
               <AlertIcon />
               <HStack justifyContent={'space-between'}>
                 <Text> {message}</Text>
@@ -43,7 +43,6 @@ const AttentionAlert = ({ severity, message, action, onClick }: AttentionAlertPr
                   px={8}
                   as={'a'}
                   borderRadius={0}
-                  background="transparent"
                   color="#fff"
                   cursor="pointer"
                   _active={{ background: '#000' }}
@@ -51,7 +50,7 @@ const AttentionAlert = ({ severity, message, action, onClick }: AttentionAlertPr
                   Start
                 </Button>
               </HStack>
-            </Alert>{' '}
+            </Alert>
           </>
         );
 
@@ -77,7 +76,7 @@ const AttentionAlert = ({ severity, message, action, onClick }: AttentionAlertPr
                   Complete
                 </Button>
               </HStack>
-            </Alert>{' '}
+            </Alert>
           </>
         );
       case (AttentionAction.SUBMIT_TESTNET, AttentionAction.SUBMIT_MAINNET):
@@ -104,13 +103,13 @@ const AttentionAlert = ({ severity, message, action, onClick }: AttentionAlertPr
                   </Button>
                 </Box>
               </HStack>
-            </Alert>{' '}
+            </Alert>
           </>
         );
 
       default:
         return (
-          <Alert status={AttentionSeverity.INFO} borderRadius={'10px'}>
+          <Alert bg="#D8EAF6" status={AttentionSeverity.INFO} borderRadius={'10px'}>
             <AlertIcon />
             {message}
           </Alert>


### PR DESCRIPTION
### Scope of changes
sc-9893 Lighten Background Color of Notification Component on Overview page

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria
https://app.shortcut.com/rotational/story/9893/lighten-background-color-of-notification-component-on-overview-page

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/54010836/195570625-d58a690a-0260-4fe4-aa5c-09a18c8c540b.png">


### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


