### PR TITLE
Avoid Auth0 role management 400

### DIFF
--- a/pkg/bff/users.go
+++ b/pkg/bff/users.go
@@ -265,15 +265,21 @@ func (s *Server) AssignRoles(userID string, roles []string) (err error) {
 	}
 
 	// Remove the existing roles from the user
-	if err = s.auth0.User.RemoveRoles(userID, userRoles.Roles); err != nil {
-		log.Error().Err(err).Str("user_id", userID).Msg("could not remove existing roles from user")
-		return err
+	// The management endpoint requires a non-empty list, otherwise it returns a 400
+	if len(userRoles.Roles) > 0 {
+		if err = s.auth0.User.RemoveRoles(userID, userRoles.Roles); err != nil {
+			log.Error().Err(err).Str("user_id", userID).Msg("could not remove existing roles from user")
+			return err
+		}
 	}
 
-	// Add the new roles to the user
-	if err = s.auth0.User.AssignRoles(userID, newRoles); err != nil {
-		log.Error().Err(err).Str("user_id", userID).Msg("could not add new roles to user")
-		return err
+	// Assign the new roles to the user
+	// The management endpoint requires a non-empty list, otherwise it returns a 400
+	if len(newRoles) > 0 {
+		if err = s.auth0.User.AssignRoles(userID, newRoles); err != nil {
+			log.Error().Err(err).Str("user_id", userID).Msg("could not add new roles to user")
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Scope of changes

This fixes an Auth0 related bug on the Login endpoint. When we remove and assign user roles, we need to make sure that we're passing a non-empty list to the management API so that we don't trip an error.

SC-11196

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


