### PR TITLE
Added stub network activity data bff endpoint

### DIFF
--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -20,7 +20,7 @@ type BFFClient interface {
 	Lookup(context.Context, *LookupParams) (*LookupReply, error)
 	LookupAutocomplete(context.Context) (map[string]string, error)
 	VerifyContact(context.Context, *VerifyContactParams) (*VerifyContactReply, error)
-	GetNetworkActivity(context.Context) (*NetworkActivityReply, error)
+	NetworkActivity(context.Context) (*NetworkActivityReply, error)
 
 	// User Management Endpoints
 	Login(context.Context, *LoginParams) error

--- a/pkg/bff/api/v1/api.go
+++ b/pkg/bff/api/v1/api.go
@@ -20,6 +20,7 @@ type BFFClient interface {
 	Lookup(context.Context, *LookupParams) (*LookupReply, error)
 	LookupAutocomplete(context.Context) (map[string]string, error)
 	VerifyContact(context.Context, *VerifyContactParams) (*VerifyContactReply, error)
+	GetNetworkActivity(context.Context) (*NetworkActivityReply, error)
 
 	// User Management Endpoints
 	Login(context.Context, *LoginParams) error
@@ -388,4 +389,18 @@ type AttentionMessage struct {
 type NetworkError struct {
 	TestNet string `json:"testnet,omitempty"`
 	MainNet string `json:"mainnet,omitempty"`
+}
+
+// Activity is a time-aggregated collection of events (Search, Lookup, etc)
+type Activity struct {
+	Date   string `json:"date"`
+	Events int    `json:"events"`
+}
+
+// NetworkActivityReply is a map of the network (TestNet or MainNet) to Activity,
+// which is a time-aggregated collection of events (Search, Lookup, etc)
+// that occurred on the network
+type NetworkActivityReply struct {
+	TestNet []Activity `json:"testnet"`
+	MainNet []Activity `json:"mainnet"`
 }

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -612,6 +612,21 @@ func (s *APIv1) Attention(ctx context.Context) (out *AttentionReply, err error) 
 	return out, nil
 }
 
+func (s *APIv1) GetNetworkActivity(ctx context.Context) (out *NetworkActivityReply, err error) {
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/network/activity", nil, nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &NetworkActivityReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 //===========================================================================
 // Helper Methods
 //===========================================================================

--- a/pkg/bff/api/v1/client.go
+++ b/pkg/bff/api/v1/client.go
@@ -612,7 +612,7 @@ func (s *APIv1) Attention(ctx context.Context) (out *AttentionReply, err error) 
 	return out, nil
 }
 
-func (s *APIv1) GetNetworkActivity(ctx context.Context) (out *NetworkActivityReply, err error) {
+func (s *APIv1) NetworkActivity(ctx context.Context) (out *NetworkActivityReply, err error) {
 	// Make the HTTP request
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/network/activity", nil, nil); err != nil {

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -1130,7 +1130,7 @@ func TestNoAttention(t *testing.T) {
 	require.Nil(t, out)
 }
 
-func TestGetNetworkActivity(t *testing.T) {
+func TestNetworkActivity(t *testing.T) {
 	TestNetActivity := []api.Activity{
 		{
 			Date:   "Aug 21",
@@ -1173,7 +1173,7 @@ func TestGetNetworkActivity(t *testing.T) {
 	client, err := api.New(ts.URL)
 	require.NoError(t, err)
 
-	out, err := client.GetNetworkActivity(context.TODO())
+	out, err := client.NetworkActivity(context.TODO())
 	require.NoError(t, err)
 	require.Equal(t, fixture, out)
 	require.Equal(t, fixture.TestNet, out.TestNet)

--- a/pkg/bff/api/v1/client_test.go
+++ b/pkg/bff/api/v1/client_test.go
@@ -1130,6 +1130,56 @@ func TestNoAttention(t *testing.T) {
 	require.Nil(t, out)
 }
 
+func TestGetNetworkActivity(t *testing.T) {
+	TestNetActivity := []api.Activity{
+		{
+			Date:   "Aug 21",
+			Events: 10,
+		},
+		{
+			Date:   "Aug 22",
+			Events: 20,
+		},
+	}
+
+	MainNetActivity := []api.Activity{
+		{
+			Date:   "Aug 21",
+			Events: 15,
+		},
+		{
+			Date:   "Aug 22",
+			Events: 25,
+		},
+	}
+
+	fixture := &api.NetworkActivityReply{
+		TestNet: TestNetActivity,
+		MainNet: MainNetActivity,
+	}
+
+	// Create a Test Server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/network/activity", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a Client that makes requests to the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err)
+
+	out, err := client.GetNetworkActivity(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, fixture, out)
+	require.Equal(t, fixture.TestNet, out.TestNet)
+	require.Equal(t, fixture.MainNet, out.MainNet)
+}
+
 func loadFixture(path string, v interface{}) (err error) {
 	switch t := v.(type) {
 	case proto.Message:

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -1227,6 +1227,10 @@ func (s *Server) RegistrationStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
+func (s *Server) GetNetworkActivity(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, api.ErrorResponse(fmt.Errorf("not implemented")))
+}
+
 // Checks if the user supplied registered directory is one of the known directories that
 // maps to either the testnet or to the mainnet (by domain).
 func validRegisteredDirectory(r string) bool {

--- a/pkg/bff/gds.go
+++ b/pkg/bff/gds.go
@@ -1227,7 +1227,7 @@ func (s *Server) RegistrationStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
-func (s *Server) GetNetworkActivity(c *gin.Context) {
+func (s *Server) NetworkActivity(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, api.ErrorResponse(fmt.Errorf("not implemented")))
 }
 

--- a/pkg/bff/gds_test.go
+++ b/pkg/bff/gds_test.go
@@ -1575,6 +1575,6 @@ func (s *bffTestSuite) TestRegistrationStatus() {
 	require.Equal(org.Mainnet.Submitted, reply.MainNetSubmitted, "expected mainnet timestamp to be returned")
 }
 
-func (s *bffTestSuite) TestGetNetworkActivity() {
+func (s *bffTestSuite) TestNetworkActivity() {
 	s.T().Skip("not implemented yet")
 }

--- a/pkg/bff/gds_test.go
+++ b/pkg/bff/gds_test.go
@@ -1574,3 +1574,7 @@ func (s *bffTestSuite) TestRegistrationStatus() {
 	require.Equal(org.Testnet.Submitted, reply.TestNetSubmitted, "expected testnet timestamp to be returned")
 	require.Equal(org.Mainnet.Submitted, reply.MainNetSubmitted, "expected mainnet timestamp to be returned")
 }
+
+func (s *bffTestSuite) TestGetNetworkActivity() {
+	s.T().Skip("not implemented yet")
+}

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -367,6 +367,7 @@ func (s *Server) setupRoutes() (err error) {
 		v1.GET("/verify", s.VerifyContact)
 		v1.POST("/users/login", userinfo, s.Login)
 		v1.GET("/users/roles", s.ListUserRoles)
+		v1.GET("/network/activity", s.GetNetworkActivity)
 
 		// Authenticated routes
 		// Logged-in user queries and updates

--- a/pkg/bff/server.go
+++ b/pkg/bff/server.go
@@ -372,7 +372,7 @@ func (s *Server) setupRoutes() (err error) {
 		v1.GET("/verify", s.VerifyContact)
 		v1.POST("/users/login", userinfo, s.Login)
 		v1.GET("/users/roles", s.ListUserRoles)
-		v1.GET("/network/activity", s.GetNetworkActivity)
+		v1.GET("/network/activity", s.NetworkActivity)
 
 		// Authenticated routes
 		// Logged-in user queries and updates


### PR DESCRIPTION
### Scope of changes

This PR resolves SC-20290 which asked to add a new stub BFF endpoint that the front end will use to display the activities that take place on TestNet and MainNet (Search, Lookup).

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


