### PR TITLE
Add pagination to list orgs

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -25,7 +25,7 @@ type BFFClient interface {
 	UpdateUser(context.Context, *UpdateUserParams) error
 	UserOrganization(context.Context) (*OrganizationReply, error)
 	CreateOrganization(context.Context, *OrganizationParams) (*OrganizationReply, error)
-	ListOrganizations(context.Context) ([]*OrganizationReply, error)
+	ListOrganizations(context.Context, *ListOrganizationsParams) (*ListOrganizationsReply, error)
 	AddCollaborator(context.Context, *models.Collaborator) (*models.Collaborator, error)
 	ListCollaborators(context.Context) (*ListCollaboratorsReply, error)
 	UpdateCollaboratorRoles(_ context.Context, id string, request *UpdateRolesParams) (*models.Collaborator, error)
@@ -90,6 +90,20 @@ type OrganizationReply struct {
 	CreatedAt    string `json:"created_at"`
 	LastLogin    string `json:"last_login"`
 	RefreshToken bool   `json:"refresh_token,omitempty"`
+}
+
+// ListOrganizationsParams contains query parameters for listing organizations.
+type ListOrganizationsParams struct {
+	Page     int `url:"page,omitempty" form:"page" default:"1"`
+	PageSize int `url:"page_size,omitempty" form:"page_size" default:"8"`
+}
+
+// ListOrganizationsReply contains a page of organizations.
+type ListOrganizationsReply struct {
+	Organizations []*OrganizationReply `json:"organizations"`
+	Count         int                  `json:"count"`
+	Page          int                  `json:"page"`
+	PageSize      int                  `json:"page_size"`
 }
 
 // LoginParams contains additional information needed for post-authentication checks

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -218,16 +218,22 @@ func (s *APIv1) CreateOrganization(ctx context.Context, in *OrganizationParams) 
 }
 
 // List available organizations.
-func (s *APIv1) ListOrganizations(ctx context.Context) (out []*OrganizationReply, err error) {
+func (s *APIv1) ListOrganizations(ctx context.Context, in *ListOrganizationsParams) (out *ListOrganizationsReply, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if params, err = query.Values(in); err != nil {
+		return nil, fmt.Errorf("could not encode query params: %s", err)
+	}
+
 	// Make the HTTP request
 	var req *http.Request
-	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/organizations", nil, nil); err != nil {
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/organizations", nil, &params); err != nil {
 		return nil, err
 	}
 
 	// Execute the request and get a response
-	out = make([]*OrganizationReply, 0)
-	if _, err = s.Do(req, &out, true); err != nil {
+	out = &ListOrganizationsReply{}
+	if _, err = s.Do(req, out, true); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -340,23 +340,29 @@ func TestUserOrganization(t *testing.T) {
 }
 
 func TestListOrganizations(t *testing.T) {
-	fixture := []*api.OrganizationReply{
-		{
-			ID:     "8b2e9e78-baca-4c34-a382-8b285503c901",
-			Name:   "Alice VASP",
-			Domain: "alicevasp.io",
+	fixture := &api.ListOrganizationsReply{
+		Organizations: []*api.OrganizationReply{
+			{
+				ID:     "8b2e9e78-baca-4c34-a382-8b285503c901",
+				Name:   "Alice VASP",
+				Domain: "alicevasp.io",
+			},
+			{
+				ID:     "c22ef329-2b8a-4b0c-9c1f-2b8a4b0c9c1f",
+				Name:   "Bob VASP",
+				Domain: "bobvasp.io",
+			},
 		},
-		{
-			ID:     "c22ef329-2b8a-4b0c-9c1f-2b8a4b0c9c1f",
-			Name:   "Bob VASP",
-			Domain: "bobvasp.io",
-		},
+		Count:    2,
+		Page:     2,
+		PageSize: 10,
 	}
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/v1/organizations", r.URL.Path)
+		require.Equal(t, "page=2&page_size=10", r.URL.RawQuery)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
@@ -368,7 +374,10 @@ func TestListOrganizations(t *testing.T) {
 	client, err := api.New(ts.URL)
 	require.NoError(t, err)
 
-	out, err := client.ListOrganizations(context.TODO())
+	out, err := client.ListOrganizations(context.TODO(), &api.ListOrganizationsParams{
+		Page:     2,
+		PageSize: 10,
+	})
 	require.NoError(t, err)
 	require.Equal(t, fixture, out)
 }

--- a/pkg/bff/docs/docs.go
+++ b/pkg/bff/docs/docs.go
@@ -486,11 +486,27 @@ const docTemplate = `{
                     "organizations"
                 ],
                 "summary": "List organizations [read:organizations]",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 8,
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "list"
+                            "$ref": "#/definitions/api.ListOrganizationsReply"
                         }
                     },
                     "401": {
@@ -1073,6 +1089,26 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/models.Collaborator"
                     }
+                }
+            }
+        },
+        "api.ListOrganizationsReply": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.OrganizationReply"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
                 }
             }
         },

--- a/pkg/bff/docs/swagger.json
+++ b/pkg/bff/docs/swagger.json
@@ -478,11 +478,27 @@
                     "organizations"
                 ],
                 "summary": "List organizations [read:organizations]",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 8,
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "list"
+                            "$ref": "#/definitions/api.ListOrganizationsReply"
                         }
                     },
                     "401": {
@@ -1065,6 +1081,26 @@
                     "items": {
                         "$ref": "#/definitions/models.Collaborator"
                     }
+                }
+            }
+        },
+        "api.ListOrganizationsReply": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.OrganizationReply"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
                 }
             }
         },

--- a/pkg/bff/docs/swagger.yaml
+++ b/pkg/bff/docs/swagger.yaml
@@ -59,6 +59,19 @@ definitions:
           $ref: '#/definitions/models.Collaborator'
         type: array
     type: object
+  api.ListOrganizationsReply:
+    properties:
+      count:
+        type: integer
+      organizations:
+        items:
+          $ref: '#/definitions/api.OrganizationReply'
+        type: array
+      page:
+        type: integer
+      page_size:
+        type: integer
+    type: object
   api.LoginParams:
     properties:
       orgid:
@@ -596,13 +609,24 @@ paths:
   /organizations:
     get:
       description: Return the list of organizations that the user is assigned to.
+      parameters:
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      - default: 8
+        description: Page size
+        in: query
+        name: page_size
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            type: list
+            $ref: '#/definitions/api.ListOrganizationsReply'
         "401":
           description: Unauthorized
           schema:

--- a/pkg/bff/organization_test.go
+++ b/pkg/bff/organization_test.go
@@ -144,20 +144,35 @@ func (s *bffTestSuite) TestListOrganizations() {
 	}
 
 	// Endpoint must be authenticated
-	_, err := s.client.ListOrganizations(context.TODO())
+	_, err := s.client.ListOrganizations(context.TODO(), &api.ListOrganizationsParams{})
 	s.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
 
 	// Endpoint requires the update:collaborator permission
 	require.NoError(s.SetClientCredentials(claims), "could not create token with incorrect permissions")
-	_, err = s.client.ListOrganizations(context.TODO())
+	_, err = s.client.ListOrganizations(context.TODO(), &api.ListOrganizationsParams{})
 	s.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user is not authorized")
 
 	// Should return empty response when user has no organizations
 	claims.Permissions = []string{auth.ReadOrganizations}
 	require.NoError(s.SetClientCredentials(claims), "could not create token with correct permissions")
-	reply, err := s.client.ListOrganizations(context.TODO())
+	expected := &api.ListOrganizationsReply{
+		Organizations: []*api.OrganizationReply{},
+		Count:         0,
+		Page:          1,
+		PageSize:      8,
+	}
+	reply, err := s.client.ListOrganizations(context.TODO(), &api.ListOrganizationsParams{})
 	require.NoError(err, "list organizations call failed")
-	require.Empty(reply, "expected empty response")
+	require.Equal(expected, reply, "expected default response")
+
+	// Should enforce defaults for query parameters
+	req := &api.ListOrganizationsParams{
+		Page:     -1,
+		PageSize: -1,
+	}
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "expected default response for invalid query parameters")
 
 	// Should not return an error if there is an organization on the app metadata that's not in the database
 	metadata := &auth.AppMetadata{}
@@ -166,9 +181,9 @@ func (s *bffTestSuite) TestListOrganizations() {
 	appdata, err := metadata.Dump()
 	require.NoError(err, "could not dump app metadata")
 	s.auth.SetUserAppMetadata(appdata)
-	reply, err = s.client.ListOrganizations(context.TODO())
+	reply, err = s.client.ListOrganizations(context.TODO(), &api.ListOrganizationsParams{})
 	require.NoError(err, "list organizations call failed")
-	require.Empty(reply, "expected empty response")
+	require.Equal(expected, reply, "expected default response")
 
 	// Create some organizations for the user
 	alice := &models.Organization{
@@ -219,7 +234,7 @@ func (s *bffTestSuite) TestListOrganizations() {
 	require.NoError(err, "could not dump app metadata")
 	s.auth.SetUserAppMetadata(appdata)
 
-	expected := []*api.OrganizationReply{
+	orgReplies := []*api.OrganizationReply{
 		{
 			ID:        alice.Id,
 			Name:      alice.Name,
@@ -241,10 +256,38 @@ func (s *bffTestSuite) TestListOrganizations() {
 			LastLogin: charlieCollab.LastLogin,
 		},
 	}
+	expected.Organizations = orgReplies
+	expected.Count = 3
 
 	// Should return all organizations the user is a collaborator on
 	// If the user is not a collaborator, the endpoint should not return an error
-	reply, err = s.client.ListOrganizations(context.TODO())
+	reply, err = s.client.ListOrganizations(context.TODO(), &api.ListOrganizationsParams{})
 	require.NoError(err, "list organizations call failed")
 	require.Equal(expected, reply, "expected returned organizations to match")
+
+	// List organizations across multiple pages
+	req = &api.ListOrganizationsParams{
+		Page:     1,
+		PageSize: 2,
+	}
+	expected.Organizations = orgReplies[0:2]
+	expected.PageSize = 2
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "wrong results for page 1")
+
+	req.Page = 2
+	expected.Organizations = orgReplies[2:3]
+	expected.Page = 2
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "wrong results for page 2")
+
+	// Should return no organizations if the page is out of bounds
+	req.Page = 3
+	expected.Organizations = []*api.OrganizationReply{}
+	expected.Page = 3
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "wrong results for page out of bounds")
 }


### PR DESCRIPTION
### Scope of changes

This adds pagination to the `ListOrganizations` BFF endpoint. It now accepts two query parameters to control the pagination: `page` and `page_size`, similar to how pagination is implemented for `ListVASPs` on the Admin API. This will allow the user UI frontend to load pages of organizations individually to avoid the list filling up the entire page.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Callers should be able to use the query params in the `ListOrganizations` request to control the paginated response.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] The pagination logic is correct
- [ ] There is enough test coverage
