### PR TITLE
Certman leveldb tests

### DIFF
--- a/pkg/gds/certman/certs_test.go
+++ b/pkg/gds/certman/certs_test.go
@@ -1016,14 +1016,13 @@ func (s *certTestSuite) setupCertManager(profile string, fType fixtures.FixtureT
 	switch s.fixtures.StoreType() {
 	case fixtures.StoreLevelDB:
 		s.conf.Database.URL = "leveldb:///" + s.fixtures.DBPath()
-		if s.db, err = store.Open(s.conf.Database); err != nil {
-			require.NoError(err, "could not open leveldb store")
-		}
+		s.db, err = store.Open(s.conf.Database)
+		require.NoError(err, "could not open leveldb store")
 	case fixtures.StoreTrtl:
 		conn, err := s.fixtures.ConnectTrtl(context.Background())
 		require.NoError(err, "could not connect to trtl database")
 		s.db, err = trtlstore.NewMock(conn)
-		require.NoError(err, "could not create trtl store")
+		require.NoError(err, "could not open trtl store")
 	default:
 		require.Fail("unrecognized store type %d", s.fixtures.StoreType())
 	}


### PR DESCRIPTION
### Scope of changes

This adds leveldb testing to the certman test suite. Previously the certman tests only tested with trtl as the underlying database. This creates another test suite which runs the same certman tests, but with leveldb as the underlying store instead.

We were already using the `store` abstraction for certman so this turned out to be pretty simple.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] tests

### Acceptance criteria

There should now be two separate tests suites when we run the certman tests, one for leveldb and the other for trtl.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


