### PR TITLE
Fixes reg authority error in review section

### DIFF
--- a/web/gds-user-ui/src/components/NameIdentification/index.tsx
+++ b/web/gds-user-ui/src/components/NameIdentification/index.tsx
@@ -93,7 +93,7 @@ const NationalIdentification: React.FC<NationalIdentificationProps> = () => {
 
 useEffect(() => {
     if (NationalIdentificationType === 'NATIONAL_IDENTIFIER_TYPE_CODE_LEIX') {
-      setValue('entity.national_identification.registration_authority', 'N/A');
+      setValue('entity.national_identification.registration_authority', '');
       clearErrors('entity.national_identification.registration_authority');
 
       inputRegRef?.current?.clear();

--- a/web/gds-user-ui/src/components/RegistrationForm/InvalidFormPrompt.tsx
+++ b/web/gds-user-ui/src/components/RegistrationForm/InvalidFormPrompt.tsx
@@ -23,7 +23,6 @@ function InvalidFormPrompt({
   isOpen,
   onClose,
   handleContinueClick,
-  isNextStep
 }: InvalidFormPromptProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -44,8 +43,12 @@ function InvalidFormPrompt({
               <Text>
                 <Trans>
                   If you continue, your changes will be lost. To save your changes, click Cancel and
-                  then click on the{' '}
-                {isNextStep ? <Text as="span" fontWeight={'bold'} whiteSpace={'break-spaces'}>Save & Next</Text> : <Text as="span" fontWeight={'bold'} whiteSpace={'break-spaces'}>Save & Previous</Text>} button.
+                  then click on the
+                </Trans>
+              </Text>
+              <Text as="span" fontWeight="bold">
+                <Trans>
+                "Save & Next" or "Save & Previous" button.
                 </Trans>
               </Text>
             </Box>


### PR DESCRIPTION
### Scope of changes

Sets `Reg Authority` default value to empty string if the Identification Type is LEI. Also updates the `Unsaved Alert` modal text.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/17939614?key=f04fe2d6caa83964255ccc6a329c1abc

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


