### PR TITLE
Adds conditional to reg authority and updates unsave modal text

### DIFF
--- a/web/gds-user-ui/src/components/CertificateReview/LegalPersonReviewDataTable.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/LegalPersonReviewDataTable.tsx
@@ -184,12 +184,14 @@ function LegalPersonReviewDataTable({ data }: LegalReviewProps) {
               </Td>
               <Td>{(COUNTRIES as any)[data?.national_identification?.country_of_issue] || 'N/A'}</Td>
             </Tr> */}
-            <Tr>
+            {data?.national_identification?.national_identifier_type !== 'NATIONAL_IDENTIFIER_TYPE_CODE_LEIX' && (
+              <Tr>
               <Td pt={0}>
                 <Trans id="Reg Authority">Reg Authority</Trans>
               </Td>
-              <Td pt={0}>{data?.national_identification?.registration_authority || 'N/A'}</Td>
+              <Td pt={0}>{data?.national_identification?.registration_authority || ''}</Td>
             </Tr>
+            )}
           </Tbody>
         </Table>
       </Sentry.ErrorBoundary>

--- a/web/gds-user-ui/src/components/RegistrationForm/InvalidFormPrompt.tsx
+++ b/web/gds-user-ui/src/components/RegistrationForm/InvalidFormPrompt.tsx
@@ -45,7 +45,7 @@ function InvalidFormPrompt({
                 <Trans>
                   If you continue, your changes will be lost. To save your changes, click Cancel and
                   then click on the{' '}
-                {isNextStep ? <Text as="span" fontWeight={700} whiteSpace={'break-spaces'}>Save & Next</Text> : <Text as="span" fontWeight={700} whiteSpace={'break-spaces'}>Save & Previous</Text>} button.
+                {isNextStep ? <Text as="span" fontWeight={'bold'} whiteSpace={'break-spaces'}>Save & Next</Text> : <Text as="span" fontWeight={'bold'} whiteSpace={'break-spaces'}>Save & Previous</Text>} button.
                 </Trans>
               </Text>
             </Box>

--- a/web/gds-user-ui/src/components/RegistrationForm/InvalidFormPrompt.tsx
+++ b/web/gds-user-ui/src/components/RegistrationForm/InvalidFormPrompt.tsx
@@ -12,7 +12,6 @@ import {
   Box
 } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
-import { useEffect, useState } from 'react';
 type InvalidFormPromptProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -26,16 +25,6 @@ function InvalidFormPrompt({
   handleContinueClick,
   isNextStep
 }: InvalidFormPromptProps) {
-  const [btnContent, setIsBtnContent] = useState("");
-
-  useEffect(() => {
-    if (isNextStep) {
-      setIsBtnContent("Save & Next");
-    } else {
-      setIsBtnContent("Save & Previous");
-    }
-  }, [isNextStep]);
-
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -55,11 +44,9 @@ function InvalidFormPrompt({
               <Text>
                 <Trans>
                   If you continue, your changes will be lost. To save your changes, click Cancel and
-                  then click on the
+                  then click on the{' '}
+                {isNextStep ? <Text as="span" fontWeight={700} whiteSpace={'break-spaces'}>Save & Next</Text> : <Text as="span" fontWeight={700} whiteSpace={'break-spaces'}>Save & Previous</Text>} button.
                 </Trans>
-              </Text>
-              <Text fontWeight={'bold'} as="span">
-                <Trans>{btnContent} button.</Trans>
               </Text>
             </Box>
           </VStack>


### PR DESCRIPTION
### Scope of changes

Shows the `Reg Authority` in Section 2 on the Review page only if `LEI` isn't the selected Identification Type. This should prevent the error seen in the screenshot below from appearing:

<img width="1239" alt="Screenshot 2023-05-31 at 5 17 57 PM" src="https://github.com/trisacrypto/directory/assets/94616884/62f406d6-cb4a-447b-9520-ed1a97da8168">

Also, fixes error where the `Unsaved Changes` modal doesn't display button text. The previous fix didn't work in staging.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/17930045?key=fa619095c4864f67d9944e01bbe942e8

Note: I noticed that the `Unsaved Changed` modal doesn't display if the step before it is displaying as `In Progress`. I included this in the video. I didn't attempt to fix because I believe other changes are being made to the progress bar and am not sure if that will resolve the issue.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


