### PR TITLE
Fix missing auth0 user id

### DIFF
--- a/pkg/bff/users.go
+++ b/pkg/bff/users.go
@@ -180,6 +180,7 @@ func (s *Server) Login(c *gin.Context) {
 
 		// Other endpoints expect the user's verification status to be up to date
 		collaborator.Verified = *user.EmailVerified
+		collaborator.UserId = *user.ID
 		collaborator.ExpiresAt = ""
 	}
 

--- a/pkg/bff/users_test.go
+++ b/pkg/bff/users_test.go
@@ -240,11 +240,9 @@ func (s *bffTestSuite) TestUserInviteLogin() {
 	}
 	require.NoError(org.AddCollaborator(leader), "could not add collaborator to organization")
 
-	// Add the user as a collaborator in the organization
+	// Add the user as an unverified collaborator in the organization
 	collab := &models.Collaborator{
 		Email:     claims.Email,
-		UserId:    "auth0|5f7b5f1b0b8b9b0069b0b1d5",
-		Verified:  true,
 		ExpiresAt: time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
 	}
 	require.NoError(org.AddCollaborator(collab), "could not add collaborator to organization")
@@ -270,11 +268,13 @@ func (s *bffTestSuite) TestUserInviteLogin() {
 	// User should have the same role
 	require.Equal([]string{bff.CollaboratorRole}, s.auth.GetUserRoles(), "user should have the collaborator role")
 
-	// Collaborator should contain updated timestamps
+	// Collaborator should now be verified
 	org, err = s.bff.OrganizationFromID(org.Id)
 	require.NoError(err, "could not get organization from ID")
 	collab = org.GetCollaborator(claims.Email)
 	require.NotNil(collab, "collaborator should exist in organization")
+	require.Equal(authtest.UserID, collab.UserId, "collaborator user id should match")
+	require.True(collab.Verified, "collaborator should be verified")
 	require.NotEmpty(collab.JoinedAt, "collaborator last login timestamp should not be empty")
 	require.Equal(collab.JoinedAt, collab.LastLogin, "collaborator joined at timestamp should not be empty")
 
@@ -307,11 +307,13 @@ func (s *bffTestSuite) TestUserInviteLogin() {
 	// User should have the same role
 	require.Equal([]string{bff.CollaboratorRole}, s.auth.GetUserRoles(), "user should have the collaborator role")
 
-	// Collaborator should contain updated timestamps
+	// Collaborator should be verified in the new organization
 	newOrg, err = s.bff.OrganizationFromID(newOrg.Id)
 	require.NoError(err, "could not get organization from ID")
 	collab = newOrg.GetCollaborator(claims.Email)
 	require.NotNil(collab, "collaborator should exist in organization")
+	require.Equal(authtest.UserID, collab.UserId, "collaborator user id should match")
+	require.True(collab.Verified, "collaborator should be verified")
 	require.NotEmpty(collab.JoinedAt, "collaborator last login timestamp should not be empty")
 	require.Equal(collab.JoinedAt, collab.LastLogin, "collaborator joined at timestamp should not be empty")
 
@@ -339,11 +341,13 @@ func (s *bffTestSuite) TestUserInviteLogin() {
 	_, err = s.bff.OrganizationFromID(org.Id)
 	require.Error(err, "organization should be deleted")
 
-	// Leader's collab record should contain updated timestamps
+	// Leader should be a verified collaborator in the new organization
 	newOrg, err = s.bff.OrganizationFromID(newOrg.Id)
 	require.NoError(err, "could not get organization from ID")
 	leader = newOrg.GetCollaborator(leader.Email)
 	require.NotNil(leader, "leader should exist in organization")
+	require.Equal(authtest.UserID, leader.UserId, "leader user id should match")
+	require.True(leader.Verified, "leader should be verified")
 	require.NotEmpty(leader.JoinedAt, "leader last login timestamp should not be empty")
 	require.Equal(leader.JoinedAt, leader.LastLogin, "leader joined at timestamp should not be empty")
 
@@ -379,11 +383,13 @@ func (s *bffTestSuite) TestUserInviteLogin() {
 	// User should have the same role
 	require.Equal([]string{bff.TSPRole}, s.auth.GetUserRoles(), "user should have the TSP role")
 
-	// Collaborator record should contain updated timestamps
+	// Collaborator should be verified in the new organization
 	newOrg, err = s.bff.OrganizationFromID(newOrg.Id)
 	require.NoError(err, "could not get organization from ID")
 	collab = newOrg.GetCollaborator(claims.Email)
 	require.NotNil(collab, "collaborator should exist in organization")
+	require.Equal(authtest.UserID, collab.UserId, "collaborator user id should match")
+	require.True(collab.Verified, "collaborator should be verified")
 	require.NotEmpty(collab.JoinedAt, "collaborator last login timestamp should not be empty")
 	require.Equal(collab.JoinedAt, collab.LastLogin, "collaborator joined at timestamp should not be empty")
 }


### PR DESCRIPTION
### Scope of changes

This fixes a bug where the collaborator details weren't showing up on the collaborators page after a user is invited due to the Auth0 user id being missing from the collaborator record. The fix is to update the user id when the user logs in.

SC-11826

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


