### PR TITLE
Fix network details and vasp category validation

### DIFF
--- a/pkg/bff/models/v1/errors.go
+++ b/pkg/bff/models/v1/errors.go
@@ -34,6 +34,7 @@ var (
 	ErrLegalNatIDRequired      = errors.New("national identification is required to verify legal person")
 	ErrNoRAForLEIX             = errors.New("registration authority must be empty for identifier type LEI")
 	ErrRARequired              = errors.New("registration authority must be specified unless the identifier type is LEI")
+	ErrMissingTestNetOrMainNet = errors.New("testnet or mainnet information is required")
 	ErrInvalidEndpoint         = errors.New("endpoint must have the format host:port")
 	ErrDuplicateEndpoint       = errors.New("mainnet endpoint cannot be the same as testnet endpoint")
 	ErrMissingHost             = errors.New("endpoint string must have a host")

--- a/pkg/bff/models/v1/errors.go
+++ b/pkg/bff/models/v1/errors.go
@@ -34,7 +34,7 @@ var (
 	ErrLegalNatIDRequired      = errors.New("national identification is required to verify legal person")
 	ErrNoRAForLEIX             = errors.New("registration authority must be empty for identifier type LEI")
 	ErrRARequired              = errors.New("registration authority must be specified unless the identifier type is LEI")
-	ErrMissingTestNetOrMainNet = errors.New("testnet or mainnet information is required")
+	ErrMissingTestNetOrMainNet = errors.New("node implementation details are required for at least one network: testnet or mainnet")
 	ErrInvalidEndpoint         = errors.New("endpoint must have the format host:port")
 	ErrDuplicateEndpoint       = errors.New("mainnet endpoint cannot be the same as testnet endpoint")
 	ErrMissingHost             = errors.New("endpoint string must have a host")


### PR DESCRIPTION
### Scope of changes

This fixes two registration form validation issues:

1. Only one of testnet/mainnet TRISA details are required (SC-17594)
2. VASP categories is not a required field (SC-17596)

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


