### PR TITLE
Removes empty scrollbars and sets overflow value to auto

### DIFF
--- a/web/gds-user-ui/src/components/Collaborators/index.tsx
+++ b/web/gds-user-ui/src/components/Collaborators/index.tsx
@@ -130,7 +130,7 @@ const CollaboratorsSection: React.FC = () => {
     onClose();
   };
   return (
-    <FormLayout overflowX={'scroll'}>
+    <FormLayout overflowX={'auto'}>
       <Table variant="simple">
         <TableCaption placement="top" textAlign="end" p={0} m={0} mb={3} fontSize={20}>
           <Tooltip

--- a/web/gds-user-ui/src/components/Sidebar/index.tsx
+++ b/web/gds-user-ui/src/components/Sidebar/index.tsx
@@ -30,7 +30,7 @@ const Sidebar: React.FC<SidebarProps> = ({ children }) => {
         </DrawerContent>
       </Drawer>
       <MobileNav onOpen={onOpen} />
-      <Box ml={{ base: 0, md: 274 }} pt={10} px="10" height="100%" overflow="scroll">
+      <Box ml={{ base: 0, md: 274 }} pt={10} px="10" height="100%" overflow="auto">
         {children}
       </Box>
     </Box>

--- a/web/gds-user-ui/src/modules/dashboard/member/index.tsx
+++ b/web/gds-user-ui/src/modules/dashboard/member/index.tsx
@@ -15,7 +15,7 @@ const MemberPage: React.FC = () => {
       </Heading>
       <Suspense fallback={<Loader />}>
         <DirectoryNotification />
-        <FormLayout overflowX={'scroll'}>
+        <FormLayout overflowX={'auto'}>
           <MemberHeader />
           <MemberSelectNetwork />
           <MemberTable />


### PR DESCRIPTION
### Scope of changes

Sets the overflow value to auto to remove empty scrollbars that made extra whitespace appear in the right and bottom margins.

Below are links to images to provide examples of how the whitespace currently appears on all pages:

https://www.awesomescreenshot.com/image/45224195?key=efb925603878b13acfca7cec44967126
https://www.awesomescreenshot.com/image/45224206?key=7915d0b8867061ca132ca5a3e2cfbbe7

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/23798456?key=f3d65d6eda9b16f7c0bbf99a82e9b9ca

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


