### PR TITLE
Add user as collaborator on CreateOrganization

### DIFF
--- a/pkg/bff/organization.go
+++ b/pkg/bff/organization.go
@@ -89,11 +89,29 @@ func (s *Server) CreateOrganization(c *gin.Context) {
 		Name:   params.Name,
 		Domain: domain,
 	}
+
+	// CreatedBy is used to render the organization name for the frontend if no other
+	// organization name is available
 	if org.CreatedBy, err = auth.UserDisplayName(user); err != nil {
 		log.Error().Err(err).Msg("could not get user display name")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not resolve name for user"))
 		return
 	}
+
+	// Add the user to their new organization
+	// Note: The UserInfo middleware ensures that these fields are present in the Auth0
+	// user record
+	collaborator := &models.Collaborator{
+		Email:    *user.Email,
+		UserId:   *user.ID,
+		Verified: *user.EmailVerified,
+	}
+	if err = org.AddCollaborator(collaborator); err != nil {
+		log.Error().Err(err).Str("user_id", collaborator.UserId).Msg("could not add user as collaborator in organization")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not create organization"))
+		return
+	}
+
 	if _, err = s.db.CreateOrganization(org); err != nil {
 		log.Error().Err(err).Msg("could not create organization in database")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not create organization"))

--- a/pkg/bff/organization_test.go
+++ b/pkg/bff/organization_test.go
@@ -66,6 +66,14 @@ func (s *bffTestSuite) TestCreateOrganization() {
 	require.Equal(params.Name, org.Name, "organization name does not match")
 	require.Equal(params.Domain, org.Domain, "organization domain does not match")
 
+	// User should be added as a collaborator
+	require.Len(org.Collaborators, 1, "expected one collaborator")
+	collab := org.GetCollaborator(claims.Email)
+	require.NotNil(collab, "expected user to exist as collaborator in new organization")
+	require.Equal(authtest.Email, collab.Email, "expected collaborator email to match")
+	require.Equal(authtest.UserID, collab.UserId, "expected collaborator user id to match")
+	require.True(collab.Verified, "expected collaborator to be verified")
+
 	// User app metadata should be updated with the organization id
 	metadata := &auth.AppMetadata{}
 	require.NoError(metadata.Load(s.auth.GetUserAppMetadata()))
@@ -108,6 +116,14 @@ func (s *bffTestSuite) TestCreateOrganization() {
 	require.NoError(err, "could not find organization in database")
 	require.Equal(params.Name, org.Name, "organization name does not match")
 	require.Equal("bobvasp.io", org.Domain, "organization domain does not match")
+
+	// User should be added as a collaborator
+	require.Len(org.Collaborators, 1, "expected one collaborator")
+	collab = org.GetCollaborator(claims.Email)
+	require.NotNil(collab, "expected user to exist as collaborator in new organization")
+	require.Equal(authtest.Email, collab.Email, "expected collaborator email to match")
+	require.Equal(authtest.UserID, collab.UserId, "expected collaborator user id to match")
+	require.True(collab.Verified, "expected collaborator to be verified")
 
 	// User app metadata should be updated with the organization id
 	metadata = &auth.AppMetadata{}


### PR DESCRIPTION
### Scope of changes

This fixes a bug where the user tries to switch organizations and gets a 401 error due to not being a collaborator on the organization. The fix is to add them as a collaborator when they create the organization.

SC-11488

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


