### PR TITLE
Rewire VASP summary

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -362,7 +362,7 @@ type MemberDetailsParams struct {
 
 // MemberDetailsReply contains sensitive details about a VASP member.
 type MemberDetailsReply struct {
-	Summary     *members.VASPMember    `json:"summary"`
+	Summary     map[string]interface{} `json:"summary"`
 	LegalPerson map[string]interface{} `json:"legal_person"`
 	Contacts    map[string]interface{} `json:"contacts"`
 	Trixo       map[string]interface{} `json:"trixo"`

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -1013,16 +1013,16 @@ func TestMemberList(t *testing.T) {
 
 func TestMemberDetails(t *testing.T) {
 	fixture := &api.MemberDetailsReply{
-		Summary: &members.VASPMember{
-			Id:                  "8b2e9e78-baca-4c34-a382-8b285503c901",
-			RegisteredDirectory: "trisatest.net",
-			CommonName:          "trisa.example.com",
-			Endpoint:            "trisa.example.com:443",
-			Name:                "Trisa TestNet",
-			Website:             "https://trisa.example.com",
-			Country:             "US",
-			VaspCategories:      []string{"P2P"},
-			VerifiedOn:          "2022-04-21T12:05:23Z",
+		Summary: map[string]interface{}{
+			"id":                   "8b2e9e78-baca-4c34-a382-8b285503c901",
+			"registered_directory": "trisatest.net",
+			"common_name":          "trisa.example.com",
+			"endpoint":             "trisa.example.com:443",
+			"name":                 "Trisa TestNet",
+			"website":              "https://trisa.example.com",
+			"country":              "US",
+			"vasp_categories":      []interface{}{"P2P"},
+			"verified_on":          "2022-04-21T12:05:23Z",
 		},
 		LegalPerson: map[string]interface{}{
 			"country_of_registration": "US",

--- a/pkg/bff/testdata/mainnet/details_reply.json
+++ b/pkg/bff/testdata/mainnet/details_reply.json
@@ -1,92 +1,92 @@
 {
-    "summary": {
-        "id": "9e069e01-8515-4d57-b9a5-e249f7ab4fca",
-        "registered_directory": "trisatest.net",
-        "common_name": "api.bob.vaspbot.net",
-        "endpoint": "api.bob.vaspbot.net:443",
-        "name": "BobVASP",
-        "website": "https://bob.vaspbot.net/",
-        "country": "GB",
-        "business_category": "PRIVATE_ORGANIZATION",
-        "vasp_categories": [
-          "Exchange"
-        ],
-        "verified_on": "",
-        "status": "VERIFIED"
-      },
-      "legal_person": {
-        "name": {
-          "name_identifiers": [
-            {
-              "legal_person_name": "Bob's Discount VASP, PLC",
-              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
-            },
-            {
-              "legal_person_name": "BobVASP",
-              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
-            }
-          ],
-          "local_name_identifiers": [],
-          "phonetic_name_identifiers": []
+  "member_summary": {
+    "id": "9e069e01-8515-4d57-b9a5-e249f7ab4fca",
+    "registered_directory": "trisatest.net",
+    "common_name": "api.bob.vaspbot.net",
+    "endpoint": "api.bob.vaspbot.net:443",
+    "name": "BobVASP",
+    "website": "https://bob.vaspbot.net/",
+    "country": "GB",
+    "business_category": "PRIVATE_ORGANIZATION",
+    "vasp_categories": [
+      "Exchange"
+    ],
+    "verified_on": "",
+    "status": "VERIFIED"
+  },
+  "legal_person": {
+    "name": {
+      "name_identifiers": [
+        {
+          "legal_person_name": "Bob's Discount VASP, PLC",
+          "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
         },
-        "geographic_addresses": [
-          {
-            "address_type": "ADDRESS_TYPE_CODE_BIZZ",
-            "department": "",
-            "sub_department": "",
-            "street_name": "Grimsby Road",
-            "building_number": "762",
-            "building_name": "",
-            "floor": "",
-            "post_box": "",
-            "room": "",
-            "post_code": "OX8 U89",
-            "town_name": "Oxford",
-            "town_location_name": "",
-            "district_name": "",
-            "country_sub_division": "",
-            "address_line": [],
-            "country": "GB"
-          }
-        ],
-        "customer_number": "",
-        "national_identification": {
-          "national_identifier": "213800AQUAUP6I215N33",
-          "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
-          "country_of_issue": "GB",
-          "registration_authority": "RA000589"
-        },
-        "country_of_registration": "GB"
-      },
-      "contacts": {
-        "technical": {
-          "name": "Naz Hill",
-          "email": "nhill@testing.net",
-          "phone": "000-123-4567"
-        },
-        "legal": {
-          "name": "Candy Parker",
-          "email": "cparker@testing.net",
-          "phone": "000-111-2233"
+        {
+          "legal_person_name": "BobVASP",
+          "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
         }
-      },
-      "trixo": {
-        "primary_national_jurisdiction": "GB",
-        "primary_regulator": "Financial Conduct Authority",
-        "financial_transfers_permitted": "yes",
-        "other_jurisdictions": [],
-        "has_required_regulatory_program": "yes",
-        "conducts_customer_kyc": true,
-        "kyc_threshold": 100,
-        "kyc_threshold_currency": "USD",
-        "must_comply_travel_rule": false,
-        "applicable_regulations": [
-          "Legal statement on cryptoassets and smart contracts",
-          "FCA Cryptoassets: AML / CTF regime"
-        ],
-        "compliance_threshold": 10000,
-        "compliance_threshold_currency": "USD",
-        "must_safeguard_pii": true,
-        "safeguards_pii": true
+      ],
+      "local_name_identifiers": [],
+      "phonetic_name_identifiers": []
+    },
+    "geographic_addresses": [
+      {
+        "address_type": "ADDRESS_TYPE_CODE_BIZZ",
+        "department": "",
+        "sub_department": "",
+        "street_name": "Grimsby Road",
+        "building_number": "762",
+        "building_name": "",
+        "floor": "",
+        "post_box": "",
+        "room": "",
+        "post_code": "OX8 U89",
+        "town_name": "Oxford",
+        "town_location_name": "",
+        "district_name": "",
+        "country_sub_division": "",
+        "address_line": [],
+        "country": "GB"
       }
+    ],
+    "customer_number": "",
+    "national_identification": {
+      "national_identifier": "213800AQUAUP6I215N33",
+      "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
+      "country_of_issue": "GB",
+      "registration_authority": "RA000589"
+    },
+    "country_of_registration": "GB"
+  },
+  "contacts": {
+    "technical": {
+      "name": "Naz Hill",
+      "email": "nhill@testing.net",
+      "phone": "000-123-4567"
+    },
+    "legal": {
+      "name": "Candy Parker",
+      "email": "cparker@testing.net",
+      "phone": "000-111-2233"
+    }
+  },
+  "trixo": {
+    "primary_national_jurisdiction": "GB",
+    "primary_regulator": "Financial Conduct Authority",
+    "financial_transfers_permitted": "yes",
+    "other_jurisdictions": [],
+    "has_required_regulatory_program": "yes",
+    "conducts_customer_kyc": true,
+    "kyc_threshold": 100,
+    "kyc_threshold_currency": "USD",
+    "must_comply_travel_rule": false,
+    "applicable_regulations": [
+      "Legal statement on cryptoassets and smart contracts",
+      "FCA Cryptoassets: AML / CTF regime"
+    ],
+    "compliance_threshold": 10000,
+    "compliance_threshold_currency": "USD",
+    "must_safeguard_pii": true,
+    "safeguards_pii": true
+  }
 }

--- a/pkg/bff/testdata/testnet/details_reply.json
+++ b/pkg/bff/testdata/testnet/details_reply.json
@@ -1,96 +1,96 @@
 {
-    "summary": {
-        "id": "7a96ca2c-2818-4106-932e-1bcfd743b04c",
-        "registered_directory": "trisatest.net",
-        "common_name": "api.alice.vaspbot.net",
-        "endpoint": "api.alice.vaspbot.net:443",
-        "name": "AliceCoin",
-        "website": "https://alice.vaspbot.net/",
-        "country": "US",
-        "business_category": "PRIVATE_ORGANIZATION",
-        "vasp_categories": [
-          "Exchange"
-        ],
-        "verified_on": "",
-        "status": "VERIFIED"
-      },
-      "legal_person": {
-        "name": {
-          "name_identifiers": [
-            {
-              "legal_person_name": "AliceCoin, Inc.",
-              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
-            },
-            {
-              "legal_person_name": "AliceVASP",
-              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
-            },
-            {
-              "legal_person_name": "AliceCoin",
-              "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_TRAD"
-            }
-          ],
-          "local_name_identifiers": [],
-          "phonetic_name_identifiers": []
+  "member_summary": {
+    "id": "7a96ca2c-2818-4106-932e-1bcfd743b04c",
+    "registered_directory": "trisatest.net",
+    "common_name": "api.alice.vaspbot.net",
+    "endpoint": "api.alice.vaspbot.net:443",
+    "name": "AliceCoin",
+    "website": "https://alice.vaspbot.net/",
+    "country": "US",
+    "business_category": "PRIVATE_ORGANIZATION",
+    "vasp_categories": [
+      "Exchange"
+    ],
+    "verified_on": "",
+    "status": "VERIFIED"
+  },
+  "legal_person": {
+    "name": {
+      "name_identifiers": [
+        {
+          "legal_person_name": "AliceCoin, Inc.",
+          "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_LEGL"
         },
-        "geographic_addresses": [
-          {
-            "address_type": "ADDRESS_TYPE_CODE_BIZZ",
-            "department": "",
-            "sub_department": "",
-            "street_name": "Roosevelt Place",
-            "building_number": "23",
-            "building_name": "",
-            "floor": "",
-            "post_box": "",
-            "room": "",
-            "post_code": "02151",
-            "town_name": "Boston",
-            "town_location_name": "",
-            "district_name": "",
-            "country_sub_division": "MA",
-            "address_line": [],
-            "country": "US"
-          }
-        ],
-        "customer_number": "",
-        "national_identification": {
-          "national_identifier": "5493004YBI24IF4TIP92",
-          "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
-          "country_of_issue": "US",
-          "registration_authority": "RA000744"
+        {
+          "legal_person_name": "AliceVASP",
+          "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_SHRT"
         },
-        "country_of_registration": "US"
-      },
-      "contacts": {
-        "technical": {
-          "name": "Ry Howard",
-          "email": "rhoward@testing.net",
-          "phone": "000-123-4567"
-        },
-        "legal": {
-          "name": "Al Gray",
-          "email": "agray@testing.net",
-          "phone": "000-111-2233"
+        {
+          "legal_person_name": "AliceCoin",
+          "legal_person_name_identifier_type": "LEGAL_PERSON_NAME_TYPE_CODE_TRAD"
         }
-      },
-      "trixo": {
-        "primary_national_jurisdiction": "US",
-        "primary_regulator": "FinCEN",
-        "financial_transfers_permitted": "yes",
-        "other_jurisdictions": [],
-        "has_required_regulatory_program": "yes",
-        "conducts_customer_kyc": true,
-        "kyc_threshold": 10000,
-        "kyc_threshold_currency": "USD",
-        "must_comply_travel_rule": true,
-        "applicable_regulations": [
-          "BSA Travel Rule – 31 CFR 103.33(g)",
-          "FATF Travel Rule"
-        ],
-        "compliance_threshold": 10000,
-        "compliance_threshold_currency": "USD",
-        "must_safeguard_pii": false,
-        "safeguards_pii": true
+      ],
+      "local_name_identifiers": [],
+      "phonetic_name_identifiers": []
+    },
+    "geographic_addresses": [
+      {
+        "address_type": "ADDRESS_TYPE_CODE_BIZZ",
+        "department": "",
+        "sub_department": "",
+        "street_name": "Roosevelt Place",
+        "building_number": "23",
+        "building_name": "",
+        "floor": "",
+        "post_box": "",
+        "room": "",
+        "post_code": "02151",
+        "town_name": "Boston",
+        "town_location_name": "",
+        "district_name": "",
+        "country_sub_division": "MA",
+        "address_line": [],
+        "country": "US"
       }
+    ],
+    "customer_number": "",
+    "national_identification": {
+      "national_identifier": "5493004YBI24IF4TIP92",
+      "national_identifier_type": "NATIONAL_IDENTIFIER_TYPE_CODE_LEIX",
+      "country_of_issue": "US",
+      "registration_authority": "RA000744"
+    },
+    "country_of_registration": "US"
+  },
+  "contacts": {
+    "technical": {
+      "name": "Ry Howard",
+      "email": "rhoward@testing.net",
+      "phone": "000-123-4567"
+    },
+    "legal": {
+      "name": "Al Gray",
+      "email": "agray@testing.net",
+      "phone": "000-111-2233"
+    }
+  },
+  "trixo": {
+    "primary_national_jurisdiction": "US",
+    "primary_regulator": "FinCEN",
+    "financial_transfers_permitted": "yes",
+    "other_jurisdictions": [],
+    "has_required_regulatory_program": "yes",
+    "conducts_customer_kyc": true,
+    "kyc_threshold": 10000,
+    "kyc_threshold_currency": "USD",
+    "must_comply_travel_rule": true,
+    "applicable_regulations": [
+      "BSA Travel Rule – 31 CFR 103.33(g)",
+      "FATF Travel Rule"
+    ],
+    "compliance_threshold": 10000,
+    "compliance_threshold_currency": "USD",
+    "must_safeguard_pii": false,
+    "safeguards_pii": true
+  }
 }


### PR DESCRIPTION
### Scope of changes

This rewires the VASP summary in the member details response so that protobuf enums show up as strings in the response rather than the number.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


