### PR TITLE
sc-10109 Warning text color is too hard to read

### DIFF
--- a/web/gds-admin-ui/src/pages/app/details/contact/Contact.js
+++ b/web/gds-admin-ui/src/pages/app/details/contact/Contact.js
@@ -1,11 +1,10 @@
 
-import classNames from 'classnames';
 import React from 'react'
 import PropTypes from 'prop-types';
 import { Button, Col, Row } from 'react-bootstrap';
 import { formatPhoneNumberIntl, isValidPhoneNumber } from 'react-phone-number-input';
 import { formatDisplayedData, verifiedContactStatus } from 'utils';
-import { VERIFIED_CONTACT_STATUS, VERIFIED_CONTACT_STATUS_LABEL } from 'constants/index';
+import { VERIFIED_CONTACT_STATUS_LABEL, VERIFIED_CONTACT_STATUS } from 'constants/index';
 import DeleteContactModal from './DeleteContactModal';
 import { Modal, ModalContent, ModalOpenButton } from 'components/Modal';
 import EditContactModal from './EditContactModal';
@@ -13,18 +12,28 @@ import EditContactModal from './EditContactModal';
 
 function Contact({ data, type, verifiedContact }) {
     const status = verifiedContactStatus({ data, type, verifiedContact })
-    const getColor = (state) => {
+
+    const getIcons = React.useCallback((state) => {
         if (state === VERIFIED_CONTACT_STATUS.ALTERNATE_VERIFIED) {
-            return 'text-warning'
+            return <i className="mdi mdi-alert fs-4 text-warning"></i>
+
         }
         if (state === VERIFIED_CONTACT_STATUS.UNVERIFIED) {
-            return 'text-danger'
+            return <i className="mdi mdi-close-circle fs-4 text-danger"></i>
         }
-        return undefined
-    }
+
+        if (state === VERIFIED_CONTACT_STATUS.VERIFIED) {
+            return <i className='mdi mdi-check-all fs-4 text-success'></i>
+        }
+        return
+    }, [])
+
+    const hasIVMSRecord = !!data?.person
+    const hasValue = React.useMemo(() => data && Object.values(data).length, [data])
+
 
     return (
-        <div data-testid="contact-node" className={classNames(getColor(status))}>
+        <div data-testid="contact-node">
             <p className="fw-bold mb-1 mt-2"> <span className='text-capitalize'>{type}</span> contact
                 <Modal>
                     <ModalOpenButton>
@@ -46,15 +55,21 @@ function Contact({ data, type, verifiedContact }) {
                     <DeleteContactModal type={type} />
                 </Modal>
             </p>
-            <hr className='my-1' />
+            <hr className={'my-1'} />
             <Row>
-                <ul className='list-unstyled'>
-                    {data?.name ? <li>{formatDisplayedData(data?.name)}</li> : null}
-                    {data?.phone && isValidPhoneNumber(data.phone) ? <li>{formatDisplayedData(formatPhoneNumberIntl(data.phone))}</li> : null}
-                    {data?.email ? <li>{formatDisplayedData(data?.email)} <small data-testid="verifiedContactStatus" style={{ fontStyle: 'italic' }}>{VERIFIED_CONTACT_STATUS_LABEL[status]}</small> </li> : null}
-                    <li><small style={{ fontStyle: 'italic' }}>{data?.person ? 'Has IVMS101 Record' : 'No IVMS101 Data'}</small></li>
-                </ul>
+                <div className='d-flex gap-2'>
+                    <div className=''>
+                        {hasValue && getIcons(status)}
+                    </div>
+                    <ul className='list-unstyled'>
+                        {data?.name ? <li>{formatDisplayedData(data?.name)}</li> : null}
+                        {data?.phone && isValidPhoneNumber(data.phone) ? <li>{formatDisplayedData(formatPhoneNumberIntl(data.phone))}</li> : null}
+                        {data?.email ? <li>{formatDisplayedData(data?.email)} <small data-testid="verifiedContactStatus" style={{ fontStyle: 'italic' }}>{VERIFIED_CONTACT_STATUS_LABEL[status]}</small> </li> : null}
+                        <li><small style={{ fontStyle: 'italic' }}>{hasIVMSRecord ? 'Has IVMS101 Record' : 'No IVMS101 Data'}</small></li>
+                    </ul>
+                </div>
             </Row>
+
         </div>
     )
 }

--- a/web/gds-admin-ui/src/pages/app/details/contact/__tests__/contact.spec.js
+++ b/web/gds-admin-ui/src/pages/app/details/contact/__tests__/contact.spec.js
@@ -56,7 +56,6 @@ describe('Contact', () => {
         contactNode = screen.getByTestId('contact-node')
 
         expect(status.textContent).toBe(VERIFIED_CONTACT_STATUS_LABEL.ALTERNATE_VERIFIED)
-        expect(contactNode).toHaveClass('text-warning')
     })
 
     it('should be unverified', () => {
@@ -78,6 +77,5 @@ describe('Contact', () => {
         contactNode = screen.getByTestId('contact-node')
 
         expect(status.textContent).toBe('')
-        expect(contactNode).toHaveClass('text-danger')
     })
 })

--- a/web/gds-admin-ui/src/pages/app/details/contact/index.js
+++ b/web/gds-admin-ui/src/pages/app/details/contact/index.js
@@ -7,6 +7,21 @@ export default function ContactList({ data, verifiedContact }) {
         <Card>
             <Card.Body>
                 <h4 className="mt-0 mb-3 text-dark">Contacts</h4>
+                <div className='d-flex justify-content-between'>
+                    <div className=''>
+                        <i className="mdi mdi-alert fs-5 text-warning me-1"></i>
+                        <small className='fst-italic'>Alternate verified</small>
+                    </div>
+                    <div>
+                        <i className='mdi mdi-check-all fs-5 text-success me-1'></i>
+                        <small className='fst-italic'>Verified</small>
+                    </div>
+                    <div>
+                    <i className="mdi mdi-close-circle fs-5 text-danger me-1"></i>
+                        <small className='fst-italic'>Unverified</small>
+                    </div>
+                    
+                </div>
                 {
                     Object.entries(data || {}).map(([k]) => (
                         <Contact key={k} data={data[k]} verifiedContact={verifiedContact} type={k} />


### PR DESCRIPTION
### Scope of changes
sc-10109 Warning text color is too hard to read

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria
https://app.shortcut.com/rotational/story/10109/warning-text-color-is-too-hard-to-read



### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


