### PR TITLE
Sorted appdata organizations

### DIFF
--- a/pkg/bff/auth/metadata_test.go
+++ b/pkg/bff/auth/metadata_test.go
@@ -152,3 +152,40 @@ func TestEquals(t *testing.T) {
 	b.Organizations = []string{"67428be4-3fa4-4bf2-9e15-edbf043f8670"}
 	require.True(t, a.Equals(b), "all fields are equal, but Equals returned false")
 }
+
+func TestOrganizationList(t *testing.T) {
+	appdata := &AppMetadata{}
+
+	// Add an organization to an empty list
+	appdata.AddOrganization("bob")
+	require.Equal(t, []string{"bob"}, appdata.Organizations, "organization was not added")
+
+	// Should not be able to add an organization twice
+	appdata.AddOrganization("bob")
+	require.Equal(t, []string{"bob"}, appdata.Organizations, "organization was added twice")
+
+	// Add a second organization
+	appdata.AddOrganization("alice")
+	require.Equal(t, []string{"alice", "bob"}, appdata.Organizations, "unexpected result adding a second organization")
+
+	// Add a third organization
+	appdata.AddOrganization("carol")
+	require.Equal(t, []string{"alice", "bob", "carol"}, appdata.Organizations, "unexpected result adding a third organization")
+
+	// Remove an organization
+	appdata.RemoveOrganization("bob")
+	require.Equal(t, []string{"alice", "carol"}, appdata.Organizations, "unexpected result removing an organization")
+
+	// Removing a non-existent organization should not change the list
+	appdata.RemoveOrganization("dave")
+	require.Equal(t, []string{"alice", "carol"}, appdata.Organizations, "unexpected result removing a non-existent organization")
+
+	// Removing the last organization should clear the list
+	appdata.RemoveOrganization("carol")
+	appdata.RemoveOrganization("alice")
+	require.Equal(t, []string{}, appdata.Organizations, "unexpected result removing the last organization")
+
+	// Removing an organization from an empty list should not change the list
+	appdata.RemoveOrganization("alice")
+	require.Equal(t, []string{}, appdata.Organizations, "unexpected result removing an organization from an empty list")
+}


### PR DESCRIPTION
### Scope of changes

This modifies the `AddOrganization` and `RemoveOrganization` methods on the `AppMetadata` struct so that ordering is preserved in the list for the org IDs in a user's app metadata. This is primarily a performance improvement which is relevant to TSPs who exist in many organizations at once, since a binary search can be used (via the go `sort` package) rather than iterating through the entire list.

This change will require a migration to sort the organization IDs in Auth0 (currently they are unordered).

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] performance optimization

### Acceptance criteria

The existing methods should still operate as described in the docstring with the new sort code.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] The optimization makes sense
- [ ] There is enough test coverage


