### PR TITLE
BFF update organization

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -26,6 +26,7 @@ type BFFClient interface {
 	UserOrganization(context.Context) (*OrganizationReply, error)
 	CreateOrganization(context.Context, *OrganizationParams) (*OrganizationReply, error)
 	ListOrganizations(context.Context) ([]*OrganizationReply, error)
+	PatchOrganization(_ context.Context, id string, request *OrganizationParams) (*OrganizationReply, error)
 	AddCollaborator(context.Context, *models.Collaborator) (*models.Collaborator, error)
 	ListCollaborators(context.Context) (*ListCollaboratorsReply, error)
 	UpdateCollaboratorRoles(_ context.Context, id string, request *UpdateRolesParams) (*models.Collaborator, error)
@@ -76,7 +77,7 @@ type UpdateUserParams struct {
 	Name string `json:"name,omitempty"`
 }
 
-// OrganizationParams is used to create new organizations.
+// OrganizationParams is used to create and update organizations.
 type OrganizationParams struct {
 	Name   string `json:"name"`
 	Domain string `json:"domain"`

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -233,6 +233,22 @@ func (s *APIv1) ListOrganizations(ctx context.Context) (out []*OrganizationReply
 	return out, nil
 }
 
+// Patch an organization.
+func (s *APIv1) PatchOrganization(ctx context.Context, id string, in *OrganizationParams) (out *OrganizationReply, err error) {
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPatch, "/v1/organizations/"+id, in, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &OrganizationReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Add a collaborator to an organization.
 func (s *APIv1) AddCollaborator(ctx context.Context, request *models.Collaborator) (collaborator *models.Collaborator, err error) {
 	// Make the HTTP request

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -373,6 +373,36 @@ func TestListOrganizations(t *testing.T) {
 	require.Equal(t, fixture, out)
 }
 
+func TestPatchOrganization(t *testing.T) {
+	fixture := &api.OrganizationReply{
+		Name:   "Alice VASP",
+		Domain: "alicevasp.io",
+	}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		require.Equal(t, "/v1/organizations/8b2e9e78-baca-4c34-a382-8b285503c901", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err)
+
+	req := &api.OrganizationParams{
+		Name:   fixture.Name,
+		Domain: fixture.Domain,
+	}
+	out, err := client.PatchOrganization(context.TODO(), "8b2e9e78-baca-4c34-a382-8b285503c901", req)
+	require.NoError(t, err)
+	require.Equal(t, fixture, out)
+}
+
 func TestAddCollaborator(t *testing.T) {
 	fixture := &models.Collaborator{
 		Email:     "alice@example.com",

--- a/pkg/bff/auth/user.go
+++ b/pkg/bff/auth/user.go
@@ -12,6 +12,7 @@ const (
 	ReadOrganizations   = "read:organizations"
 	CreateOrganizations = "create:organizations"
 	SwitchOrganizations = "switch:organizations"
+	UpdateOrganizations = "update:organizations"
 
 	// Collaborators management
 	ReadCollaborators   = "read:collaborators"

--- a/pkg/bff/docs/docs.go
+++ b/pkg/bff/docs/docs.go
@@ -564,6 +564,83 @@ const docTemplate = `{
                 }
             }
         },
+        "/organizations/{id}": {
+            "patch": {
+                "description": "Patch an organization with the provided fields.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "Patch organization [update:organizations]",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "params",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.OrganizationParams"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.OrganizationReply"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid organization domain",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "403": {
+                        "description": "User is not authorized to access this organization",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "404": {
+                        "description": "Organization not found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "409": {
+                        "description": "Organization with domain already exists",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    }
+                }
+            }
+        },
         "/overview": {
             "get": {
                 "description": "Returns a high level summary representing the state of each directory service and VASP registrations.",

--- a/pkg/bff/docs/swagger.json
+++ b/pkg/bff/docs/swagger.json
@@ -556,6 +556,83 @@
                 }
             }
         },
+        "/organizations/{id}": {
+            "patch": {
+                "description": "Patch an organization with the provided fields.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "Patch organization [update:organizations]",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "params",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.OrganizationParams"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.OrganizationReply"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid organization domain",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "403": {
+                        "description": "User is not authorized to access this organization",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "404": {
+                        "description": "Organization not found",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "409": {
+                        "description": "Organization with domain already exists",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    }
+                }
+            }
+        },
         "/overview": {
             "get": {
                 "description": "Returns a high level summary representing the state of each directory service and VASP registrations.",

--- a/pkg/bff/docs/swagger.yaml
+++ b/pkg/bff/docs/swagger.yaml
@@ -652,6 +652,57 @@ paths:
       summary: Create a new organization [create:organizations]
       tags:
       - organizations
+  /organizations/{id}:
+    patch:
+      consumes:
+      - application/json
+      description: Patch an organization with the provided fields.
+      parameters:
+      - description: Organization ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Fields to update
+        in: body
+        name: params
+        required: true
+        schema:
+          $ref: '#/definitions/api.OrganizationParams'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.OrganizationReply'
+        "400":
+          description: Invalid organization domain
+          schema:
+            $ref: '#/definitions/api.Reply'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.Reply'
+        "403":
+          description: User is not authorized to access this organization
+          schema:
+            $ref: '#/definitions/api.Reply'
+        "404":
+          description: Organization not found
+          schema:
+            $ref: '#/definitions/api.Reply'
+        "409":
+          description: Organization with domain already exists
+          schema:
+            $ref: '#/definitions/api.Reply'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Reply'
+      summary: Patch organization [update:organizations]
+      tags:
+      - organizations
   /overview:
     get:
       description: Returns a high level summary representing the state of each directory

--- a/pkg/bff/organization.go
+++ b/pkg/bff/organization.go
@@ -197,6 +197,112 @@ func (s *Server) ListOrganizations(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
+// PatchOrganization patches an organization in the database with the provided fields.
+//
+// @Summary Patch organization [update:organizations]
+// @Description Patch an organization with the provided fields.
+// @Tags organizations
+// @Accept json
+// @Produce json
+// @Param id path string true "Organization ID"
+// @Param params body api.OrganizationParams true "Fields to update"
+// @Success 200 {object} api.OrganizationReply
+// @Failure 400 {object} api.Reply "Invalid organization domain"
+// @Failure 401 {object} api.Reply
+// @Failure 403 {object} api.Reply "User is not authorized to access this organization"
+// @Failure 404 {object} api.Reply "Organization not found"
+// @Failure 409 {object} api.Reply "Organization with domain already exists"
+// @Failure 500 {object} api.Reply
+// @Router /organizations/{id} [patch]
+func (s *Server) PatchOrganization(c *gin.Context) {
+	var (
+		err  error
+		user *management.User
+	)
+
+	// Fetch the user from the context
+	if user, err = auth.GetUserInfo(c); err != nil {
+		log.Error().Err(err).Msg("create organization handler requires user info; expected middleware to return 401")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not identify user to patch organization"))
+		return
+	}
+
+	// Load the user app metadata to check their organization assignments
+	appdata := &auth.AppMetadata{}
+	if err = appdata.Load(user.AppMetadata); err != nil {
+		log.Error().Err(err).Msg("could not parse user app metadata")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not parse user app metadata"))
+		return
+	}
+
+	// Unmarshal the params from the PATCH request
+	params := &api.OrganizationParams{}
+	if err = c.ShouldBind(params); err != nil {
+		log.Warn().Err(err).Msg("could not bind request")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// At least one field must be provided
+	if *params == (api.OrganizationParams{}) {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("no fields provided to patch"))
+		return
+	}
+
+	// Retrieve the organization to be updated
+	var org *models.Organization
+	id := c.Param("orgID")
+	if org, err = s.OrganizationFromID(id); err != nil {
+		log.Error().Err(err).Str("org_id", id).Msg("could not retrieve organization from database")
+		c.JSON(http.StatusNotFound, api.ErrorResponse("organization not found"))
+		return
+	}
+
+	// LastLogin timestamp is on the collaborator record
+	var collab *models.Collaborator
+	if collab = org.GetCollaborator(*user.Email); collab == nil {
+		log.Warn().Str("org_id", id).Str("email", *user.Email).Msg("user is not a collaborator on organization")
+		c.JSON(http.StatusForbidden, api.ErrorResponse("user is not authorized to access this organization"))
+		return
+	}
+
+	domain := params.Domain
+	if domain != "" && domain != org.Domain {
+		// Prevent duplicate names for organizations
+		// TODO: Perform universal check against the database using an index
+		if org.Domain, err = s.ValidateOrganizationDomain(domain, appdata); err != nil {
+			log.Error().Err(err).Str("domain", domain).Msg("could not validate organization domain")
+			if errors.Is(err, ErrDomainAlreadyExists) {
+				c.JSON(http.StatusConflict, api.ErrorResponse("organization with domain already exists"))
+				return
+			}
+			c.JSON(http.StatusBadRequest, api.ErrorResponse("invalid domain provided"))
+			return
+		}
+	}
+
+	if params.Name != "" {
+		org.Name = params.Name
+	}
+
+	// Save the updated organization
+	if err = s.db.UpdateOrganization(org); err != nil {
+		log.Error().Err(err).Str("org_id", id).Msg("could not update organization in database")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse(err))
+		return
+	}
+
+	// Create the organization response
+	out := &api.OrganizationReply{
+		ID:        org.Id,
+		Name:      org.ResolveName(),
+		Domain:    org.Domain,
+		CreatedAt: org.Created,
+		LastLogin: collab.LastLogin,
+	}
+	c.JSON(http.StatusOK, out)
+}
+
 // ValidateOrganizationDomain performs any necessary normalization and validation of an
 // organization domain name, ensuring that the domain is not already in use by another
 // organization on the specified app metadata and returning the normalized domain name

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -374,6 +374,7 @@ func (s *Server) setupRoutes() (err error) {
 		{
 			organizations.GET("", auth.Authorize(auth.ReadOrganizations), userinfo, s.ListOrganizations)
 			organizations.POST("", auth.DoubleCookie(), auth.Authorize(auth.CreateOrganizations), userinfo, s.CreateOrganization)
+			organizations.PATCH("/:orgID", auth.DoubleCookie(), auth.Authorize(auth.UpdateOrganizations), userinfo, s.PatchOrganization)
 		}
 		collaborators := v1.Group("/collaborators")
 		{


### PR DESCRIPTION
### Scope of changes

This adds an update organization endpoint to the BFF API. This takes as input the same schema as `CreateOrganization` but only updates the provided fields.

SC-11814

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

The client should be able to update the name and domain on existing organizations with the new endpoint.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


