### PR TITLE
Name filter for org list

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -96,8 +96,9 @@ type OrganizationReply struct {
 
 // ListOrganizationsParams contains query parameters for listing organizations.
 type ListOrganizationsParams struct {
-	Page     int `url:"page,omitempty" form:"page" default:"1"`
-	PageSize int `url:"page_size,omitempty" form:"page_size" default:"8"`
+	Name     string `url:"name,omitempty" form:"name"`
+	Page     int    `url:"page,omitempty" form:"page" default:"1"`
+	PageSize int    `url:"page_size,omitempty" form:"page_size" default:"8"`
 }
 
 // ListOrganizationsReply contains a page of organizations.

--- a/pkg/bff/docs/docs.go
+++ b/pkg/bff/docs/docs.go
@@ -488,6 +488,12 @@ const docTemplate = `{
                 "summary": "List organizations [read:organizations]",
                 "parameters": [
                     {
+                        "type": "string",
+                        "description": "Organization name filter",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "default": 1,
                         "description": "Page number",

--- a/pkg/bff/docs/swagger.json
+++ b/pkg/bff/docs/swagger.json
@@ -480,6 +480,12 @@
                 "summary": "List organizations [read:organizations]",
                 "parameters": [
                     {
+                        "type": "string",
+                        "description": "Organization name filter",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "default": 1,
                         "description": "Page number",

--- a/pkg/bff/docs/swagger.yaml
+++ b/pkg/bff/docs/swagger.yaml
@@ -610,6 +610,10 @@ paths:
     get:
       description: Return the list of organizations that the user is assigned to.
       parameters:
+      - description: Organization name filter
+        in: query
+        name: name
+        type: string
       - default: 1
         description: Page number
         in: query

--- a/pkg/bff/organization.go
+++ b/pkg/bff/organization.go
@@ -3,6 +3,7 @@ package bff
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/gin-gonic/gin"
@@ -144,6 +145,7 @@ func (s *Server) CreateOrganization(c *gin.Context) {
 // @Description Return the list of organizations that the user is assigned to.
 // @Tags organizations
 // @Produce json
+// @Param name query string false "Organization name filter"
 // @Param page query int false "Page number" default(1)
 // @Param page_size query int false "Page size" default(8)
 // @Success 200 {object} api.ListOrganizationsReply
@@ -217,11 +219,17 @@ func (s *Server) ListOrganizations(c *gin.Context) {
 			continue
 		}
 
+		// Filter by name if specified using basic substring matching
+		name := org.ResolveName()
+		if params.Name != "" && !strings.Contains(strings.ToLower(name), strings.ToLower(params.Name)) {
+			continue
+		}
+
 		if out.Count >= minIndex && out.Count < maxIndex {
 			// Within the page range so add the organization to the response
 			out.Organizations = append(out.Organizations, &api.OrganizationReply{
 				ID:        org.Id,
-				Name:      org.ResolveName(),
+				Name:      name,
 				Domain:    org.Domain,
 				CreatedAt: org.Created,
 				LastLogin: collaborator.LastLogin,

--- a/pkg/bff/organization_test.go
+++ b/pkg/bff/organization_test.go
@@ -290,6 +290,50 @@ func (s *bffTestSuite) TestListOrganizations() {
 	reply, err = s.client.ListOrganizations(context.TODO(), req)
 	require.NoError(err, "list organizations call failed")
 	require.Equal(expected, reply, "wrong results for page out of bounds")
+
+	// Test name filter that matches no organizations
+	req.Name = "nomatches"
+	req.Page = 1
+	req.PageSize = 10
+	expected.Count = 0
+	expected.Page = 1
+	expected.PageSize = 10
+	expected.Organizations = []*api.OrganizationReply{}
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "wrong results for page 1 with no match filter")
+
+	// Test name filter that matches some organizations
+	req.Name = "bob"
+	req.Page = 1
+	req.PageSize = 10
+	expected.Count = 1
+	expected.Page = 1
+	expected.PageSize = 10
+	expected.Organizations = orgReplies[1:2]
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "wrong results for page 1 with some match filter")
+
+	// Test name filter that matches all organizations
+	req.Name = "Vasp"
+	req.Page = 1
+	req.PageSize = 2
+	expected.Count = 3
+	expected.Page = 1
+	expected.PageSize = 2
+	expected.Organizations = orgReplies[0:2]
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "wrong results for page 1 with all match filter")
+
+	req.Page = 2
+	expected.Page = 2
+	expected.PageSize = 2
+	expected.Organizations = orgReplies[2:3]
+	reply, err = s.client.ListOrganizations(context.TODO(), req)
+	require.NoError(err, "list organizations call failed")
+	require.Equal(expected, reply, "wrong results for page 2 with all match filter")
 }
 
 func (s *bffTestSuite) TestPatchOrganization() {


### PR DESCRIPTION
### Scope of changes

This adds a basic name filter to the `ListOrganizations` endpoint on the BFF, to enable the GDS user UI to implement a "search" feature where the user can type in an organization name rather than going through the pages.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


