### PR TITLE
Add reissaunce timestamp to vasp snippet

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "cSpell.words": ["import", "State"],
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "files.trimTrailingWhitespace": true
 }

--- a/pkg/gds/admin.go
+++ b/pkg/gds/admin.go
@@ -840,6 +840,7 @@ func (s *Admin) ListVASPs(c *gin.Context) {
 			// Add certificate serial number if it exists
 			if vasp.IdentityCertificate != nil {
 				snippet.CertificateSerial = fmt.Sprintf("%X", vasp.IdentityCertificate.SerialNumber)
+				snippet.CertificateIssued = vasp.IdentityCertificate.NotBefore
 				snippet.CertificateExpiration = vasp.IdentityCertificate.NotAfter
 			}
 

--- a/pkg/gds/admin/v2/api.go
+++ b/pkg/gds/admin/v2/api.go
@@ -135,6 +135,7 @@ type VASPSnippet struct {
 	VerifiedOn            string          `json:"verified_on,omitempty"`
 	Traveler              bool            `json:"traveler"`
 	CertificateSerial     string          `json:"certificate_serial_number,omitempty"`
+	CertificateIssued     string          `json:"certificate_issued,omitempty"`
 	CertificateExpiration string          `json:"certificate_expiration,omitempty"`
 	VerifiedContacts      map[string]bool `json:"verified_contacts"`
 }

--- a/pkg/gds/fixtures/fixtures.go
+++ b/pkg/gds/fixtures/fixtures.go
@@ -53,6 +53,7 @@ var (
 		wire.NamespaceVASPs: {
 			"charliebank": {},
 			"delta":       {},
+			"hotel":       {},
 		},
 	}
 )

--- a/pkg/gds/fixtures/fixtures_test.go
+++ b/pkg/gds/fixtures/fixtures_test.go
@@ -28,7 +28,7 @@ func TestFixtures(t *testing.T) {
 
 	expected := map[fixtures.FixtureType]map[string]int{
 		fixtures.Empty: {},
-		fixtures.Small: {wire.NamespaceVASPs: 2},
+		fixtures.Small: {wire.NamespaceVASPs: 3},
 		fixtures.Full:  {wire.NamespaceVASPs: 14, wire.NamespaceCerts: 3, wire.NamespaceCertReqs: 10},
 	}
 


### PR DESCRIPTION
### Scope of changes

This adds a reissuance timestamp to the VASP snippet. This is required for the frontend to be able to filter/order VASPs by certificate reissuance date.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


