### PR TITLE
Change duplicate email error to warning

### DIFF
--- a/pkg/bff/users.go
+++ b/pkg/bff/users.go
@@ -436,21 +436,27 @@ func (s *Server) ListUserRoles(c *gin.Context) {
 	c.JSON(http.StatusOK, []string{auth.CollaboratorRole, auth.LeaderRole})
 }
 
-// FindUserByEmail returns the Auth0 user record by email address.
+// FindUserByEmail returns the Auth0 user record by email address. This method returns
+// an ErrUserEmailNotFound error if the user does not exist and returns the first user
+// if there are multiple users with the same email address.
 func (s *Server) FindUserByEmail(email string) (user *management.User, err error) {
 	var users []*management.User
 	if users, err = s.auth0.User.ListByEmail(strings.ToLower(email)); err != nil {
 		return nil, err
 	}
 
-	switch len(users) {
-	case 0:
+	if len(users) == 0 {
 		return nil, ErrUserEmailNotFound
-	case 1:
-		return users[0], nil
-	default:
-		return nil, ErrMultipleEmailUsers
 	}
+
+	if len(users) > 1 {
+		// TODO: This can happen if the user has authenticated with Auth0 using
+		// multiple identities (e.g. email and Google). We might be able to handle this
+		// by linking the identities.
+		log.Warn().Str("email", email).Int("count", len(users)).Msg("multiple users found with same email address")
+	}
+
+	return users[0], nil
 }
 
 func (s *Server) FindRoleByName(name string) (*management.Role, error) {


### PR DESCRIPTION
### Scope of changes

This addresses an issue that can happen when a user has the same email address on multiple accounts (e.g. an email account and a Google account) and another user tries to invite them. We do a search of Auth0 to fetch the invited user's record, but this can return multiple results. We were previously returning an error, but the ambiguity doesn't really matter too much in this case since nothing official happens until the invited user logs in.

This removes the error in place of just using the first available record returned from Auth0. The only difference is that we may or may not include the user's real name in the invite email.

The long term solution however is to probably have a way for users to link accounts, but that is a much larger effort.

SC-11849

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


