### PR TITLE
Ensure GDS Member Detail returns Contacts

### DIFF
--- a/pkg/gds/members.go
+++ b/pkg/gds/members.go
@@ -328,18 +328,55 @@ func (s *Members) Details(ctx context.Context, in *api.DetailsRequest) (out *api
 
 	// Add the IVMS101 legal person to the response
 	if vasp.Entity == nil {
-		log.Error().Str("vasp_id", vasp.Id).Msg("VASP is missing legal person")
-		return nil, status.Error(codes.Internal, "VASP is missing legal person")
+		log.Warn().Str("vasp_id", vasp.Id).Msg("VASP is missing legal person")
 	}
 	out.LegalPerson = vasp.Entity
 
 	// Add the TRIXO form data to the response
 	if vasp.Trixo == nil {
-		log.Error().Str("vasp_id", vasp.Id).Msg("VASP is missing TRIXO form data")
-		return nil, status.Error(codes.Internal, "VASP is missing TRIXO form data")
+		log.Warn().Str("vasp_id", vasp.Id).Msg("VASP is missing TRIXO form data")
 	}
 	out.Trixo = vasp.Trixo
 
+	// Add the contacts data to the response
+	if vasp.Contacts == nil {
+		log.Warn().Str("vasp_id", vasp.Id).Msg("VASP is missing contacts data")
+	}
+
+	// NOTE: ensure that extra and person are null on return.
+	// We only want to supply name, email, and phone to other VASPs.
+	out.Contacts = &pb.Contacts{}
+	if vasp.Contacts.Administrative != nil {
+		out.Contacts.Administrative = &pb.Contact{
+			Name: vasp.Contacts.Administrative.Name,
+			Email: vasp.Contacts.Administrative.Email,
+			Phone: vasp.Contacts.Administrative.Phone,
+		}
+	}
+
+	if vasp.Contacts.Technical != nil {
+		out.Contacts.Technical = &pb.Contact{
+			Name: vasp.Contacts.Technical.Name,
+			Email: vasp.Contacts.Technical.Email,
+			Phone: vasp.Contacts.Technical.Phone,
+		}
+	}
+
+	if vasp.Contacts.Billing != nil {
+		out.Contacts.Billing = &pb.Contact{
+			Name: vasp.Contacts.Billing.Name,
+			Email: vasp.Contacts.Billing.Email,
+			Phone: vasp.Contacts.Billing.Phone,
+		}
+	}
+
+	if vasp.Contacts.Legal != nil {
+		out.Contacts.Legal = &pb.Contact{
+			Name: vasp.Contacts.Legal.Name,
+			Email: vasp.Contacts.Legal.Email,
+			Phone: vasp.Contacts.Legal.Phone,
+		}
+	}
 	return out, nil
 }
 


### PR DESCRIPTION
### Scope of changes

Ensures that only the name, email, and phone number of the administrative, technical, legal, and billing contacts are returned in a Member Detail RPC. This is a follow on from #1072 (SC-18635) to update the GDS to participate in the request.

Fixes SC-18767.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


