### PR TITLE
Certman Bug Fixes and Helper Utility

### DIFF
--- a/cmd/reissuer/build.sh
+++ b/cmd/reissuer/build.sh
@@ -59,7 +59,7 @@ if [[ $# -eq 1 ]]; then
     case $1 in
         clean)
             echo "your k8s cluster context is $KUBECTX"
-            echo "removing issuer from GDS pod in $NAMESPACE"
+            echo "removing reissuer from GDS pod in $NAMESPACE"
             kubectl -n $NAMESPACE exec -it gds-0 -- rm /usr/local/bin/reissuer
             exit 0
             ;;

--- a/pkg/gds/certman/certs.go
+++ b/pkg/gds/certman/certs.go
@@ -813,7 +813,7 @@ vaspsLoop:
 		if !bytes.Equal(sig, updated) {
 			// We need to update the vasp record in the database so that the email logs are preserved.
 			if err = c.db.UpdateVASP(vasp); err != nil {
-				log.Error().Err(err).Str("vasp_id", vasp.Id).Msg("error updating the vasp record in the database")
+				log.Error().Err(err).Str("vasp_id", vasp.Id).Msg("error updating the VASP record in the database")
 				continue vaspsLoop
 			}
 		}

--- a/pkg/models/v1/models.go
+++ b/pkg/models/v1/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"crypto/sha512"
 	"errors"
 	"fmt"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/trisacrypto/directory/pkg/sectigo"
 	"github.com/trisacrypto/trisa/pkg/ivms101"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -600,4 +602,17 @@ func ValidateVASP(vasp *pb.VASP, partial bool) (err error) {
 	default:
 		return err
 	}
+}
+
+// VASPSignature returns a SHA512 hash of the protocol buffer bytes that represents the
+// current data in the VASP. This signature can be used to compare two VASP records for
+// equality or to detect if a VASP record has been changed.
+func VASPSignature(vasp *pb.VASP) (_ []byte, err error) {
+	var data []byte
+	if data, err = proto.Marshal(vasp); err != nil {
+		return nil, err
+	}
+
+	sum := sha512.Sum512(data)
+	return sum[:], nil
 }

--- a/pkg/models/v1/models_test.go
+++ b/pkg/models/v1/models_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trisacrypto/directory/pkg/models/v1"
 	. "github.com/trisacrypto/directory/pkg/models/v1"
 	"github.com/trisacrypto/directory/pkg/sectigo"
 	"github.com/trisacrypto/trisa/pkg/ivms101"
@@ -888,7 +887,7 @@ func TestVASPSignature(t *testing.T) {
 	siga, err := VASPSignature(vaspa)
 	require.NoError(t, err, "could not compute vaspa signature")
 
-	vaspa.Extra, _ = anypb.New(&models.GDSExtraData{})
+	vaspa.Extra, _ = anypb.New(&GDSExtraData{})
 
 	_, err = CreateReviewNote(vaspa, "123", "admin@example.com", "this is a test note")
 	require.NoError(t, err, "could not add review note")

--- a/pkg/models/v1/models_test.go
+++ b/pkg/models/v1/models_test.go
@@ -1,16 +1,21 @@
 package models_test
 
 import (
+	"bytes"
 	"encoding/hex"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/directory/pkg/models/v1"
 	. "github.com/trisacrypto/directory/pkg/models/v1"
 	"github.com/trisacrypto/directory/pkg/sectigo"
 	"github.com/trisacrypto/trisa/pkg/ivms101"
 	pb "github.com/trisacrypto/trisa/pkg/trisa/gds/models/v1beta1"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestVASPExtra(t *testing.T) {
@@ -847,4 +852,74 @@ func TestUpdateVerificationStatus(t *testing.T) {
 	require.Equal(t, pb.VerificationState_REVIEWED, auditLog[1].CurrentState)
 	require.Equal(t, "review completed", auditLog[1].Description)
 	require.Equal(t, "pontoon@boatz.com", auditLog[1].Source)
+}
+
+func TestVASPSignature(t *testing.T) {
+	// Signature comparison assertion (can require equal or require not equal using cmp)
+	compare := func(a, b *pb.VASP, cmp require.BoolAssertionFunc, msg ...interface{}) {
+		siga, err := VASPSignature(a)
+		require.NoError(t, err, "could not get signature from vaspa")
+
+		sigb, err := VASPSignature(b)
+		require.NoError(t, err, "could not get signature from vaspb")
+
+		cmp(t, bytes.Equal(siga, sigb), msg...)
+	}
+
+	// empty VASPs should have the same signature
+	vaspa := &pb.VASP{}
+	vaspb := &pb.VASP{}
+	compare(vaspa, vaspb, require.True)
+
+	// load a VASP fixture from disk
+	vaspa, err := loadFixture("testdata/vasp.json")
+	require.NoError(t, err, "could not load vasp fixture from disk")
+
+	// full vasp should not be the same as empty vasp
+	compare(vaspa, vaspb, require.False)
+
+	// load a second VASP fixture from disk (different pointer)
+	vaspb, err = loadFixture("testdata/vasp.json")
+	require.NoError(t, err, "could not load vasp fixture from disk again")
+
+	compare(vaspa, vaspb, require.True)
+
+	// make changes to vaspa to ensure its signature changes
+	siga, err := VASPSignature(vaspa)
+	require.NoError(t, err, "could not compute vaspa signature")
+
+	vaspa.Extra, _ = anypb.New(&models.GDSExtraData{})
+
+	_, err = CreateReviewNote(vaspa, "123", "admin@example.com", "this is a test note")
+	require.NoError(t, err, "could not add review note")
+
+	siga2, err := VASPSignature(vaspa)
+	require.NoError(t, err, "could not compute vaspa signature")
+	require.NotEqual(t, siga, siga2, "changing vasp a did not change singature")
+
+	err = AppendAdminEmailLog(vaspa, "manual entry", "this is a test email log")
+	require.NoError(t, err, "could not append admin email log")
+
+	siga3, err := VASPSignature(vaspa)
+	require.NoError(t, err, "could not compute vaspa signature")
+	require.NotEqual(t, siga2, siga3, "changing vasp a did not change singature")
+}
+
+func loadFixture(path string) (vasp *pb.VASP, err error) {
+	pbjson := protojson.UnmarshalOptions{
+		AllowPartial:   true,
+		DiscardUnknown: false,
+	}
+
+	var data []byte
+	if data, err = os.ReadFile(path); err != nil {
+		return nil, err
+	}
+
+	vasp = &pb.VASP{}
+	if err = pbjson.Unmarshal(data, vasp); err != nil {
+		return nil, err
+	}
+
+	return vasp, nil
 }

--- a/pkg/models/v1/testdata/vasp.json
+++ b/pkg/models/v1/testdata/vasp.json
@@ -1,0 +1,88 @@
+{
+  "id": "0fcf2267-9724-4c0c-ade3-72dfc9d28388",
+  "registered_directory": "trisatest.net",
+  "entity": {
+    "name": {
+      "name_identifiers": [{
+        "legal_person_name": "Example Exchange, Inc.",
+        "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
+      }]
+    },
+    "geographic_addresses": [{
+      "address_type": "ADDRESS_TYPE_CODE_BIZZ",
+      "address_line": [
+        "78 Market Street",
+        "Springfield, WI 59213"
+      ],
+      "country": "US"
+    }],
+    "customer_number": "2f3076300689",
+    "national_identification": {
+      "national_identifier": "37771777",
+      "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_TXID",
+      "registration_authority": "RA777777"
+    },
+    "country_of_registration": "US"
+  },
+  "contacts": {
+    "technical": {
+      "name": "James Franklin",
+      "email": "jfranklin@example.com",
+      "phone": "+1 555-555-5555"
+    },
+    "administrative": {
+      "name": "Judy Bloomfeld",
+      "email": "jbloomfeld@example.com",
+      "phone": ""
+    },
+    "billing": {
+      "name": "Christine Cradock",
+      "email": "ccradock@example.com",
+      "phone": ""
+    },
+    "legal": {
+      "name": "Richard Simlake",
+      "email": "rsimlake@example.com",
+      "phone": "+1 555-555-5557"
+    }
+  },
+  "identity_certificate": {},
+  "signing_certificates": [],
+  "common_name": "trisa.example.com",
+  "trisa_endpoint": "trisa.example.com:443",
+  "website": "https://example.com",
+  "business_category": "PRIVATE_ORGANIZATION",
+  "vasp_categories": [
+    "Exchange", "DEX", "P2P", "Mixer"
+  ],
+  "established_on": "2020-11-05",
+  "trixo": {
+    "primary_national_jurisdiction": "US",
+    "primary_regulator": "FinCEN",
+    "financial_transfers_permitted": "yes",
+    "other_jurisdictions": [],
+    "has_required_regulatory_program": "yes",
+    "conducts_customer_kyc": true,
+    "kyc_threshold": 3000.0,
+    "kyc_threshold_currency": "USD",
+    "must_comply_travel_rule": true,
+    "applicable_regulations": [
+      "BSA", "Recommendation 16"
+    ],
+    "compliance_threshold": 3000.0,
+    "compliance_threshold_currency": "USD",
+    "must_safeguard_pii": false,
+    "safeguards_pii": true
+  },
+  "verification_status": "VERIFIED",
+  "service_status": "HEALTHY",
+  "verified_on": "2021-01-21T16:42:22Z",
+  "first_listed": "2021-01-03T08:12:54Z",
+  "last_updated": "2022-01-13T20:32:12Z",
+  "signature": "",
+  "version": {
+    "pid": 0,
+    "version": 42
+  },
+  "extra": {}
+}


### PR DESCRIPTION
### Scope of changes

We had an issue with a TRISA TestNet registration today where Sectigo rejected the domain name causing multiple critical alerts to trigger. To remediate the situation we put the registration back to "PENDING_REVIEW". This PR contains the helper script in the `reissuer` command that allowed us to do that.

While working on that, I noticed that the batch names had an extra `")"` at the end, so I fixed that minor typo, and since I was there, I also fixed the typo where Certman saves the VASP every day even if it hasn't been changed (causing the last updated timestamp to be unusable). 

Fixes SC-10097
Fixes SC-10325

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

For the most part you can ignore the helper command in `reissuer` -- we've already run this command and it worked. The real question is about certman. Is the `updateRequired` bool sufficient to handle the switch with all the various `continue` statements? Is there a better way we could implement it and still have effective error handling? Is this maintainable in the future? 

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


