### PR TITLE
BFF Members List RPC

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -40,6 +40,7 @@ type BFFClient interface {
 	UpdateCollaboratorRoles(_ context.Context, id string, request *UpdateRolesParams) (*models.Collaborator, error)
 	DeleteCollaborator(_ context.Context, id string) error
 
+	MemberList(context.Context, *MemberPageInfo) (*MemberListReply, error)
 	MemberDetails(context.Context, *MemberDetailsParams) (*MemberDetailsReply, error)
 
 	// Registration form
@@ -303,6 +304,10 @@ type NetworkOverview struct {
 	NewMembers         int           `json:"new_members"`
 	MemberDetails      MemberDetails `json:"member_details"`
 }
+
+type MemberPageInfo struct{}
+
+type MemberListReply struct{}
 
 // MemberDetails contains VASP-specific information.
 type MemberDetails struct {

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -305,10 +305,6 @@ type NetworkOverview struct {
 	MemberDetails      MemberDetails `json:"member_details"`
 }
 
-type MemberPageInfo struct{}
-
-type MemberListReply struct{}
-
 // MemberDetails contains VASP-specific information.
 type MemberDetails struct {
 	ID          string                 `json:"id"`
@@ -341,6 +337,19 @@ type Certificate struct {
 	ExpiresAt    string                 `json:"expires_at"`
 	Revoked      bool                   `json:"revoked"`
 	Details      map[string]interface{} `json:"details"`
+}
+
+// MembersPageInfo enables paginated requests to the TRISAMembers/List RPC for the
+// specified directory. Pagination is not stateful and requires a token.
+type MemberPageInfo struct {
+	Directory string `url:"registered_directory,omitempty" form:"registered_directory"`
+	PageSize  int32  `url:"page_size,omitempty" form:"page_size"`
+	PageToken string `url:"page_token,omitempty" form:"page_token"`
+}
+
+type MemberListReply struct {
+	VASPs         []*members.VASPMember `json:"vasps"`
+	NextPageToken string                `json:"next_page_token,omitempty"`
 }
 
 // MemberDetailsParams contains details required to identify a VASP member for the

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -524,6 +524,28 @@ func (s *APIv1) Certificates(ctx context.Context) (out *CertificatesReply, err e
 	return out, nil
 }
 
+// Returns a list of all verified VASPs in the specified directory.
+func (s *APIv1) MemberList(ctx context.Context, in *MemberPageInfo) (out *MemberListReply, err error) {
+	// Create the query params from the input
+	var params url.Values
+	if params, err = query.Values(in); err != nil {
+		return nil, fmt.Errorf("could not encode query params: %s", err)
+	}
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/members", nil, &params); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &MemberListReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Details returns the sensitive details for a VASP member.
 func (s *APIv1) MemberDetails(ctx context.Context, in *MemberDetailsParams) (out *MemberDetailsReply, err error) {
 	// Create the query params from the input

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -941,7 +941,23 @@ func TestCertificates(t *testing.T) {
 }
 
 func TestMemberList(t *testing.T) {
-	fixture := &api.MemberListReply{}
+	fixture := &api.MemberListReply{
+		VASPs: []*members.VASPMember{
+			{
+				Id:                  "7b8e1638-cf44-4b72-a4ae-08ff0352563b",
+				RegisteredDirectory: "testnet",
+				CommonName:          "example.com",
+				Endpoint:            "trisa.example.com",
+			},
+			{
+				Id:                  "03f47724-4751-40d4-8dda-fa5468f3b4a7",
+				RegisteredDirectory: "testnet",
+				CommonName:          "foobear.io",
+				Endpoint:            "trisa-test.foobear.io.com",
+			},
+		},
+		NextPageToken: "thenextpage",
+	}
 
 	// Create a Test Server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -958,7 +974,11 @@ func TestMemberList(t *testing.T) {
 	client, err := api.New(ts.URL)
 	require.NoError(t, err)
 
-	req := &api.MemberPageInfo{}
+	req := &api.MemberPageInfo{
+		Directory: "testnet",
+		PageSize:  100,
+		PageToken: "theprevpage",
+	}
 
 	out, err := client.MemberList(context.TODO(), req)
 	require.NoError(t, err)

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -940,6 +940,31 @@ func TestCertificates(t *testing.T) {
 	require.Equal(t, fixture.MainNet, out.MainNet)
 }
 
+func TestMemberList(t *testing.T) {
+	fixture := &api.MemberListReply{}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/members", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err)
+
+	req := &api.MemberPageInfo{}
+
+	out, err := client.MemberList(context.TODO(), req)
+	require.NoError(t, err)
+	require.Equal(t, fixture, out)
+}
+
 func TestMemberDetails(t *testing.T) {
 	fixture := &api.MemberDetailsReply{
 		Summary: &members.VASPMember{

--- a/pkg/bff/members.go
+++ b/pkg/bff/members.go
@@ -20,6 +20,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// The default query parameters against the TRISAMembers gRPC API
+const (
+	DefaultMembersTimeout  = 25 * time.Second
+	DefaultMembersPageSize = 200
+)
+
 // GetSummaries makes parallel calls to the members service to get the summary
 // information for both testnet and mainnet. If an endpoint returned an error, then a
 // nil value is returned from this function for that endpoint instead of an error.
@@ -187,12 +193,12 @@ func (s *Server) Overview(c *gin.Context) {
 // read:vasp permission and is only available to organizations that have themselves been
 // verified through the TRISA directory that they are querying.
 //
-// @Summary
-// @Description
+// @Summary List verified VASPs in the specified directory (MainNet by default).
+// @Description Returns a list of verified VASPs in the specified directory so long as the organization is a verified member of that directory.
 // @Tags members
 // @Accept json
 // @Produce json
-// @Param params
+// @Param params body api.MemberPageInfo true "Directory and Pagination"
 // @Success 200 {object} object "VASP List"
 // @Failure 400 {object} api.Reply "VASP ID and directory are required"
 // @Failure 401 {object} api.Reply
@@ -200,7 +206,76 @@ func (s *Server) Overview(c *gin.Context) {
 // @Failure 500 {object} api.Reply
 // @Router /members [get]
 func (s *Server) MemberList(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, api.ErrorResponse("endpoint not implemented yet"))
+	var (
+		err    error
+		params *api.MemberPageInfo
+		rep    *members.ListReply
+	)
+
+	// Bind the query parameters and add reasonable defaults
+	params = &api.MemberPageInfo{}
+	if err = c.ShouldBindQuery(params); err != nil {
+		log.Warn().Err(err).Msg("could not bind request with query params")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// Add reasonable defaults to the params if they do not exist
+	if params.PageSize <= 0 {
+		params.PageSize = DefaultMembersPageSize
+	}
+
+	// By default query the mainnet if a directory is not specified
+	if params.Directory == "" {
+		params.Directory = config.MainNet
+	}
+
+	// Validate the registered directory
+	params.Directory = strings.ToLower(params.Directory)
+	if !validRegisteredDirectory(params.Directory) {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("unknown registered directory"))
+		return
+	}
+
+	// Execute the members list request against the specified GDS
+	log.Debug().Str("registered_directory", params.Directory).Int32("page_size", params.PageSize).Str("page_token", params.PageToken).Msg("members list request")
+	req := &members.ListRequest{
+		PageSize:  params.PageSize,
+		PageToken: params.PageToken,
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), DefaultMembersTimeout)
+	defer cancel()
+
+	switch registeredDirectoryType(params.Directory) {
+	case config.TestNet:
+		rep, err = s.testnetGDS.List(ctx, req)
+	case config.MainNet:
+		rep, err = s.mainnetGDS.List(ctx, req)
+	default:
+		log.Error().Str("registered_directory", params.Directory).Msg("unhandled directory")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not retrieve member list"))
+		return
+	}
+
+	// Handle gRPC errors
+	if err != nil {
+		if serr, ok := status.FromError(err); ok {
+			log.Error().Err(err).Str("code", serr.Code().String()).Str("grpc_error", serr.Message()).Msg("members list rpc error")
+			c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not retrieve member list"))
+			return
+		}
+
+		log.Error().Err(err).Msg("unhandled error from gRPC service")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not retrieve member list"))
+		return
+	}
+
+	// Create the list response
+	c.JSON(http.StatusOK, &api.MemberListReply{
+		VASPs:         rep.Vasps,
+		NextPageToken: rep.NextPageToken,
+	})
 }
 
 // MemberDetails endpoint is an authenticated endpoint that requires the read:vasp
@@ -214,7 +289,7 @@ func (s *Server) MemberList(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param params body api.MemberDetailsParams true "VASP ID and directory"
-// @Success 200 {object} object "VASP details"
+// @Success 200 {object} object "VASP Details"
 // @Failure 400 {object} api.Reply "VASP ID and directory are required"
 // @Failure 401 {object} api.Reply
 // @Failure 404 {object} api.Reply
@@ -247,7 +322,7 @@ func (s *Server) MemberDetails(c *gin.Context) {
 	req := &members.DetailsRequest{
 		MemberId: params.ID,
 	}
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 25*time.Second)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), DefaultMembersTimeout)
 	defer cancel()
 
 	var (

--- a/pkg/bff/members.go
+++ b/pkg/bff/members.go
@@ -182,8 +182,31 @@ func (s *Server) Overview(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
+// MemberList is an authenticated endpoint that returns a list of all verified VASPs in
+// the requested directory (e.g. either TestNet or MainNet). This endpoint requires the
+// read:vasp permission and is only available to organizations that have themselves been
+// verified through the TRISA directory that they are querying.
+//
+// @Summary
+// @Description
+// @Tags members
+// @Accept json
+// @Produce json
+// @Param params
+// @Success 200 {object} object "VASP List"
+// @Failure 400 {object} api.Reply "VASP ID and directory are required"
+// @Failure 401 {object} api.Reply
+// @Failure 404 {object} api.Reply
+// @Failure 500 {object} api.Reply
+// @Router /members [get]
+func (s *Server) MemberList(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, api.ErrorResponse("endpoint not implemented yet"))
+}
+
 // MemberDetails endpoint is an authenticated endpoint that requires the read:vasp
 // permission and returns details about a VASP member.
+// TODO: convert to /members/:vaspID
+// TODO: ensure only verified VASPs can query this endpoint
 //
 // @Summary Get details for a VASP [read:vasp]
 // @Description Returns details for a VASP by ID and directory.

--- a/pkg/bff/testdata/mainnet/list_reply.json
+++ b/pkg/bff/testdata/mainnet/list_reply.json
@@ -1,0 +1,57 @@
+{
+  "vasps":  [
+    {
+      "id":  "fe29b582-20b3-4b75-acb2-4d014af25f28",
+      "registered_directory":  "vaspdirectory.net",
+      "common_name":  "mainnet.firecoinex.co",
+      "endpoint":  "mainnet.firecoinex.co:443",
+      "name":  "FireCoin Exchange",
+      "website":  "https://www.firecoinex.co/",
+      "country":  "SG",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "OTC"
+      ],
+      "verified_on":  "2022-04-20T10:45:33Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2022-04-20T11:10:06Z",
+      "last_updated":  "2022-11-19T09:32:45Z"
+    },
+    {
+      "id":  "52842ac3-7d9d-4520-8bfb-e6083dbdc8aa",
+      "registered_directory":  "vaspdirectory.net",
+      "common_name":  "mainnet.testmachine.com",
+      "endpoint":  "mainnet.testmachine.com:443",
+      "name":  "Test Machine",
+      "website":  "https://testmachine.com",
+      "country":  "US",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "Exchange",
+        "Other"
+      ],
+      "verified_on":  "2023-03-22T03:55:00Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2023-03-22T04:22:18Z",
+      "last_updated":  "2023-05-10T04:44:00Z"
+    },
+    {
+      "id":  "ec6f2056-726b-4e8c-a916-f7359f6f5581",
+      "registered_directory":  "vaspdirectory.net",
+      "common_name":  "mainnet.newcoinex.ai",
+      "endpoint":  "mainnet.newcoinex.ai:8221",
+      "name":  "New Coin Exchange",
+      "website":  "https://newcoinex.ai/",
+      "country":  "US",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "Other"
+      ],
+      "verified_on":  "2023-01-20T12:55:03Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2023-01-20T14:10:26Z",
+      "last_updated":  "2023-06-18T10:30:01Z"
+    }
+  ],
+  "next_page_token":  ""
+}

--- a/pkg/bff/testdata/testnet/list_reply.json
+++ b/pkg/bff/testdata/testnet/list_reply.json
@@ -1,0 +1,91 @@
+{
+  "vasps":  [
+    {
+      "id":  "1b99f17d-3441-4885-b9df-8f3475f7e1b4",
+      "registered_directory":  "trisatest.net",
+      "common_name":  "trisa-travelrule.sendcoin.io",
+      "endpoint":  "trisa-travelrule.sendcoin.io:443",
+      "name":  "SendCoin VASP",
+      "website":  "https://www.sendcoin.io/",
+      "country":  "SG",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "OTC"
+      ],
+      "verified_on":  "2022-02-10T17:12:23Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2022-02-10T13:43:55Z",
+      "last_updated":  "2023-04-09T04:02:50Z"
+    },
+    {
+      "id":  "aa4c6714-49dc-411c-adfa-b8edc4d58cd7",
+      "registered_directory":  "trisatest.net",
+      "common_name":  "testing.example.com",
+      "endpoint":  "testing.example.com:443",
+      "name":  "Example Crypto",
+      "website":  "https://example.com",
+      "country":  "US",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "Exchange",
+        "Other"
+      ],
+      "verified_on":  "2021-12-07T20:22:00Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2021-12-01T23:22:18Z",
+      "last_updated":  "2023-01-23T19:19:43Z"
+    },
+    {
+      "id":  "688059d6-9d14-4b49-8435-f641ba1dec3a",
+      "registered_directory":  "trisatest.net",
+      "common_name":  "testnet.spudcoin.ai",
+      "endpoint":  "testnet.spudcoin.ai:8221",
+      "name":  "SpudCoin",
+      "website":  "https://spudcoin.ai/",
+      "country":  "US",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "Other"
+      ],
+      "verified_on":  "2021-07-29T19:11:03Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2021-07-23T17:10:26Z",
+      "last_updated":  "2022-12-27T18:59:01Z"
+    },
+    {
+      "id":  "62291255-1ea2-4932-8248-22af4abde298",
+      "registered_directory":  "trisatest.net",
+      "common_name":  "test.signal.co.fr",
+      "endpoint":  "test.signal.co.fr:9212",
+      "name":  "Signal Coin France",
+      "website":  "https://ciphertrace.com/",
+      "country":  "US",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "Other"
+      ],
+      "verified_on":  "2021-06-23T17:46:10Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2021-06-23T17:12:00Z",
+      "last_updated":  "2022-12-27T18:59:22Z"
+    },
+    {
+      "id":  "dae1555d-e4cf-4bfb-9858-9b86db71ccb6",
+      "registered_directory":  "trisatest.net",
+      "common_name":  "testnet.bitfriend.link",
+      "endpoint":  "testnet.bitfriend.link:443",
+      "name":  "BitFriendly",
+      "website":  "https://bitfriend.link/",
+      "country":  "US",
+      "business_category":  "BUSINESS_ENTITY",
+      "vasp_categories":  [
+        "Kiosk"
+      ],
+      "verified_on":  "2021-09-14T10:40:30Z",
+      "status":  "VERIFIED",
+      "first_listed":  "2021-09-01T19:46:04Z",
+      "last_updated":  "2023-01-23T19:29:43Z"
+    }
+  ],
+  "next_page_token":  "mLB9CU8O8xQj2XEyjAtlfvTj9imoXnLv/1p8fTLchTg="
+}


### PR DESCRIPTION
### Scope of changes

Adds a BFF endpoint `GET /v1/members` that available to verified VASPs to request the list of other verified VASPs in the specified directory. 

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Requests to either the TestNet or MainNet return a list of paginated members from that directory service. 

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


