### PR TITLE
Delete registration form endpoint

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -45,7 +45,7 @@ type BFFClient interface {
 	// Registration form
 	LoadRegistrationForm(context.Context, *RegistrationFormParams) (*RegistrationForm, error)
 	SaveRegistrationForm(context.Context, *RegistrationForm) (*RegistrationForm, error)
-	DeleteRegistrationForm(context.Context, *RegistrationFormParams) (*RegistrationForm, error)
+	ResetRegistrationForm(context.Context, *RegistrationFormParams) (*RegistrationForm, error)
 	SubmitRegistration(_ context.Context, network string) (*RegisterReply, error)
 	RegistrationStatus(context.Context) (*RegistrationStatus, error)
 

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -43,8 +43,9 @@ type BFFClient interface {
 	MemberDetails(context.Context, *MemberDetailsParams) (*MemberDetailsReply, error)
 
 	// Registration form
-	LoadRegistrationForm(context.Context, *LoadRegistrationFormParams) (*RegistrationForm, error)
+	LoadRegistrationForm(context.Context, *RegistrationFormParams) (*RegistrationForm, error)
 	SaveRegistrationForm(context.Context, *RegistrationForm) (*RegistrationForm, error)
+	DeleteRegistrationForm(context.Context, *RegistrationFormParams) (*RegistrationForm, error)
 	SubmitRegistration(_ context.Context, network string) (*RegisterReply, error)
 	RegistrationStatus(context.Context) (*RegistrationStatus, error)
 
@@ -216,10 +217,13 @@ const (
 	StepTRIXO        RegistrationFormStep = "trixo"
 )
 
-// Allows the front-end to specify which part of the registration form they want to fetch.
+// Allows the front-end to specify which part of the registration form they want to
+// fetch or delete.
 // GET /v1/registration will return the entire registration form, while
 // GET /v1/registration?step=trixo would return just the TRIXO form
-type LoadRegistrationFormParams struct {
+// DELETE /v1/registration will reset the entire registration form, while
+// DELETE /v1/registration?step=trixo would reset just the TRIXO form
+type RegistrationFormParams struct {
 	Step RegistrationFormStep `url:"step,omitempty" form:"step"`
 }
 

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -346,7 +346,7 @@ func (s *APIv1) DeleteCollaborator(ctx context.Context, id string) (err error) {
 }
 
 // Load registration form data from the server to populate the front-end form.
-func (s *APIv1) LoadRegistrationForm(ctx context.Context, in *LoadRegistrationFormParams) (form *RegistrationForm, err error) {
+func (s *APIv1) LoadRegistrationForm(ctx context.Context, in *RegistrationFormParams) (form *RegistrationForm, err error) {
 	// Create the query params from the input
 	var params url.Values
 	if in != nil {
@@ -389,6 +389,29 @@ func (s *APIv1) SaveRegistrationForm(ctx context.Context, form *RegistrationForm
 	}
 
 	return out, nil
+}
+
+// Delete registration form data from the server, resetting the form to the defaults.
+func (s *APIv1) DeleteRegistrationForm(ctx context.Context, in *RegistrationFormParams) (form *RegistrationForm, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if in != nil {
+		if params, err = query.Values(in); err != nil {
+			return nil, fmt.Errorf("could not encode query params: %s", err)
+		}
+	}
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodDelete, "/v1/register", nil, &params); err != nil {
+		return nil, err
+	}
+
+	form = &RegistrationForm{}
+	if _, err = s.Do(req, form, true); err != nil {
+		return nil, err
+	}
+	return form, nil
 }
 
 // Submit the registration form to the specified network (testnet or mainnet).

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -391,8 +391,8 @@ func (s *APIv1) SaveRegistrationForm(ctx context.Context, form *RegistrationForm
 	return out, nil
 }
 
-// Delete registration form data from the server, resetting the form to the defaults.
-func (s *APIv1) DeleteRegistrationForm(ctx context.Context, in *RegistrationFormParams) (form *RegistrationForm, err error) {
+// Reset the registration form on the server to its default values.
+func (s *APIv1) ResetRegistrationForm(ctx context.Context, in *RegistrationFormParams) (form *RegistrationForm, err error) {
 	// Create the query params from the input
 	var params url.Values
 	if in != nil {

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -632,6 +632,35 @@ func TestSaveRegistrationForm(t *testing.T) {
 	require.Nil(t, out)
 }
 
+func TestDeleteRegistrationForm(t *testing.T) {
+	// Load a defualt form
+	fixture := models.NewRegisterForm()
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/v1/register", r.URL.Path)
+
+		form := &api.RegistrationForm{
+			Form: fixture,
+		}
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(form)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err)
+
+	// Should return no content
+	out, err := client.DeleteRegistrationForm(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, fixture, out.Form)
+}
+
 func TestSubmitRegistration(t *testing.T) {
 	fixture := &api.RegisterReply{
 		Id:                  "8b2e9e78-baca-4c34-a382-8b285503c901",

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -632,7 +632,7 @@ func TestSaveRegistrationForm(t *testing.T) {
 	require.Nil(t, out)
 }
 
-func TestDeleteRegistrationForm(t *testing.T) {
+func TestResetRegistrationForm(t *testing.T) {
 	// Load a defualt form
 	fixture := models.NewRegisterForm()
 
@@ -656,7 +656,7 @@ func TestDeleteRegistrationForm(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return no content
-	out, err := client.DeleteRegistrationForm(context.Background(), nil)
+	out, err := client.ResetRegistrationForm(context.Background(), nil)
 	require.NoError(t, err)
 	require.Equal(t, fixture, out.Form)
 }

--- a/pkg/bff/docs/docs.go
+++ b/pkg/bff/docs/docs.go
@@ -750,7 +750,7 @@ const docTemplate = `{
                         "name": "params",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/api.LoadRegistrationFormParams"
+                            "$ref": "#/definitions/api.RegistrationFormParams"
                         }
                     }
                 ],
@@ -813,6 +813,52 @@ const docTemplate = `{
                     },
                     "204": {
                         "description": "Empty form was provided"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Reset the registration form associated with the user's organization for the requested step.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "registration"
+                ],
+                "summary": "Reset the user's current registration form [update:vasp]",
+                "parameters": [
+                    {
+                        "description": "Reset registration form parameters",
+                        "name": "params",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/api.RegistrationFormParams"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Registration form",
+                        "schema": {
+                            "type": "object"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -1250,14 +1296,6 @@ const docTemplate = `{
                 }
             }
         },
-        "api.LoadRegistrationFormParams": {
-            "type": "object",
-            "properties": {
-                "step": {
-                    "type": "string"
-                }
-            }
-        },
         "api.LoginParams": {
             "type": "object",
             "properties": {
@@ -1436,6 +1474,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.RegistrationFormParams": {
+            "type": "object",
+            "properties": {
+                "step": {
                     "type": "string"
                 }
             }

--- a/pkg/bff/docs/swagger.json
+++ b/pkg/bff/docs/swagger.json
@@ -742,7 +742,7 @@
                         "name": "params",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/api.LoadRegistrationFormParams"
+                            "$ref": "#/definitions/api.RegistrationFormParams"
                         }
                     }
                 ],
@@ -805,6 +805,52 @@
                     },
                     "204": {
                         "description": "Empty form was provided"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Reply"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Reset the registration form associated with the user's organization for the requested step.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "registration"
+                ],
+                "summary": "Reset the user's current registration form [update:vasp]",
+                "parameters": [
+                    {
+                        "description": "Reset registration form parameters",
+                        "name": "params",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/api.RegistrationFormParams"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Registration form",
+                        "schema": {
+                            "type": "object"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -1242,14 +1288,6 @@
                 }
             }
         },
-        "api.LoadRegistrationFormParams": {
-            "type": "object",
-            "properties": {
-                "step": {
-                    "type": "string"
-                }
-            }
-        },
         "api.LoginParams": {
             "type": "object",
             "properties": {
@@ -1428,6 +1466,14 @@
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.RegistrationFormParams": {
+            "type": "object",
+            "properties": {
+                "step": {
                     "type": "string"
                 }
             }

--- a/pkg/bff/docs/swagger.yaml
+++ b/pkg/bff/docs/swagger.yaml
@@ -72,11 +72,6 @@ definitions:
       page_size:
         type: integer
     type: object
-  api.LoadRegistrationFormParams:
-    properties:
-      step:
-        type: string
-    type: object
   api.LoginParams:
     properties:
       orgid:
@@ -194,6 +189,11 @@ definitions:
       registered_directory:
         type: string
       status:
+        type: string
+    type: object
+  api.RegistrationFormParams:
+    properties:
+      step:
         type: string
     type: object
   api.RegistrationStatus:
@@ -787,6 +787,37 @@ paths:
       tags:
       - overview
   /register:
+    delete:
+      description: Reset the registration form associated with the user's organization
+        for the requested step.
+      parameters:
+      - description: Reset registration form parameters
+        in: body
+        name: params
+        schema:
+          $ref: '#/definitions/api.RegistrationFormParams'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Registration form
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Reply'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.Reply'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Reply'
+      summary: Reset the user's current registration form [update:vasp]
+      tags:
+      - registration
     get:
       description: Get the registration form associated with the user's organization.
       parameters:
@@ -794,7 +825,7 @@ paths:
         in: body
         name: params
         schema:
-          $ref: '#/definitions/api.LoadRegistrationFormParams'
+          $ref: '#/definitions/api.RegistrationFormParams'
       produces:
       - application/json
       responses:

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -438,19 +438,19 @@ func (s *Server) SaveRegisterForm(c *gin.Context) {
 	c.JSON(http.StatusOK, cleaned)
 }
 
-// Delete's the user's current registration form, resetting the form to the defaults.
+// Resets the user's current registration form to the defaults.
 //
-// @Summary Delete the user's current registration form [update:vasp]
-// @Description Delete the registration form associated with the user's organization for the requested step.
+// @Summary Reset the user's current registration form [update:vasp]
+// @Description Reset the registration form associated with the user's organization for the requested step.
 // @Tags registration
 // @Produce json
-// @Param params body api.RegistrationFormParams false "Delete registration form parameters"
+// @Param params body api.RegistrationFormParams false "Reset registration form parameters"
 // @Success 200 {object} object "Registration form"
 // @Failure 400 {object} api.Reply
 // @Failure 401 {object} api.Reply
 // @Failure 500 {object} api.Reply
 // @Router /register [delete]
-func (s *Server) DeleteRegisterForm(c *gin.Context) {
+func (s *Server) ResetRegisterForm(c *gin.Context) {
 	var (
 		err    error
 		org    *records.Organization
@@ -495,7 +495,7 @@ func (s *Server) DeleteRegisterForm(c *gin.Context) {
 		// Ignore validation errors on delete
 		var fields records.ValidationErrors
 		if !errors.As(err, &fields) {
-			log.Debug().Err(err).Msg("could not delete registration form")
+			log.Debug().Err(err).Msg("could not reset registration form")
 			c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
 			return
 		}
@@ -506,8 +506,8 @@ func (s *Server) DeleteRegisterForm(c *gin.Context) {
 	defer cancel()
 
 	if err = s.db.UpdateOrganization(ctx, org); err != nil {
-		log.Error().Err(err).Msg("could not update organization")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not delete registration form"))
+		log.Error().Err(err).Msg("could not update organization with reset registration form")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not reset registration form"))
 		return
 	}
 

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -253,7 +253,7 @@ func (s *Server) VerifyContact(c *gin.Context) {
 // @Description Get the registration form associated with the user's organization.
 // @Tags registration
 // @Produce json
-// @Param params body api.LoadRegistrationFormParams false "Load registration form parameters"
+// @Param params body api.RegistrationFormParams false "Load registration form parameters"
 // @Success 200 {object} object "Registration form"
 // @Failure 400 {object} api.Reply
 // @Failure 401 {object} api.Reply
@@ -264,7 +264,7 @@ func (s *Server) LoadRegisterForm(c *gin.Context) {
 		err    error
 		org    *records.Organization
 		step   records.StepType
-		params *api.LoadRegistrationFormParams
+		params *api.RegistrationFormParams
 	)
 
 	// Load the organization from the claims
@@ -275,7 +275,7 @@ func (s *Server) LoadRegisterForm(c *gin.Context) {
 
 	// Bind the parameters associated with the load registration request
 	// NOTE: the step is optional and does not need to be specified
-	params = &api.LoadRegistrationFormParams{}
+	params = &api.RegistrationFormParams{}
 	if err = c.ShouldBindQuery(&params); err != nil {
 		log.Debug().Err(err).Msg("could not bind request with query params")
 		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
@@ -378,9 +378,11 @@ func (s *Server) SaveRegisterForm(c *gin.Context) {
 		org.Registration = records.NewRegisterForm()
 	}
 
-	// If the form is nil, create a new registration form to "clear" the form
+	// A form should always be provided to this endpoint, the delete endpoint must be
+	// used to reset a form.
 	if form.Form == nil {
-		form.Form = records.NewRegisterForm()
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("no form was provided"))
+		return
 	}
 
 	// Mark the form as started, the BFF relies on this state so the frontend should
@@ -416,6 +418,96 @@ func (s *Server) SaveRegisterForm(c *gin.Context) {
 	if err = s.db.UpdateOrganization(ctx, org); err != nil {
 		log.Error().Err(err).Msg("could not update organization")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not save registration form"))
+		return
+	}
+
+	// Return the updated form in a 200 OK response, truncated if necessary.
+	if out.Form, err = org.Registration.Truncate(step); err != nil {
+		log.Warn().Err(err).Str("step", string(step)).Msg("could not truncate registration form")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse(err))
+		return
+	}
+
+	var cleaned gin.H
+	if cleaned, err = out.MarshalStepJSON(); err != nil {
+		log.Warn().Err(err).Str("step", string(step)).Msg("could not marshal registration form for the requested step")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse(err))
+		return
+	}
+
+	c.JSON(http.StatusOK, cleaned)
+}
+
+// Delete's the user's current registration form, resetting the form to the defaults.
+//
+// @Summary Delete the user's current registration form [update:vasp]
+// @Description Delete the registration form associated with the user's organization for the requested step.
+// @Tags registration
+// @Produce json
+// @Param params body api.RegistrationFormParams false "Delete registration form parameters"
+// @Success 200 {object} object "Registration form"
+// @Failure 400 {object} api.Reply
+// @Failure 401 {object} api.Reply
+// @Failure 500 {object} api.Reply
+// @Router /register [delete]
+func (s *Server) DeleteRegisterForm(c *gin.Context) {
+	var (
+		err    error
+		org    *records.Organization
+		step   records.StepType
+		params *api.RegistrationFormParams
+	)
+
+	// Load the organization from the claims
+	// NOTE: this method will handle the error logging and response.
+	if org, err = s.OrganizationFromClaims(c); err != nil {
+		return
+	}
+
+	// Bind the parameters associated with the delete registration request
+	// NOTE: the step is optional and does not need to be specified
+	params = &api.RegistrationFormParams{}
+	if err = c.ShouldBindQuery(&params); err != nil {
+		log.Debug().Err(err).Msg("could not bind request with query params")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// Convert the step into a StepType
+	if step, err = records.ParseStepType(string(params.Step)); err != nil {
+		log.Debug().Err(err).Msg("user requested invalid form step type")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// If the organization form does not exist; create a new registration form
+	if org.Registration == nil {
+		org.Registration = records.NewRegisterForm()
+	}
+
+	// Prepare the response
+	out := &api.RegistrationForm{
+		Step: api.RegistrationFormStep(step),
+	}
+
+	// Delete the form step by doing an update with a default form
+	if err = org.Registration.Update(records.NewRegisterForm(), step); err != nil {
+		// Ignore validation errors on delete
+		var fields records.ValidationErrors
+		if !errors.As(err, &fields) {
+			log.Debug().Err(err).Msg("could not delete registration form")
+			c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+			return
+		}
+	}
+
+	// Update the form on the organization
+	ctx, cancel := utils.WithDeadline(context.Background())
+	defer cancel()
+
+	if err = s.db.UpdateOrganization(ctx, org); err != nil {
+		log.Error().Err(err).Msg("could not update organization")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not delete registration form"))
 		return
 	}
 

--- a/pkg/bff/gds_test.go
+++ b/pkg/bff/gds_test.go
@@ -334,11 +334,11 @@ func (s *bffTestSuite) TestSaveRegisterForm() {
 	s.requireError(err, http.StatusBadRequest, "unknown registration form step \"invalid\"", "expected error when step is invalid")
 
 	// Providing no form should return an error
-	reply, err := s.client.SaveRegistrationForm(context.TODO(), &api.RegistrationForm{Form: nil})
+	_, err = s.client.SaveRegistrationForm(context.TODO(), &api.RegistrationForm{Form: nil})
 	s.requireError(err, http.StatusBadRequest, "no form was provided", "expected error when form is not provided")
 
 	// Should be able to save the fixture form
-	reply, err = s.client.SaveRegistrationForm(context.TODO(), form)
+	reply, err := s.client.SaveRegistrationForm(context.TODO(), form)
 	require.NoError(err, "should not receive an error when saving a registration form")
 	require.NotNil(reply, "uploaded form should be returned when a non-empty registration form is saved")
 	require.NotEmpty(reply.Form.State.Started, "expected form started timestamp to be set")

--- a/pkg/bff/gds_test.go
+++ b/pkg/bff/gds_test.go
@@ -120,7 +120,7 @@ func (s *bffTestSuite) TestLoadRegisterForm() {
 	require.NoError(s.SetClientCredentials(claims), "could not create token with valid claims")
 
 	// Should return an error if the step is not a valid step
-	_, err = s.client.LoadRegistrationForm(context.TODO(), &api.LoadRegistrationFormParams{Step: "invalid"})
+	_, err = s.client.LoadRegistrationForm(context.TODO(), &api.RegistrationFormParams{Step: "invalid"})
 	s.requireError(err, http.StatusBadRequest, "unknown registration form step \"invalid\"", "expected error when step is invalid")
 
 	out, err := s.client.LoadRegistrationForm(context.TODO(), nil)
@@ -152,7 +152,7 @@ func (s *bffTestSuite) TestLoadRegisterForm() {
 	// Test loading individual steps of the registration form
 	// Basic Details
 	full := out.Form
-	params := &api.LoadRegistrationFormParams{
+	params := &api.RegistrationFormParams{
 		Step: api.StepBasicDetails,
 	}
 	out, err = s.client.LoadRegistrationForm(context.Background(), params)
@@ -333,15 +333,9 @@ func (s *bffTestSuite) TestSaveRegisterForm() {
 	_, err = s.client.SaveRegistrationForm(context.TODO(), &api.RegistrationForm{Step: "invalid"})
 	s.requireError(err, http.StatusBadRequest, "unknown registration form step \"invalid\"", "expected error when step is invalid")
 
-	// Should be able to save an empty registration form to go back to default values.
+	// Providing no form should return an error
 	reply, err := s.client.SaveRegistrationForm(context.TODO(), &api.RegistrationForm{Form: nil})
-	require.NoError(err, "should not receive an error when saving an empty registration form")
-	require.NotEmpty(reply, "should receive default values when saving a nil empty registration form")
-
-	// Registration form should be cleared and new registration form with default values saved to database.
-	org, err = s.DB().RetrieveOrganization(context.Background(), org.UUID())
-	require.NoError(err, "could not retrieve organization from database")
-	require.True(proto.Equal(org.Registration, reply.Form), "expected registration form empty except for default values")
+	s.requireError(err, http.StatusBadRequest, "no form was provided", "expected error when form is not provided")
 
 	// Should be able to save the fixture form
 	reply, err = s.client.SaveRegistrationForm(context.TODO(), form)
@@ -357,27 +351,22 @@ func (s *bffTestSuite) TestSaveRegisterForm() {
 	org.Registration.State.Started = ""
 	require.True(proto.Equal(org.Registration, form.Form), "expected form saved in database to match form uploaded")
 
-	// Should be able to "clear" a registration by saving an empty registration form
-	reply, err = s.client.SaveRegistrationForm(context.TODO(), &api.RegistrationForm{Form: nil})
-	require.NoError(err, "should not receive an error when saving an empty registration form")
-	require.NotEmpty(reply, "should receive default values when saving an empty registration form")
-
-	org, err = s.DB().RetrieveOrganization(context.Background(), org.UUID())
-	require.NoError(err, "could not retrieve updated org from database")
-	require.False(proto.Equal(org.Registration, form.Form), "expected form saved in database to be cleared")
+	// Reset the form in the database
+	org.Registration = records.NewRegisterForm()
+	err = s.DB().UpdateOrganization(context.Background(), org)
+	require.NoError(err, "could not update org in database")
 
 	// Test saving steps of a registration form one by one
 	// Basic details
 	defaultForm := records.NewRegisterForm()
 	partial := &api.RegistrationForm{}
 	partial.Step = api.StepBasicDetails
-	partial.Form = &records.RegistrationForm{
-		Website:          form.Form.Website,
-		BusinessCategory: form.Form.BusinessCategory,
-		VaspCategories:   form.Form.VaspCategories,
-		EstablishedOn:    form.Form.EstablishedOn,
-		OrganizationName: form.Form.OrganizationName,
-	}
+	partial.Form = records.NewRegisterForm()
+	partial.Form.Website = form.Form.Website
+	partial.Form.BusinessCategory = form.Form.BusinessCategory
+	partial.Form.VaspCategories = form.Form.VaspCategories
+	partial.Form.EstablishedOn = form.Form.EstablishedOn
+	partial.Form.OrganizationName = form.Form.OrganizationName
 	reply, err = s.client.SaveRegistrationForm(context.TODO(), partial)
 	require.NoError(err, "should not receive an error when saving a partial registration form")
 	require.NotNil(reply, "uploaded form should be returned when a non-empty registration form is saved")
@@ -385,6 +374,7 @@ func (s *bffTestSuite) TestSaveRegisterForm() {
 
 	org, err = s.DB().RetrieveOrganization(context.Background(), org.UUID())
 	require.NoError(err, "could not retrieve updated org from database")
+	require.NotEmpty(org.Registration.State.Started, "expected registration form started timestamp to be populated")
 	require.Equal(partial.Form.Website, org.Registration.Website, "expected form saved in database to match partial form uploaded")
 	require.Equal(partial.Form.BusinessCategory, org.Registration.BusinessCategory, "expected form field in database to match partial form uploaded")
 	require.Equal(partial.Form.VaspCategories, org.Registration.VaspCategories, "expected form field in database to match partial form uploaded")
@@ -518,6 +508,143 @@ func (s *bffTestSuite) TestSaveRegisterForm() {
 		require.NotNil(reply, "uploaded form should be returned when a non-empty registration form is saved")
 		require.Equal(verrs[tc.step], reply.Errors, "wrong errors when saving form step %s", tc.step)
 	}
+}
+
+func (s *bffTestSuite) TestDeleteRegisterForm() {
+	require := s.Require()
+
+	// Create initial claims fixture
+	claims := &authtest.Claims{
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"read:nothing"},
+	}
+
+	// Load registration forms fixture
+	form := &records.RegistrationForm{}
+	err := loadFixture("testdata/registration_form.pb.json", form)
+	require.NoError(err, "could not load registration form fixture")
+
+	// Endpoint requires CSRF protection
+	_, err = s.client.DeleteRegistrationForm(context.TODO(), nil)
+	s.requireError(err, http.StatusForbidden, "csrf verification failed for request", "expected error when request is not CSRF protected")
+
+	// Endpoint must be authenticated
+	require.NoError(s.SetClientCSRFProtection(), "could not set csrf protection on client")
+	_, err = s.client.DeleteRegistrationForm(context.TODO(), nil)
+	s.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// Endpoint requires the update:vasp permission
+	require.NoError(s.SetClientCredentials(claims), "could not create token with incorrect permissions")
+	_, err = s.client.DeleteRegistrationForm(context.TODO(), nil)
+	s.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user is not authorized")
+
+	// Claims must have an organization ID and the server must not panic if it does not
+	claims.Permissions = []string{auth.UpdateVASP}
+	require.NoError(s.SetClientCredentials(claims), "could not create token without organizationID from claims")
+	_, err = s.client.DeleteRegistrationForm(context.TODO(), nil)
+	s.requireError(err, http.StatusUnauthorized, "missing claims info, try logging out and logging back in", "expected error when user claims does not have an orgid")
+
+	// Create valid claims but no record in the database - should not panic and should return an error
+	claims.OrgID = "2295c698-afdc-4aaf-9443-85a4515217e3"
+	require.NoError(s.SetClientCredentials(claims), "could not create token with valid claims")
+	_, err = s.client.DeleteRegistrationForm(context.TODO(), nil)
+	s.requireError(err, http.StatusUnauthorized, "no organization found, try logging out and logging back in", "expected error when claims are valid but no organization is in the database")
+
+	// Create an organization in the database
+	org := &records.Organization{}
+	_, err = s.DB().CreateOrganization(context.Background(), org)
+	require.NoError(err, "could not create organization in the database")
+	defer func() {
+		// Ensure organization is deleted at the end of the tests
+		s.DB().DeleteOrganization(context.Background(), org.UUID())
+	}()
+
+	claims.OrgID = org.Id
+	require.NoError(s.SetClientCredentials(claims), "could not create token with valid claims")
+
+	// Should return an error if the step is not a valid step
+	_, err = s.client.DeleteRegistrationForm(context.TODO(), &api.RegistrationFormParams{Step: "invalid"})
+	s.requireError(err, http.StatusBadRequest, "unknown registration form step \"invalid\"", "expected error when step is invalid")
+
+	// Load the registration form on the organization
+	org.Registration = form
+	require.NoError(s.DB().UpdateOrganization(context.Background(), org), "could not update organization with registration form")
+
+	// Test deleting the entire form
+	defaultForm := records.NewRegisterForm()
+	rep, err := s.client.DeleteRegistrationForm(context.Background(), nil)
+	require.NoError(err, "should not receive an error when deleting a registration form")
+	require.Nil(rep.Errors, "should not receive any validation errors when deleting a registration form")
+	require.True(proto.Equal(defaultForm, rep.Form), "default form should be returned when a registration form is deleted")
+
+	// Load the complete form back on the organization
+	org.Registration = form
+	require.NoError(s.DB().UpdateOrganization(context.Background(), org), "could not update organization with registration form")
+
+	// Test deleting specific steps in the form
+	params := &api.RegistrationFormParams{Step: api.StepBasicDetails}
+	rep, err = s.client.DeleteRegistrationForm(context.Background(), params)
+	require.NoError(err, "should not receive an error when deleting a registration form")
+	require.Nil(rep.Errors, "should not receive any validation errors when deleting a registration form")
+	require.Equal(defaultForm.Website, rep.Form.Website, "website should be reset when basic details are deleted")
+	require.Equal(defaultForm.BusinessCategory, rep.Form.BusinessCategory, "business category should be reset when basic details are deleted")
+	require.Equal(defaultForm.VaspCategories, rep.Form.VaspCategories, "vasp categories should be reset when basic details are deleted")
+	require.Equal(defaultForm.EstablishedOn, rep.Form.EstablishedOn, "established on should be reset when basic details are deleted")
+	require.Equal(defaultForm.OrganizationName, rep.Form.OrganizationName, "organization name should be reset when basic details are deleted")
+	require.Nil(rep.Form.Entity, "entity should not be returned on basic details delete")
+	require.Nil(rep.Form.Contacts, "contacts should not be returned on basic details delete")
+	require.Nil(rep.Form.Trixo, "trixo should not be returned on basic details delete")
+	require.Nil(rep.Form.Testnet, "testnet should not be returned on basic details delete")
+	require.Nil(rep.Form.Mainnet, "mainnet should not be returned on basic details delete")
+
+	params.Step = api.StepLegalPerson
+	rep, err = s.client.DeleteRegistrationForm(context.Background(), params)
+	require.NoError(err, "should not receive an error when deleting a registration form")
+	require.Nil(rep.Errors, "should not receive any validation errors when deleting a registration form")
+	require.Empty(rep.Form.Website, "website should not be returned on legal person delete")
+	require.Equal(defaultForm.Entity, rep.Form.Entity, "entity should be reset when legal person is deleted")
+	require.Nil(rep.Form.Contacts, "contacts should not be returned on legal person delete")
+	require.Nil(rep.Form.Trixo, "trixo should not be returned on legal person delete")
+	require.Nil(rep.Form.Testnet, "testnet should not be returned on legal person delete")
+	require.Nil(rep.Form.Mainnet, "mainnet should not be returned on legal person delete")
+
+	params.Step = api.StepContacts
+	rep, err = s.client.DeleteRegistrationForm(context.Background(), params)
+	require.NoError(err, "should not receive an error when deleting a registration form")
+	require.Nil(rep.Errors, "should not receive any validation errors when deleting a registration form")
+	require.Empty(rep.Form.Website, "website should not be returned on contacts delete")
+	require.Empty(rep.Form.Entity, "entity should not be returned on contacts delete")
+	require.Equal(defaultForm.Contacts, rep.Form.Contacts, "contacts should be reset when contacts are deleted")
+	require.Nil(rep.Form.Trixo, "trixo should not be returned on contacts delete")
+	require.Nil(rep.Form.Testnet, "testnet should not be returned on contacts delete")
+	require.Nil(rep.Form.Mainnet, "mainnet should not be returned on contacts delete")
+
+	params.Step = api.StepTRIXO
+	rep, err = s.client.DeleteRegistrationForm(context.Background(), params)
+	require.NoError(err, "should not receive an error when deleting a registration form")
+	require.Nil(rep.Errors, "should not receive any validation errors when deleting a registration form")
+	require.Empty(rep.Form.Website, "website should not be returned on trixo delete")
+	require.Empty(rep.Form.Entity, "entity should not be returned on trixo delete")
+	require.Empty(rep.Form.Contacts, "contacts should not be returned on trixo delete")
+	require.Equal(defaultForm.Trixo, rep.Form.Trixo, "trixo should be reset when trixo is deleted")
+	require.Nil(rep.Form.Testnet, "testnet should not be returned on trixo delete")
+	require.Nil(rep.Form.Mainnet, "mainnet should not be returned on trixo delete")
+
+	params.Step = api.StepTRISA
+	rep, err = s.client.DeleteRegistrationForm(context.Background(), params)
+	require.NoError(err, "should not receive an error when deleting a registration form")
+	require.Nil(rep.Errors, "should not receive any validation errors when deleting a registration form")
+	require.Empty(rep.Form.Website, "website should not be returned on trisa delete")
+	require.Empty(rep.Form.Entity, "entity should not be returned on trisa delete")
+	require.Empty(rep.Form.Contacts, "contacts should not be returned on trisa delete")
+	require.Empty(rep.Form.Trixo, "trixo should not be returned on trisa delete")
+	require.Equal(defaultForm.Testnet, rep.Form.Testnet, "testnet should be reset when trisa is deleted")
+	require.Equal(defaultForm.Mainnet, rep.Form.Mainnet, "mainnet should be reset when trisa is deleted")
+
+	// At this point the form in the database should match the default
+	org, err = s.DB().RetrieveOrganization(context.Background(), org.UUID())
+	require.NoError(err, "should not receive an error when retrieving the organization")
+	require.True(proto.Equal(defaultForm, org.Registration), "registration form should match the default form")
 }
 
 func (s *bffTestSuite) TestSubmitRegistration() {

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -384,9 +384,13 @@ func (s *Server) setupRoutes() (err error) {
 			collaborators.POST("/:collabID", auth.DoubleCookie(), auth.Authorize(auth.UpdateCollaborators), s.UpdateCollaboratorRoles)
 			collaborators.DELETE("/:collabID", auth.DoubleCookie(), auth.Authorize(auth.UpdateCollaborators), s.DeleteCollaborator)
 		}
-		v1.GET("/register", auth.Authorize(auth.ReadVASP), s.LoadRegisterForm)
-		v1.PUT("/register", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), s.SaveRegisterForm)
-		v1.POST("/register/:network", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), userinfo, s.SubmitRegistration)
+		register := v1.Group("/register")
+		{
+			register.GET("", auth.Authorize(auth.ReadVASP), s.LoadRegisterForm)
+			register.PUT("", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), s.SaveRegisterForm)
+			register.DELETE("", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), s.DeleteRegisterForm)
+			register.POST("/:network", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), userinfo, s.SubmitRegistration)
+		}
 		v1.GET("/registration", auth.Authorize(auth.ReadVASP), s.RegistrationStatus)
 		v1.GET("/overview", auth.Authorize(auth.ReadVASP), s.Overview)
 		v1.GET("/announcements", auth.Authorize(auth.ReadVASP), s.Announcements)

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -388,7 +388,7 @@ func (s *Server) setupRoutes() (err error) {
 		{
 			register.GET("", auth.Authorize(auth.ReadVASP), s.LoadRegisterForm)
 			register.PUT("", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), s.SaveRegisterForm)
-			register.DELETE("", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), s.DeleteRegisterForm)
+			register.DELETE("", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), s.ResetRegisterForm)
 			register.POST("/:network", auth.DoubleCookie(), auth.Authorize(auth.UpdateVASP), userinfo, s.SubmitRegistration)
 		}
 		v1.GET("/registration", auth.Authorize(auth.ReadVASP), s.RegistrationStatus)


### PR DESCRIPTION
### Scope of changes

This adds a BFF endpoint to delete a registration form, either by requesting a specific step or deleting the entire form by default. When a form step is deleted, the values are reset to the defaults and no validation errors are returned.

SC-17560

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


