### PR TITLE
sc-11788 Hide `Switch Acct` option when user is not a TSP

### DIFF
--- a/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
+++ b/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
@@ -29,6 +29,7 @@ import { Trans } from '@lingui/react';
 import { t } from '@lingui/macro';
 import ChooseAnOrganization from 'components/ChooseAnOrganization';
 import { colors } from 'utils/theme';
+import { canCreateOrganization } from 'utils/permission';
 interface MobileProps extends FlexProps {
   onOpen: () => void;
   isLoading?: boolean;
@@ -51,6 +52,9 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
     resetStore();
     navigate('/');
   };
+
+  console.log('[] canCreateOrganization', canCreateOrganization());
+
   return (
     <Flex
       ml={{ base: 0, md: 60 }}
@@ -86,7 +90,7 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
         </HStack>
         <Divider orientation="vertical" height={8} />
         <Menu>
-          <MenuButton transition="all 0.3s" _focus={{ boxShadow: 'none' }}>
+          <MenuButton data-testid="menu" transition="all 0.3s" _focus={{ boxShadow: 'none' }}>
             <HStack>
               <Show above="lg">
                 <Text fontSize="sm" color="blackAlpha.700">
@@ -109,10 +113,12 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
             <MenuItem onClick={() => navigate('/dashboard/profile')}>
               <Trans id="Profile">Profile</Trans>
             </MenuItem>
-            <MenuItem onClick={onAccountSwitchOpen}>
-              <Trans id="Switch Accounts">Switch accounts</Trans>
-              <ChooseAnOrganization isOpen={isAccountSwitchOpen} onClose={onAccountSwitchClose} />
-            </MenuItem>
+            {canCreateOrganization() ? (
+              <MenuItem onClick={onAccountSwitchOpen} data-testid="switch_accounts">
+                <Trans id="Switch Accounts">Switch accounts</Trans>
+                <ChooseAnOrganization isOpen={isAccountSwitchOpen} onClose={onAccountSwitchClose} />
+              </MenuItem>
+            ) : null}
             <MenuDivider />
             <MenuItem onClick={handleLogout}>
               <Trans id="Sign out">Sign out</Trans>


### PR DESCRIPTION
### Scope of changes
sc-11788 Hide 'Switch Acct' option when user is not a TSP

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria
https://app.shortcut.com/rotational/story/11788/hide-switch-acct-option-when-user-is-not-a-tsp

<img width="620" alt="image" src="https://user-images.githubusercontent.com/54010836/206027895-3992e9b4-cfb0-46d1-a87d-6976017e2b04.png">


### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


