### PR TITLE
Adjusts spacing between topbar elements to prevent spill over

### DIFF
--- a/web/gds-user-ui/src/components/LanguagesDropdown/index.tsx
+++ b/web/gds-user-ui/src/components/LanguagesDropdown/index.tsx
@@ -1,4 +1,5 @@
-import { Select } from '@chakra-ui/react';
+import { HStack, Select, Tooltip } from '@chakra-ui/react';
+import { t } from '@lingui/macro';
 import { isDashLocale } from 'application/config';
 import { useLanguageProvider } from 'contexts/LanguageContext';
 
@@ -46,9 +47,13 @@ const LanguagesDropdown: React.FC = () => {
     setLanguage(e.target.value);
   };
   return (
-    <Select w="100%" maxW="100" ml={3} value={language as string} onChange={handleLanguageClick}>
-      <LanguageOptions />
-    </Select>
+    <HStack>
+      <Tooltip label={t`Select language`} hasArrow>
+        <Select w="100%" ml={2} value={language as string} onChange={handleLanguageClick}>
+          <LanguageOptions />
+        </Select>
+      </Tooltip>
+    </HStack>
   );
 };
 

--- a/web/gds-user-ui/src/components/LanguagesDropdown/index.tsx
+++ b/web/gds-user-ui/src/components/LanguagesDropdown/index.tsx
@@ -1,5 +1,4 @@
-import { HStack, Select, Tooltip } from '@chakra-ui/react';
-import { t } from '@lingui/macro';
+import { Select } from '@chakra-ui/react';
 import { isDashLocale } from 'application/config';
 import { useLanguageProvider } from 'contexts/LanguageContext';
 
@@ -47,13 +46,9 @@ const LanguagesDropdown: React.FC = () => {
     setLanguage(e.target.value);
   };
   return (
-    <HStack>
-      <Tooltip label={t`Select language`} hasArrow>
-        <Select w="100%" ml={2} value={language as string} onChange={handleLanguageClick}>
-          <LanguageOptions />
-        </Select>
-      </Tooltip>
-    </HStack>
+    <Select w="100%" ml={2} value={language as string} onChange={handleLanguageClick}>
+      <LanguageOptions />
+    </Select>
   );
 };
 

--- a/web/gds-user-ui/src/components/Metrics/index.tsx
+++ b/web/gds-user-ui/src/components/Metrics/index.tsx
@@ -17,7 +17,7 @@ const Metrics = ({ data, type }: MetricsProps) => {
           fallback={
             <Text color={'red'} pt={20}>{t`An error has occurred to load ${type} metric`}</Text>
           }>
-          <SimpleGrid columns={{ base: 4, sm: 2, lg: 4 }} spacingX="30px">
+          <SimpleGrid columns={{ base: 1, sm: 2, lg: 4 }} spacingX="30px">
             <StatusCard isOnline={data?.status || 'UNKNOWN'} />
             <StatCard title={t`Verified VASPs`} number={data?.vasps} />
             <StatCard title={t`Identity Certificates`} number={data?.certificates_issued} />

--- a/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
+++ b/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
@@ -55,9 +55,8 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
 
   return (
     <Flex
-      ml={{ base: 0, md: 60 }}
-      px={{ base: 4, md: 4 }}
-      height="20"
+      ml={{ base: 0, md: 64 }}
+      px={{ base: 0, md: 4 }}
       alignItems="center"
       bg={useColorModeValue('white', 'gray.900')}
       borderBottomWidth="1px"
@@ -72,9 +71,8 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
         icon={<FiMenu />}
       />
       <HStack
-        spacing={{ base: '0', md: '6' }}
+        spacing={{ base: 1, lg: 2, xl: 4 }}
         w={{ base: '100%', md: 'none' }}
-        gap={{ base: 4, md: 0 }}
         justifyContent="end">
         <HStack>
           <LanguagesDropdown />

--- a/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
+++ b/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
@@ -39,6 +39,7 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
   const { setDefaultNetwork } = useMemberState();
   const dispatch = useDispatch();
   const { user } = useSelector(userSelector);
+  console.log('user', user);
   const navigate = useNavigate();
   const handleLogout = (e: any) => {
     e.preventDefault();
@@ -56,7 +57,7 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
   return (
     <Flex
       ml={{ base: 0, md: 64 }}
-      px={{ base: 0, md: 4 }}
+      px={{ base: 2, md: 4 }}
       alignItems="center"
       bg={useColorModeValue('white', 'gray.900')}
       borderBottomWidth="1px"
@@ -84,7 +85,9 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
             </Text>
           </Tooltip>
         </HStack>
-        <Divider orientation="vertical" height={8} />
+        <Show above="lg">
+          <Divider orientation="vertical" height={8} />
+        </Show>
         <Menu>
           <MenuButton data-testid="menu" transition="all 0.3s" _focus={{ boxShadow: 'none' }}>
             <HStack>

--- a/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
+++ b/web/gds-user-ui/src/components/Sidebar/MobileNav.tsx
@@ -39,7 +39,6 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
   const { setDefaultNetwork } = useMemberState();
   const dispatch = useDispatch();
   const { user } = useSelector(userSelector);
-  console.log('user', user);
   const navigate = useNavigate();
   const handleLogout = (e: any) => {
     e.preventDefault();


### PR DESCRIPTION
### Scope of changes

Adjusts spacing and margin on the `Navbar` to prevent the language select element from spilling over onto the `Sidebar`. 

The issue can be seen in the first few seconds of the following video: https://www.awesomescreenshot.com/video/23774299?key=8343b2d1c5c9b0c219a1369f7ec898c4

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/23929787?key=1af664af547cfbd087533fcdaba31248

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


