### PR TITLE
Add webhook delivery to certman

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/secretmanager v1.11.2
 	github.com/auth0/go-jwt-middleware/v2 v2.1.0
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/getsentry/sentry-go v0.22.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/cors v1.4.0
@@ -35,7 +36,7 @@ require (
 	github.com/swaggo/swag v1.16.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/trisacrypto/courier v0.0.0-20231106194613-8a8d8b5a1d91
-	github.com/trisacrypto/trisa v0.4.1-0.20231128161148-4bca000b2a54
+	github.com/trisacrypto/trisa v0.4.1
 	github.com/urfave/cli v1.22.14
 	github.com/urfave/cli/v2 v2.25.7
 	github.com/vmihailenco/msgpack/v5 v5.3.5
@@ -54,7 +55,6 @@ require (
 	github.com/PuerkitoBio/rehttp v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.9.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/swaggo/swag v1.16.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/trisacrypto/courier v0.0.0-20231106194613-8a8d8b5a1d91
-	github.com/trisacrypto/trisa v0.4.0
+	github.com/trisacrypto/trisa v0.4.1-0.20231128161148-4bca000b2a54
 	github.com/urfave/cli v1.22.14
 	github.com/urfave/cli/v2 v2.25.7
 	github.com/vmihailenco/msgpack/v5 v5.3.5

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,8 @@ github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKz
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
-github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/rehttp v1.2.0 h1:V8MGVcDwR+u/xwLlMrw5YZONDm3JISEKqwJTiIuJA+s=
 github.com/PuerkitoBio/rehttp v1.2.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -136,7 +134,6 @@ github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclK
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -256,7 +253,6 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -264,7 +260,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.9/go.mod h1:12HJgwBIZFNGL0EJnMRhmvGA0PQGx8VFwrZtM4CqbAk=
 github.com/kataras/iris/v12 v12.0.1/go.mod h1:udK4vLQKkdDqMGJJVd/msuMtN6hpYJhg/lSzuxjhO+U=
@@ -332,7 +327,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/mroth/weightedrand v1.0.0 h1:V8JeHChvl2MP1sAoXq4brElOcza+jxLkRuwvtQu8L3E=
 github.com/mroth/weightedrand v1.0.0/go.mod h1:3p2SIcC8al1YMzGhAIoXD+r9olo/g/cdJgAD905gyNE=
-github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
@@ -443,10 +437,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/trisacrypto/courier v0.0.0-20231106194613-8a8d8b5a1d91 h1:lztPBA+O79fB8aNv8/NMl4cgH0riK/cd4UMfNT7zSKA=
 github.com/trisacrypto/courier v0.0.0-20231106194613-8a8d8b5a1d91/go.mod h1:oaTJ2u1dtPO0m4lnHDFukkPI34MgAod1gHcpnR03/bY=
-github.com/trisacrypto/trisa v0.4.0 h1:0CiKrNR6slc89iYDzr9dy8lZc3LQwMfuaYy/yh4ekQw=
-github.com/trisacrypto/trisa v0.4.0/go.mod h1:19zOnzpbCs96GEyryN91Tw77dhjHNmpNlGB3bRCeB04=
-github.com/trisacrypto/trisa v0.4.1-0.20231128161148-4bca000b2a54 h1:XCXhgJLRyxW6r+7a/4YnedYpbSpmr8knqqc2dNrUBkg=
-github.com/trisacrypto/trisa v0.4.1-0.20231128161148-4bca000b2a54/go.mod h1:19zOnzpbCs96GEyryN91Tw77dhjHNmpNlGB3bRCeB04=
+github.com/trisacrypto/trisa v0.4.1 h1:6v49CfkvdwW0TWooTa/ZHPqnrxcl4qRzdk0SJGmkyxY=
+github.com/trisacrypto/trisa v0.4.1/go.mod h1:19zOnzpbCs96GEyryN91Tw77dhjHNmpNlGB3bRCeB04=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,10 @@ github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKz
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/rehttp v1.2.0 h1:V8MGVcDwR+u/xwLlMrw5YZONDm3JISEKqwJTiIuJA+s=
 github.com/PuerkitoBio/rehttp v1.2.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -134,6 +136,7 @@ github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclK
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -253,6 +256,7 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -260,6 +264,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.9/go.mod h1:12HJgwBIZFNGL0EJnMRhmvGA0PQGx8VFwrZtM4CqbAk=
 github.com/kataras/iris/v12 v12.0.1/go.mod h1:udK4vLQKkdDqMGJJVd/msuMtN6hpYJhg/lSzuxjhO+U=
@@ -327,6 +332,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/mroth/weightedrand v1.0.0 h1:V8JeHChvl2MP1sAoXq4brElOcza+jxLkRuwvtQu8L3E=
 github.com/mroth/weightedrand v1.0.0/go.mod h1:3p2SIcC8al1YMzGhAIoXD+r9olo/g/cdJgAD905gyNE=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
@@ -439,6 +445,8 @@ github.com/trisacrypto/courier v0.0.0-20231106194613-8a8d8b5a1d91 h1:lztPBA+O79f
 github.com/trisacrypto/courier v0.0.0-20231106194613-8a8d8b5a1d91/go.mod h1:oaTJ2u1dtPO0m4lnHDFukkPI34MgAod1gHcpnR03/bY=
 github.com/trisacrypto/trisa v0.4.0 h1:0CiKrNR6slc89iYDzr9dy8lZc3LQwMfuaYy/yh4ekQw=
 github.com/trisacrypto/trisa v0.4.0/go.mod h1:19zOnzpbCs96GEyryN91Tw77dhjHNmpNlGB3bRCeB04=
+github.com/trisacrypto/trisa v0.4.1-0.20231128161148-4bca000b2a54 h1:XCXhgJLRyxW6r+7a/4YnedYpbSpmr8knqqc2dNrUBkg=
+github.com/trisacrypto/trisa v0.4.1-0.20231128161148-4bca000b2a54/go.mod h1:19zOnzpbCs96GEyryN91Tw77dhjHNmpNlGB3bRCeB04=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/pkg/gds/certman/certs.go
+++ b/pkg/gds/certman/certs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/trisacrypto/courier/pkg/api/v1"
 	"github.com/trisacrypto/directory/pkg/gds/config"
 	"github.com/trisacrypto/directory/pkg/gds/emails"
 	"github.com/trisacrypto/directory/pkg/gds/secrets"
@@ -586,11 +588,21 @@ func (c *CertificateManager) downloadCertificateRequest(r *models.CertificateReq
 		return
 	}
 
-	// Email the certificates to the technical contacts
-	if _, err = c.email.SendDeliverCertificates(vasp, path); err != nil {
-		// If there is an error delivering emails, return here so we don't mark as completed
-		sentry.Error(nil).Err(err).Msg("could not deliver certificates to technical contact")
-		return
+	var deliveryErr error
+	if r.Webhook != "" {
+		// Deliver the PKCS12 password using the configured webhook.
+		if deliveryErr = c.deliverCertificatePayload(ctx, r, payload); deliveryErr != nil {
+			log.Error().Err(deliveryErr).Str("webhook", r.Webhook).Str("vasp", vasp.Id).Msg("error delivering certificate via webhook")
+		}
+	}
+
+	if !r.NoEmailDelivery || deliveryErr != nil {
+		// Ensure that the certificate is sent by email if the webhook fails
+		if _, err = c.email.SendDeliverCertificates(vasp, path); err != nil {
+			// If there is an error delivering emails, return here so we don't mark as completed
+			sentry.Error(nil).Err(err).Msg("could not deliver certificates to technical contact")
+			return
+		}
 	}
 
 	if err = c.db.UpdateVASP(ctx, vasp); err != nil {
@@ -916,14 +928,24 @@ func (c *CertificateManager) reissueIdentityCertificates(vasp *pb.VASP) (err err
 		return fmt.Errorf("error creating password version for vasp %s: %w", vasp.Id, err)
 	}
 
-	// Using the whisper utility, create a whisper link to be sent with the ReissuanceStarted email.
-	if whisperLink, err = whisper.CreateSecretLink(fmt.Sprintf(whisperPasswordTemplate, pkcs12password), "", 3, time.Now().AddDate(0, 0, 7)); err != nil {
-		return fmt.Errorf("error creating whisper link for vasp %s: %w", vasp.Id, err)
+	var deliveryErr error
+	if certreq.Webhook != "" {
+		// Deliver the PKCS12 password using the configured webhook.
+		if deliveryErr = c.deliverCertificatePassword(ctx, certreq, pkcs12password); deliveryErr != nil {
+			log.Error().Err(deliveryErr).Str("webhook", certreq.Webhook).Str("vasp", vasp.Id).Msg("error delivering pkcs12 password via webhook")
+		}
 	}
 
-	// Send the notification email that certificate reissuance is forthcoming and provide whisper link to the PKCS12 password.
-	if _, err = c.email.SendReissuanceStarted(vasp, whisperLink); err != nil {
-		return fmt.Errorf("error sending reissuance started email for vasp %s: %w", vasp.Id, err)
+	if !certreq.NoEmailDelivery || deliveryErr != nil {
+		// Ensure the password is sent by email even if the webhook fails.
+		if whisperLink, err = whisper.CreateSecretLink(fmt.Sprintf(whisperPasswordTemplate, pkcs12password), "", 3, time.Now().AddDate(0, 0, 7)); err != nil {
+			return fmt.Errorf("error creating whisper link for vasp %s: %w", vasp.Id, err)
+		}
+
+		// Send the notification email that certificate reissuance is forthcoming and provide whisper link to the PKCS12 password.
+		if _, err = c.email.SendReissuanceStarted(vasp, whisperLink); err != nil {
+			return fmt.Errorf("error sending reissuance started email for vasp %s: %w", vasp.Id, err)
+		}
 	}
 
 	// Update the certificate request in the datastore.
@@ -941,4 +963,78 @@ func (c *CertificateManager) reissueIdentityCertificates(vasp *pb.VASP) (err err
 		return fmt.Errorf("error updating vasp %s in the certman store: %w", vasp.Id, err)
 	}
 	return nil
+}
+
+// Attempt to deliver a certificate password by webhook using the configured backoff
+// strategy or return an error if the maximum number of retries was exceeded.
+func (c *CertificateManager) deliverCertificatePassword(ctx context.Context, certreq *models.CertificateRequest, password string) (err error) {
+	// Create the client to deliver the password.
+	var client api.CourierClient
+	if client, err = api.New(certreq.Webhook); err != nil {
+		return fmt.Errorf("could not create courier client for pkcs12 password delivery: %s", err)
+	}
+
+	req := &api.StorePasswordRequest{
+		ID:       certreq.Id,
+		Password: password,
+	}
+
+	// Attempt to deliver the password using the configured backoff strategy.
+	wait := c.conf.DeliveryBackoff.Ticker()
+	defer wait.Stop()
+
+	// Wait for the context to be cancelled or the password to be delivered.
+	var retries int
+	for retries = 0; retries < c.conf.DeliveryBackoff.MaxRetries+1; retries++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-wait.C:
+			if err = client.StoreCertificatePassword(ctx, req); err != nil {
+				log.Warn().Err(err).Int("attempts", retries+1).Str("webhook", certreq.Webhook).Msg("could not deliver certificate password, retrying")
+				continue
+			}
+			return nil
+		}
+	}
+
+	// Exceeded the maximum number of retries
+	return fmt.Errorf("could not deliver certificate password after %d retries", retries)
+}
+
+// Deliver a certificate payload by webhook using the configured backoff strategy or
+// return an error if the maximum number of retries was exceeded.
+func (c *CertificateManager) deliverCertificatePayload(ctx context.Context, certreq *models.CertificateRequest, payload []byte) (err error) {
+	// Create the client to deliver the password.
+	var client api.CourierClient
+	if client, err = api.New(certreq.Webhook); err != nil {
+		return fmt.Errorf("could not create courier client for certificate delivery: %s", err)
+	}
+
+	req := &api.StoreCertificateRequest{
+		ID:                certreq.Id,
+		Base64Certificate: base64.StdEncoding.EncodeToString(payload),
+	}
+
+	// Attempt to deliver the password using the configured backoff strategy.
+	wait := c.conf.DeliveryBackoff.Ticker()
+	defer wait.Stop()
+
+	// Wait for the context to be cancelled or the password to be delivered.
+	var retries int
+	for retries = 0; retries < c.conf.DeliveryBackoff.MaxRetries+1; retries++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-wait.C:
+			if err = client.StoreCertificate(ctx, req); err != nil {
+				log.Warn().Err(err).Int("attempts", retries+1).Str("webhook", certreq.Webhook).Msg("could not deliver encrypted certificate, retrying")
+				continue
+			}
+			return nil
+		}
+	}
+
+	// Exceeded the maximum number of retries
+	return fmt.Errorf("could not deliver encrypted certificate after %d retries", retries)
 }

--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -13,69 +13,75 @@ import (
 )
 
 var testEnv = map[string]string{
-	"GDS_MAINTENANCE":                          "false",
-	"GDS_DIRECTORY_ID":                         "testdirectory.org",
-	"GDS_SECRET_KEY":                           "theeaglefliesatmidnight",
-	"GDS_LOG_LEVEL":                            "debug",
-	"GDS_CONSOLE_LOG":                          "true",
-	"GDS_API_ENABLED":                          "true",
-	"GDS_BIND_ADDR":                            ":443",
-	"GDS_ADMIN_ENABLED":                        "true",
-	"GDS_ADMIN_BIND_ADDR":                      ":444",
-	"GDS_ADMIN_MODE":                           "debug",
-	"GDS_ADMIN_TOKEN_KEYS":                     "1y9fT85qWaIvAAORW7DKxtpz9FB:testdata/key1.pem,1y9fVjaUlsVdFFDUWlvRq2PLkw3:testdata/key2.pem",
-	"GDS_ADMIN_OAUTH_GOOGLE_AUDIENCE":          "abc-1234.example.fakegoogleusercontent.com",
-	"GDS_ADMIN_OAUTH_AUTHORIZED_EMAIL_DOMAINS": "trisa.io,vaspdirectory.net,trisatest.net",
-	"GDS_ADMIN_ALLOW_ORIGINS":                  "https://admin.trisatest.net",
-	"GDS_ADMIN_COOKIE_DOMAIN":                  "admin.trisatest.net",
-	"GDS_ADMIN_AUDIENCE":                       "https://api.admin.trisatest.net",
-	"GDS_MEMBERS_ENABLED":                      "true",
-	"GDS_MEMBERS_BIND_ADDR":                    ":445",
-	"GDS_MEMBERS_INSECURE":                     "true",
-	"GDS_MEMBERS_CERTS":                        "fixtures/creds/gds.gz",
-	"GDS_MEMBERS_CERT_POOL":                    "fixtures/creds/pool.gz",
-	"GDS_DATABASE_URL":                         "trtl://trtl.test:4436",
-	"GDS_DATABASE_REINDEX_ON_BOOT":             "false",
-	"GDS_DATABASE_INSECURE":                    "true",
-	"GDS_DATABASE_CERT_PATH":                   "fixtures/creds/certs.pem",
-	"GDS_DATABASE_POOL_PATH":                   "fixtures/creds/pool.zip",
-	"SECTIGO_USERNAME":                         "foo",
-	"SECTIGO_PASSWORD":                         "supersecret",
-	"SECTIGO_PROFILE":                          "17",
-	"SECTIGO_ENVIRONMENT":                      "staging",
-	"SECTIGO_ENDPOINT":                         "https://cathy.io",
-	"GDS_SERVICE_EMAIL":                        "test@example.com",
-	"GDS_ADMIN_EMAIL":                          "admin@example.com",
-	"SENDGRID_API_KEY":                         "bar1234",
-	"GDS_VERIFY_CONTACT_URL":                   "http://localhost:3000/verify",
-	"GDS_ADMIN_REVIEW_URL":                     "http://localhost:3001/vasps/",
-	"GDS_EMAIL_TESTING":                        "true",
-	"GDS_EMAIL_STORAGE":                        "fixtures/emails",
-	"GDS_CERTMAN_ENABLED":                      "false",
-	"GDS_CERTMAN_REQUEST_INTERVAL":             "60s",
-	"GDS_CERTMAN_REISSUANCE_INTERVAL":          "90s",
-	"GDS_CERTMAN_STORAGE":                      "fixtures/certs",
-	"GDS_BACKUP_ENABLED":                       "true",
-	"GDS_BACKUP_INTERVAL":                      "36h",
-	"GDS_BACKUP_STORAGE":                       "fixtures/backups",
-	"GDS_BACKUP_KEEP":                          "7",
-	"GOOGLE_APPLICATION_CREDENTIALS":           "test.json",
-	"GOOGLE_PROJECT_NAME":                      "test",
-	"GDS_SECRETS_TESTING":                      "true",
-	"GDS_SENTRY_DSN":                           "https://something.ingest.sentry.io",
-	"GDS_SENTRY_ENVIRONMENT":                   "test",
-	"GDS_SENTRY_RELEASE":                       "1.4",
-	"GDS_SENTRY_DEBUG":                         "true",
-	"GDS_SENTRY_TRACK_PERFORMANCE":             "true",
-	"GDS_SENTRY_SAMPLE_RATE":                   "0.2",
-	"GDS_ACTIVITY_ENABLED":                     "true",
-	"GDS_ACTIVITY_TOPIC":                       "gds-activity",
-	"GDS_ACTIVITY_AGGREGATION_WINDOW":          "10m",
-	"GDS_ACTIVITY_ENSIGN_CLIENT_ID":            "client-id",
-	"GDS_ACTIVITY_ENSIGN_CLIENT_SECRET":        "client-secret",
-	"GDS_ACTIVITY_ENSIGN_ENDPOINT":             "api.ensign.world:443",
-	"GDS_ACTIVITY_ENSIGN_AUTH_URL":             "https://auth.ensign.world",
-	"GDS_ACTIVITY_ENSIGN_INSECURE":             "true",
+	"GDS_MAINTENANCE":                                   "false",
+	"GDS_DIRECTORY_ID":                                  "testdirectory.org",
+	"GDS_SECRET_KEY":                                    "theeaglefliesatmidnight",
+	"GDS_LOG_LEVEL":                                     "debug",
+	"GDS_CONSOLE_LOG":                                   "true",
+	"GDS_API_ENABLED":                                   "true",
+	"GDS_BIND_ADDR":                                     ":443",
+	"GDS_ADMIN_ENABLED":                                 "true",
+	"GDS_ADMIN_BIND_ADDR":                               ":444",
+	"GDS_ADMIN_MODE":                                    "debug",
+	"GDS_ADMIN_TOKEN_KEYS":                              "1y9fT85qWaIvAAORW7DKxtpz9FB:testdata/key1.pem,1y9fVjaUlsVdFFDUWlvRq2PLkw3:testdata/key2.pem",
+	"GDS_ADMIN_OAUTH_GOOGLE_AUDIENCE":                   "abc-1234.example.fakegoogleusercontent.com",
+	"GDS_ADMIN_OAUTH_AUTHORIZED_EMAIL_DOMAINS":          "trisa.io,vaspdirectory.net,trisatest.net",
+	"GDS_ADMIN_ALLOW_ORIGINS":                           "https://admin.trisatest.net",
+	"GDS_ADMIN_COOKIE_DOMAIN":                           "admin.trisatest.net",
+	"GDS_ADMIN_AUDIENCE":                                "https://api.admin.trisatest.net",
+	"GDS_MEMBERS_ENABLED":                               "true",
+	"GDS_MEMBERS_BIND_ADDR":                             ":445",
+	"GDS_MEMBERS_INSECURE":                              "true",
+	"GDS_MEMBERS_CERTS":                                 "fixtures/creds/gds.gz",
+	"GDS_MEMBERS_CERT_POOL":                             "fixtures/creds/pool.gz",
+	"GDS_DATABASE_URL":                                  "trtl://trtl.test:4436",
+	"GDS_DATABASE_REINDEX_ON_BOOT":                      "false",
+	"GDS_DATABASE_INSECURE":                             "true",
+	"GDS_DATABASE_CERT_PATH":                            "fixtures/creds/certs.pem",
+	"GDS_DATABASE_POOL_PATH":                            "fixtures/creds/pool.zip",
+	"SECTIGO_USERNAME":                                  "foo",
+	"SECTIGO_PASSWORD":                                  "supersecret",
+	"SECTIGO_PROFILE":                                   "17",
+	"SECTIGO_ENVIRONMENT":                               "staging",
+	"SECTIGO_ENDPOINT":                                  "https://cathy.io",
+	"GDS_SERVICE_EMAIL":                                 "test@example.com",
+	"GDS_ADMIN_EMAIL":                                   "admin@example.com",
+	"SENDGRID_API_KEY":                                  "bar1234",
+	"GDS_VERIFY_CONTACT_URL":                            "http://localhost:3000/verify",
+	"GDS_ADMIN_REVIEW_URL":                              "http://localhost:3001/vasps/",
+	"GDS_EMAIL_TESTING":                                 "true",
+	"GDS_EMAIL_STORAGE":                                 "fixtures/emails",
+	"GDS_CERTMAN_ENABLED":                               "false",
+	"GDS_CERTMAN_REQUEST_INTERVAL":                      "60s",
+	"GDS_CERTMAN_REISSUANCE_INTERVAL":                   "90s",
+	"GDS_CERTMAN_STORAGE":                               "fixtures/certs",
+	"GDS_CERTMAN_DELIVERY_BACKOFF_INITIAL_INTERVAL":     "1s",
+	"GDS_CERTMAN_DELIVERY_BACKOFF_RANDOMIZATION_FACTOR": "0.5",
+	"GDS_CERTMAN_DELIVERY_BACKOFF_MULTIPLIER":           "2",
+	"GDS_CERTMAN_DELIVERY_BACKOFF_MAX_INTERVAL":         "1m",
+	"GDS_CERTMAN_DELIVERY_BACKOFF_MAX_ELAPSED_TIME":     "5m",
+	"GDS_CERTMAN_DELIVERY_BACKOFF_MAX_RETRIES":          "5",
+	"GDS_BACKUP_ENABLED":                                "true",
+	"GDS_BACKUP_INTERVAL":                               "36h",
+	"GDS_BACKUP_STORAGE":                                "fixtures/backups",
+	"GDS_BACKUP_KEEP":                                   "7",
+	"GOOGLE_APPLICATION_CREDENTIALS":                    "test.json",
+	"GOOGLE_PROJECT_NAME":                               "test",
+	"GDS_SECRETS_TESTING":                               "true",
+	"GDS_SENTRY_DSN":                                    "https://something.ingest.sentry.io",
+	"GDS_SENTRY_ENVIRONMENT":                            "test",
+	"GDS_SENTRY_RELEASE":                                "1.4",
+	"GDS_SENTRY_DEBUG":                                  "true",
+	"GDS_SENTRY_TRACK_PERFORMANCE":                      "true",
+	"GDS_SENTRY_SAMPLE_RATE":                            "0.2",
+	"GDS_ACTIVITY_ENABLED":                              "true",
+	"GDS_ACTIVITY_TOPIC":                                "gds-activity",
+	"GDS_ACTIVITY_AGGREGATION_WINDOW":                   "10m",
+	"GDS_ACTIVITY_ENSIGN_CLIENT_ID":                     "client-id",
+	"GDS_ACTIVITY_ENSIGN_CLIENT_SECRET":                 "client-secret",
+	"GDS_ACTIVITY_ENSIGN_ENDPOINT":                      "api.ensign.world:443",
+	"GDS_ACTIVITY_ENSIGN_AUTH_URL":                      "https://auth.ensign.world",
+	"GDS_ACTIVITY_ENSIGN_INSECURE":                      "true",
 }
 
 func TestConfig(t *testing.T) {
@@ -140,6 +146,12 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, 1*time.Minute, conf.CertMan.RequestInterval)
 	require.Equal(t, 90*time.Second, conf.CertMan.ReissuanceInterval)
 	require.Equal(t, testEnv["GDS_CERTMAN_STORAGE"], conf.CertMan.Storage)
+	require.Equal(t, 1*time.Second, conf.CertMan.DeliveryBackoff.InitialInterval)
+	require.Equal(t, .5, conf.CertMan.DeliveryBackoff.RandomizationFactor)
+	require.Equal(t, 2.0, conf.CertMan.DeliveryBackoff.Multiplier)
+	require.Equal(t, 1*time.Minute, conf.CertMan.DeliveryBackoff.MaxInterval)
+	require.Equal(t, 5*time.Minute, conf.CertMan.DeliveryBackoff.MaxElapsedTime)
+	require.Equal(t, 5, conf.CertMan.DeliveryBackoff.MaxRetries)
 	require.Equal(t, testEnv["GDS_DIRECTORY_ID"], conf.CertMan.DirectoryID)
 	require.Equal(t, true, conf.Backup.Enabled)
 	require.Equal(t, 36*time.Hour, conf.Backup.Interval)
@@ -330,6 +342,62 @@ func TestMembersConfigValidation(t *testing.T) {
 	conf.Insecure = false
 	err = conf.Validate()
 	require.EqualError(t, err, "invalid configuration: serving mTLS requires the path to certs and the cert pool")
+}
+
+func TestBackoffConfigValidation(t *testing.T) {
+	t.Run("NegativeInitialInterval", func(t *testing.T) {
+		conf := config.BackoffConfig{
+			InitialInterval: -1 * time.Second,
+		}
+		require.EqualError(t, conf.Validate(), "invalid configuration: initial interval must be greater than or equal to 0")
+	})
+
+	t.Run("NegativeRandomizationFactor", func(t *testing.T) {
+		conf := config.BackoffConfig{
+			RandomizationFactor: -0.5,
+		}
+		require.EqualError(t, conf.Validate(), "invalid configuration: randomization factor must be greater than or equal to 0")
+	})
+
+	t.Run("NegativeMultiplier", func(t *testing.T) {
+		conf := config.BackoffConfig{
+			Multiplier: -1,
+		}
+		require.EqualError(t, conf.Validate(), "invalid configuration: multiplier must be greater than or equal to 0")
+	})
+
+	t.Run("NegativeMaxInterval", func(t *testing.T) {
+		conf := config.BackoffConfig{
+			MaxInterval: -1 * time.Second,
+		}
+		require.EqualError(t, conf.Validate(), "invalid configuration: max interval must be greater than or equal to 0")
+	})
+
+	t.Run("NegativeMaxElapsedTime", func(t *testing.T) {
+		conf := config.BackoffConfig{
+			MaxElapsedTime: -1 * time.Second,
+		}
+		require.EqualError(t, conf.Validate(), "invalid configuration: max elapsed time must be greater than or equal to 0")
+	})
+
+	t.Run("NegativeMaxRetries", func(t *testing.T) {
+		conf := config.BackoffConfig{
+			MaxRetries: -1,
+		}
+		require.EqualError(t, conf.Validate(), "invalid configuration: max retries must be greater than or equal to 0")
+	})
+
+	t.Run("ValidConfig", func(t *testing.T) {
+		conf := config.BackoffConfig{
+			InitialInterval:     1 * time.Second,
+			RandomizationFactor: 0.5,
+			Multiplier:          2,
+			MaxInterval:         1 * time.Minute,
+			MaxElapsedTime:      5 * time.Minute,
+			MaxRetries:          5,
+		}
+		require.NoError(t, conf.Validate())
+	})
 }
 
 // Returns the current environment for the specified keys, or if no keys are specified

--- a/pkg/models/v1/models.go
+++ b/pkg/models/v1/models.go
@@ -479,12 +479,13 @@ func NewCertificateRequest(vasp *pb.VASP) (certRequest *CertificateRequest, err 
 		return nil, errors.New("must supply a VASP object for certificate request creation")
 	}
 
-	// TODO: Copy the certificate delivery preferences from the VASP to the certificate request
 	certRequest = &CertificateRequest{
-		Id:         uuid.New().String(),
-		Vasp:       vasp.Id,
-		CommonName: vasp.CommonName,
-		Params:     make(map[string]string),
+		Id:              uuid.New().String(),
+		Vasp:            vasp.Id,
+		CommonName:      vasp.CommonName,
+		Params:          make(map[string]string),
+		Webhook:         vasp.CertificateWebhook,
+		NoEmailDelivery: vasp.NoEmailDelivery,
 	}
 
 	// Populate the organization name, if available.


### PR DESCRIPTION
### Scope of changes

This adds webhook delivery functionality to certman. If the VASP has a webhook URL then certman will attempt to deliver pkcs12 passwords and certificates by webhook, in addition to emailing them. If the VASP has the `NoEmailDelivery` flag set then the password and certificate emails are not sent, unless the webhook delivery fails.

Certman now has a backoff configuration for webhook delivery. If the webhook request is unsuccessful then by default it retries after the backoff period up to the maximum number of retries before giving up.

### Type of change

- [ ] bug fix
- [x] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Retry logic should be checked for correctness and we may need to tag the trisa repo to ensure that the dependency is stable.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


