### PR TITLE
Add Spanish and Portuguese to lingui locales

### DIFF
--- a/web/gds-user-ui/.linguirc
+++ b/web/gds-user-ui/.linguirc
@@ -2,8 +2,10 @@
   "locales": [
     "de",
     "en",
+    "es",
     "fr",
     "ja",
+    "pt",
     "zh",
     "en-dh"
   ],

--- a/web/gds-user-ui/src/locales/de/messages.po
+++ b/web/gds-user-ui/src/locales/de/messages.po
@@ -150,7 +150,7 @@ msgstr "4 TRISA Implementierung"
 msgid "5 TRIXO Questionnaire"
 msgstr "5 TRIXO Fragebogen"
 
-#: src/components/Contacts/ContactForm/index.tsx:30
+#: src/components/Contacts/ContactForm/index.tsx:29
 msgid "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgid "Action"
 msgstr "Aktion"
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:70
-#: src/components/Collaborators/index.tsx:171
+#: src/components/Collaborators/index.tsx:179
 #: src/modules/dashboard/member/components/MemberTable.tsx:34
 msgid "Actions"
 msgstr ""
@@ -209,11 +209,11 @@ msgstr ""
 msgid "Add Address"
 msgstr "Adresse hinzufügen"
 
-#: src/components/NameIdentifiers/index.tsx:51
+#: src/components/NameIdentifiers/index.tsx:50
 msgid "Add Another Legal Name"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:140
+#: src/components/Collaborators/index.tsx:148
 msgid "Add Contact"
 msgstr ""
 
@@ -229,11 +229,11 @@ msgstr "Jurisdiktion hinzufügen"
 msgid "Add Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:54
+#: src/components/NameIdentifiers/index.tsx:53
 msgid "Add Local Name"
 msgstr "Lokalen Namen hinzufügen"
 
-#: src/components/NameIdentifiers/index.tsx:57
+#: src/components/NameIdentifiers/index.tsx:56
 msgid "Add Phonetic Names"
 msgstr "Phonetische Namen hinzufügen"
 
@@ -265,13 +265,13 @@ msgstr "Adresszeile 1 z.B. Gebäudename/Nummer, Straßenname (erforderlich)"
 msgid "Address line 2 e.g. apartment or suite number"
 msgstr "Adresszeile 2 z.B. Wohnungs- oder Appartementnummer"
 
-#: src/components/Addresses/index.tsx:11
+#: src/components/Addresses/index.tsx:10
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:118
 #: src/components/MemberDetails/index.tsx:244
 msgid "Addresses"
 msgstr "Adressen"
 
-#: src/components/Contacts/ContactsForm.tsx:158
+#: src/components/Contacts/ContactsForm.tsx:161
 msgid "Administrative Contact (optional)"
 msgstr "Administrativer Kontakt (optional)"
 
@@ -287,7 +287,7 @@ msgstr ""
 msgid "Administrative Contact Phone"
 msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:159
+#: src/components/Contacts/ContactsForm.tsx:162
 msgid "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
 msgstr "Administrativer oder leitender Kontakt für Ihre Organisation, um Anfragen auf höchster Ebene zu bearbeiten. (Dringend empfohlen)"
 
@@ -325,7 +325,7 @@ msgstr ""
 msgid "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:130
+#: src/components/NationalIdentification/index.tsx:129
 msgid "An identifier issued by an appropriate issuing authority"
 msgstr "Eine Identifikation, die von einer zuständigen Behörde ausgestellt wurde"
 
@@ -333,8 +333,8 @@ msgstr "Eine Identifikation, die von einer zuständigen Behörde ausgestellt wur
 msgid "App version {appVersion}"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:174
-#: src/components/TrixoQuestionnaireForm/index.tsx:417
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:173
+#: src/components/TrixoQuestionnaireForm/index.tsx:416
 msgid "Applicable Regulations"
 msgstr "Anwendbare Vorschriften"
 
@@ -346,13 +346,13 @@ msgstr "Beantragen Sie, ein TRISA-zertifizierter Virtual Asset Service Provider 
 msgid "At least 9 characters in length"
 msgstr ""
 
-#: src/components/Addresses/index.tsx:14
+#: src/components/Addresses/index.tsx:13
 msgid "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
 msgstr "Mindestens eine geografische Adresse ist erforderlich. Geben Sie die primäre geografische Adresse der Organisation ein. Organisationen können zusätzliche Adressen eingeben, wenn sie in mehreren Jurisdiktionen tätig sind."
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:143
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:142
 #: src/components/MemberDetails/index.tsx:589
-#: src/components/TrixoQuestionnaireForm/index.tsx:322
+#: src/components/TrixoQuestionnaireForm/index.tsx:321
 msgid "At what threshold and currency does your organization conduct KYC checks?"
 msgstr ""
 
@@ -391,11 +391,11 @@ msgstr "Werden Sie Travel Rule konform."
 #~ msgid "Beware the Ides of March"
 #~ msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:163
+#: src/components/Contacts/ContactsForm.tsx:168
 msgid "Billing Contact (optional)"
 msgstr "Rechnungskontakt (optional)"
 
-#: src/components/Contacts/ContactsForm.tsx:164
+#: src/components/Contacts/ContactsForm.tsx:169
 msgid "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
 msgstr "Rechnungskontakt für Ihre Organisation zur Bearbeitung von Konto- und Rechnungsanfragen oder Fragen im Zusammenhang mit dem Betrieb des TRISA-Netzwerks."
 
@@ -433,7 +433,7 @@ msgstr "Geschäfts- oder Compliance-Büro"
 msgid "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:282
+#: src/components/TrixoQuestionnaireForm/index.tsx:281
 msgid "CDD & Travel Rule Policies"
 msgstr "CDD & Reiseregelungsrichtlinien"
 
@@ -449,7 +449,7 @@ msgstr "CDD- und Datenschutzrichtlinien"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:80
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:79
 msgid "Certificate Common Name"
 msgstr "Gemeinsamer Zertifikatsname"
 
@@ -544,7 +544,7 @@ msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:158
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:198
-#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:74
+#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:75
 msgid "Close"
 msgstr ""
 
@@ -573,9 +573,9 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:286
 #: src/components/CertificateInventory/index.tsx:206
 #: src/components/CertificateInventory/index.tsx:269
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:63
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:83
-#: src/components/Section/SearchDirectory.tsx:215
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:62
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:82
+#: src/components/Section/SearchDirectory.tsx:217
 #: src/components/Section/SearchDirectory.tsx:283
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:79
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:89
@@ -586,7 +586,7 @@ msgstr " Common Name"
 #~ msgid "Common name or VASP ID"
 #~ msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:42
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:41
 msgid "Common name should match the TRISA endpoint without the port."
 msgstr ""
 
@@ -666,7 +666,7 @@ msgstr ""
 msgid "Comply with the Travel Rule"
 msgstr "Einhaltung der Reiserichtlinie"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:313
+#: src/components/TrixoQuestionnaireForm/index.tsx:312
 msgid "Conducts KYC before virtual asset transfers"
 msgstr "Führt KYC vor virtuellen Vermögensübertragungen durch"
 
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Confirm New Password"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:156
+#: src/components/Collaborators/index.tsx:164
 msgid "Contact Details"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgid "Contact information for representatives of your organization. Contacts in
 msgstr "Kontaktinformationen für Vertreter Ihrer Organisation. Zu den Kontakten gehören Personen aus den Bereichen Technik, Recht/Compliance, Verwaltung und Abrechnung."
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:21
-#: src/components/OrganizationProfile/OrganizationalDetail.tsx:157
+#: src/components/OrganizationProfile/OrganizationalDetail.tsx:158
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:165
 msgid "Contacts"
 msgstr "Kontakte"
@@ -737,8 +737,8 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:292
 #: src/components/CertificateInventory/index.tsx:212
 #: src/components/CertificateInventory/index.tsx:275
-#: src/components/Section/SearchDirectory.tsx:239
-#: src/components/Section/SearchDirectory.tsx:308
+#: src/components/Section/SearchDirectory.tsx:242
+#: src/components/Section/SearchDirectory.tsx:307
 msgid "Country"
 msgstr "Land"
 
@@ -747,16 +747,16 @@ msgid "Country (required)"
 msgstr "Land (erforderlich)"
 
 #: src/components/MemberDetails/index.tsx:321
-#: src/components/NameIdentification/index.tsx:174
+#: src/components/NationalIdentification/index.tsx:173
 msgid "Country of Issue"
 msgstr "Ausstellungsland"
 
-#: src/components/NameIdentification/index.tsx:178
+#: src/components/NationalIdentification/index.tsx:177
 msgid "Country of Issue is reserved for National Identifiers of Natural Persons"
 msgstr "Ausstellungsland ist für Nationale Identifikatoren von natürlichen Personen reserviert"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:138
-#: src/components/CountryOfRegistration/index.tsx:19
+#: src/components/CountryOfRegistration/index.tsx:18
 #: src/components/MemberDetails/index.tsx:271
 #: src/components/MemberDetails/index.tsx:331
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:137
@@ -819,11 +819,11 @@ msgstr "Erstellt und verwaltet von"
 msgid "Current Name"
 msgstr ""
 
-#: src/components/Sidebar/MobileNav.tsx:83
+#: src/components/Sidebar/MobileNav.tsx:81
 msgid "Current Organization name"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:89
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:88
 msgid "Customer Due Diligence (CDD) & Travel Rule Policies"
 msgstr ""
 
@@ -835,8 +835,8 @@ msgstr "Kundennummer"
 msgid "Dashboard"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:207
-#: src/components/TrixoQuestionnaireForm/index.tsx:429
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:206
+#: src/components/TrixoQuestionnaireForm/index.tsx:428
 msgid "Data Protection Policies"
 msgstr "Datenschutzrichtlinien"
 
@@ -904,11 +904,11 @@ msgstr "Verzeichnis Nachschlagen"
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:307
+#: src/components/TrixoQuestionnaireForm/index.tsx:306
 msgid "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr "Führt Ihre Organisation KYC/CDD durch, bevor sie ihren Kunden erlaubt, virtuelle Vermögenstransfers zu senden/empfangen?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:123
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:122
 msgid "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr ""
 
@@ -925,24 +925,24 @@ msgid ""
 "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:297
+#: src/components/TrixoQuestionnaireForm/index.tsx:296
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money\n"
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:99
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:98
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:446
+#: src/components/TrixoQuestionnaireForm/index.tsx:445
 msgid "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
 msgstr "Sichert und schützt Ihre Organisation PII, einschließlich PII, die sie von anderen VASPs im Rahmen der Reiseregelungen erhalten hat?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:234
 msgid ""
 "Does your organization secure and protect Personally Identifiable\n"
 "                Information (PII), including Personally Identifiable\n"
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
 msgstr "Jeder VASP muss einen TRISA-Endpunkt für die Inter-VASP-Kommunikation einrichten. Bitte geben Sie die Details Ihres Endpunktes für die Zertifikatsausstellung an."
 
-#: src/components/TrisaImplementation/index.tsx:66
+#: src/components/TrisaImplementation/index.tsx:65
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
 msgstr "Jeder VASP muss einen TRISA-Endpunkt für die Inter-VASP-Kommunikation einrichten. Bitte geben Sie die Details Ihres Endpunktes für die Ausstellung von Zertifikaten an. Bitte geben Sie den TestNet-Endpunkt und den MainNet-Endpunkt an. Der TestNet Endpunkt und der MainNet Endpunkt müssen unterschiedlich sein."
 
@@ -987,7 +987,7 @@ msgid "Edit collaborator Role"
 msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:129
-#: src/components/Contacts/ContactForm/index.tsx:67
+#: src/components/Contacts/ContactForm/index.tsx:66
 #: src/components/Form/LoginForm.tsx:52
 #: src/components/Form/SignupForm.tsx:53
 #: src/components/Section/PasswordResetForm.tsx:26
@@ -1024,8 +1024,8 @@ msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:181
 #: src/components/CertificateInventory/index.tsx:116
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:57
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:77
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:56
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:76
 msgid "Endpoint"
 msgstr "Endpunkt"
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
 msgstr "Geben Sie den VASP Common Name oder die VASP ID ein. Kein TRISA-Mitglied?"
 
-#: src/components/NameIdentifiers/index.tsx:31
+#: src/components/NameIdentifiers/index.tsx:30
 msgid "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
 msgstr ""
 
@@ -1113,7 +1113,7 @@ msgstr "Abschließende Überprüfung und Formularübermittlung"
 msgid "First (Given) Name"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:67
+#: src/components/OrganizationProfile/TrisaDetail.tsx:57
 msgid "First Listed"
 msgstr ""
 
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
 msgstr "Bei MainNet-Zertifikatsanträgen wird ein Mitglied des TRISA-Verifizierungsteams Ihren Antrag prüfen und einen abschließenden Kontrollanruf zur physischen Überprüfung durchführen. Wenn die physische Überprüfung abgeschlossen ist, wird TRISA MainNet-Zertifikate ausstellen. Für Anträge auf TestNet-Zertifikate ist keine physische Überprüfung erforderlich."
 
-#: src/components/NameIdentification/index.tsx:32
+#: src/components/NationalIdentification/index.tsx:31
 msgid "For identifiers other than LEI specify the registration authority from the following list. See"
 msgstr "Für Identifikatoren, die nicht LEI sind, geben Sie die Registrierungsbehörde aus der folgenden Liste an. Siehe"
 
@@ -1137,7 +1137,7 @@ msgstr "Identifikationsnummer für ausländische Investitionen"
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: src/components/Contacts/ContactForm/index.tsx:58
+#: src/components/Contacts/ContactForm/index.tsx:57
 msgid "Full Name"
 msgstr "Vollständiger Name"
 
@@ -1145,7 +1145,7 @@ msgstr "Vollständiger Name"
 msgid "Full name"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:40
+#: src/components/NationalIdentification/index.tsx:39
 msgid "GLEIF Registration Authorities"
 msgstr "GLEIF Registrierungsbehörden"
 
@@ -1194,7 +1194,7 @@ msgstr ""
 #~ msgid "I have a bad feeling about tomorrow."
 #~ msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:64
+#: src/components/OrganizationProfile/TrisaDetail.tsx:54
 msgid "ID"
 msgstr ""
 
@@ -1208,14 +1208,14 @@ msgstr "IVMS 101 Datenstruktur"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:165
 #: src/components/MemberDetails/index.tsx:303
-#: src/components/NameIdentification/index.tsx:127
+#: src/components/NationalIdentification/index.tsx:126
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:112
 msgid "Identification Number"
 msgstr "Identifikationsnummer"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:171
 #: src/components/MemberDetails/index.tsx:311
-#: src/components/NameIdentification/index.tsx:156
+#: src/components/NationalIdentification/index.tsx:155
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:120
 msgid "Identification Type"
 msgstr "Identifikationstyp"
@@ -1228,7 +1228,7 @@ msgstr "Ausweisnummer"
 msgid "Identity Certificates"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:41
+#: src/components/Contacts/ContactForm/index.tsx:40
 msgid "If supplied, use full phone number with country code"
 msgstr "Falls angegeben, vollständige Telefonnummer mit Landesvorwahl verwenden"
 
@@ -1314,12 +1314,12 @@ msgstr "Interoperabel"
 #~ msgid "Invalid date."
 #~ msgstr ""
 
-#: src/components/Collaborators/index.tsx:165
+#: src/components/Collaborators/index.tsx:173
 msgid "Invited"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:67
-#: src/components/TrixoQuestionnaireForm/index.tsx:274
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:66
+#: src/components/TrixoQuestionnaireForm/index.tsx:273
 msgid "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
 msgstr "Ist es Ihrer Organisation erlaubt, Transfers von virtuellen Vermögenswerten in den Ländern, in denen sie tätig ist, zu senden und/oder zu empfangen?"
 
@@ -1328,18 +1328,18 @@ msgstr "Ist es Ihrer Organisation erlaubt, Transfers von virtuellen Vermögenswe
 #~ msgid "Is your organization required by law to safeguard PII?"
 #~ msgstr "Ist Ihre Organisation gesetzlich verpflichtet, PII zu schützen?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:215
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:214
 msgid ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:433
+#: src/components/TrixoQuestionnaireForm/index.tsx:432
 msgid "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:154
-#: src/components/TrixoQuestionnaireForm/index.tsx:363
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:153
+#: src/components/TrixoQuestionnaireForm/index.tsx:362
 msgid "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
 msgstr "Ist Ihre Organisation verpflichtet, die Standards der Reiserichtlinie in der/den Jurisdiktion(en) einzuhalten, in der/denen sie lizenziert/zugelassen/registriert ist?"
 
@@ -1376,7 +1376,7 @@ msgstr "Treten Sie heute dem TRISA-Netzwerk bei."
 #~ msgid "Join us on Thursday Apr 28 for the TRISA Working Group."
 #~ msgstr ""
 
-#: src/components/Collaborators/index.tsx:168
+#: src/components/Collaborators/index.tsx:176
 #: src/modules/dashboard/member/components/MemberTable.tsx:22
 #: src/modules/dashboard/member/utils.ts:12
 msgid "Joined"
@@ -1394,7 +1394,7 @@ msgstr ""
 msgid "Last Login:"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:73
+#: src/components/OrganizationProfile/TrisaDetail.tsx:63
 #: src/modules/dashboard/member/components/MemberTable.tsx:25
 #: src/modules/dashboard/member/utils.ts:16
 msgid "Last Updated"
@@ -1453,7 +1453,7 @@ msgstr "Rechtlicher/ Compliance Kontakt (erforderlich)"
 msgid "Link Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:36
 msgid "Local Name Identifiers"
 msgstr "Lokale Namensbezeichner"
 
@@ -1501,7 +1501,7 @@ msgstr "Login"
 msgid "Login & Identity"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:196
+#: src/components/Section/SearchDirectory.tsx:187
 msgid "MAINNET DIRECTORY RECORD"
 msgstr "MAINNET VERZEICHNISAUFZEICHNUNG"
 
@@ -1515,7 +1515,7 @@ msgid "MAINNET SUBMISSION"
 msgstr "MAINNET EINGABE"
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:53
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:72
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:51
 #: src/components/ReviewSubmit/index.tsx:224
 msgid "MainNet"
 msgstr " MainNet"
@@ -1583,16 +1583,16 @@ msgstr "Misc"
 #~ msgid "Missing required element"
 #~ msgstr "Fehlendes erforderliches Element"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:369
+#: src/components/TrixoQuestionnaireForm/index.tsx:368
 msgid "Must comply with Travel Rule"
 msgstr "Muss der Reiseregel unterliegen"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:439
+#: src/components/TrixoQuestionnaireForm/index.tsx:438
 msgid "Must safeguard PII"
 msgstr "Muss PII schützen"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "NO"
 msgstr ""
 
@@ -1602,7 +1602,7 @@ msgid "NO VERIFICATION"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:57
-#: src/components/NameIdentifier/index.tsx:118
+#: src/components/NameIdentifier/index.tsx:117
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:19
 msgid "Name"
 msgstr "Name"
@@ -1621,7 +1621,7 @@ msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:43
 #: src/components/MemberDetails/index.tsx:172
-#: src/components/NameIdentifiers/index.tsx:29
+#: src/components/NameIdentifiers/index.tsx:28
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:68
 msgid "Name Identifiers"
 msgstr "Namensidentifikatoren"
@@ -1630,8 +1630,8 @@ msgstr "Namensidentifikatoren"
 #~ msgid "Name identifiers"
 #~ msgstr "Namensidentifikatoren"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:43
-#: src/components/TrixoQuestionnaireForm/index.tsx:245
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:42
+#: src/components/TrixoQuestionnaireForm/index.tsx:244
 msgid "Name of Primary Regulator"
 msgstr "Name der primären Aufsichtsbehörde"
 
@@ -1645,7 +1645,7 @@ msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:156
 #: src/components/MemberDetails/index.tsx:298
-#: src/components/NameIdentification/index.tsx:115
+#: src/components/NationalIdentification/index.tsx:114
 msgid "National Identification"
 msgstr "Nationale Identifikation"
 
@@ -1691,7 +1691,7 @@ msgstr "Weiter"
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:26
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:33
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:31
 #: src/constants/trixo.ts:7
 msgid "No"
@@ -1769,7 +1769,7 @@ msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:120
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:30
-#: src/components/Section/SearchDirectory.tsx:209
+#: src/components/Section/SearchDirectory.tsx:211
 #: src/components/Section/SearchDirectory.tsx:277
 msgid "Organization Name"
 msgstr "Name der Organisation"
@@ -1798,8 +1798,8 @@ msgstr ""
 msgid "Organizational Details"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:49
-#: src/components/TrixoQuestionnaireForm/index.tsx:251
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:48
+#: src/components/TrixoQuestionnaireForm/index.tsx:250
 msgid "Other Jurisdictions"
 msgstr "Andere Jurisdiktionen"
 
@@ -1848,11 +1848,11 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:91
+#: src/components/Contacts/ContactForm/index.tsx:90
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: src/components/NameIdentifiers/index.tsx:44
+#: src/components/NameIdentifiers/index.tsx:43
 msgid "Phonetic Name Identifiers"
 msgstr "Phonetische Namensidentifikatoren"
 
@@ -1860,7 +1860,7 @@ msgstr "Phonetische Namensidentifikatoren"
 msgid "Please Provide the Name and Email Address"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:254
+#: src/components/TrixoQuestionnaireForm/index.tsx:253
 msgid "Please add any other regulatory jurisdictions your organization complies with."
 msgstr "Bitte fügen Sie alle anderen gesetzlichen Bestimmungen hinzu, die Ihre Organisation einhält."
 
@@ -1913,11 +1913,11 @@ msgstr "Bitte überprüfen Sie die angegebenen Informationen, bearbeiten Sie sie
 msgid "Please select as many categories needed to represent the types of virtual asset services your organization provides."
 msgstr "Bitte wählen Sie so viele Kategorien aus, wie nötig sind, um die Arten von Dienstleistungen für virtuelle Assets zu repräsentieren, die Ihre Organisation anbietet."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:420
+#: src/components/TrixoQuestionnaireForm/index.tsx:419
 msgid "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
 msgstr "Bitte geben Sie die anwendbare(n) Vorschrift(en) zur Einhaltung der Reiseregelstandards an, z.B.\"FATF Recommendation 16\""
 
-#: src/components/NameIdentification/index.tsx:118
+#: src/components/NationalIdentification/index.tsx:117
 msgid "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
 msgstr "Bitte geben Sie eine gültige nationale Identifikationsnummer an. TRISA empfiehlt die Verwendung von LEI-Nummern. Für weitere Informationen, besuchen Sie bitte"
 
@@ -1930,15 +1930,15 @@ msgstr "Bitte geben Sie eine gültige nationale Identifikationsnummer an. TRISA 
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
 msgstr ""
 
-#: src/components/Contacts/index.tsx:62
+#: src/components/Contacts/index.tsx:61
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:23
+#: src/components/Contacts/ContactForm/index.tsx:22
 msgid "Please use the email address associated with your organization."
 msgstr "Bitte verwenden Sie die mit Ihrer Organisation verbundene E-Mail-Adresse."
 
-#: src/components/Contacts/ContactForm/index.tsx:21
+#: src/components/Contacts/ContactForm/index.tsx:20
 msgid "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
@@ -1957,7 +1957,7 @@ msgstr ""
 msgid "Postal Code / Postcode / ZIP Code"
 msgstr "Postleitzahl/ ZIP Code"
 
-#: src/components/Contacts/ContactForm/index.tsx:59
+#: src/components/Contacts/ContactForm/index.tsx:58
 msgid "Preferred name for email communication."
 msgstr "Bevorzugter Name für die E-Mail-Kommunikation."
 
@@ -1965,12 +1965,12 @@ msgstr "Bevorzugter Name für die E-Mail-Kommunikation."
 msgid "Previous"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:37
-#: src/components/TrixoQuestionnaireForm/index.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:36
+#: src/components/TrixoQuestionnaireForm/index.tsx:234
 msgid "Primary National Jurisdiction"
 msgstr "Primäre nationale Jurisdiktion"
 
-#: src/components/Contacts/ContactsForm.tsx:154
+#: src/components/Contacts/ContactsForm.tsx:155
 msgid "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
 msgstr "Hauptansprechpartner für die Bearbeitung von technischen Fragen zum Betrieb und Status Ihres Dienstes, der am TRISA-Netzwerk teilnimmt. Kann eine Gruppen- oder Admin-E-Mail sein."
 
@@ -2027,12 +2027,12 @@ msgstr "Zulassungsbehörde"
 msgid "Region / Province / State (required)"
 msgstr "Region/Provinz/Bundesland (erforderlich)"
 
-#: src/components/Section/SearchDirectory.tsx:227
+#: src/components/Section/SearchDirectory.tsx:229
 #: src/components/Section/SearchDirectory.tsx:295
 msgid "Registered Directory"
 msgstr "Registriertes Verzeichnis"
 
-#: src/components/NameIdentification/index.tsx:196
+#: src/components/NationalIdentification/index.tsx:195
 msgid "Registration Authority"
 msgstr "Registrierungsstelle"
 
@@ -2060,7 +2060,7 @@ msgstr "Name des Regulierers"
 msgid "Remove Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifier/index.tsx:137
+#: src/components/NameIdentifier/index.tsx:136
 #: src/components/OtherJuridictions/index.tsx:58
 #: src/components/Regulations/index.tsx:31
 msgid "Remove line"
@@ -2106,7 +2106,7 @@ msgstr "Überprüfung"
 msgid "Review section"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:159
+#: src/components/Collaborators/index.tsx:167
 #: src/components/UserProfile/UserDetails.tsx:22
 msgid "Role"
 msgstr ""
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "SUBMITTED"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:452
+#: src/components/TrixoQuestionnaireForm/index.tsx:451
 msgid "Safeguards PII"
 msgstr "Schützt PII"
 
@@ -2155,7 +2155,7 @@ msgstr "Suche im Verzeichnisdienst"
 msgid "Section"
 msgstr "Abschnitt"
 
-#: src/components/BasicDetail/index.tsx:132
+#: src/components/BasicDetail/index.tsx:130
 #: src/components/CertificateReview/BasicDetailsReview.tsx:29
 #: src/components/CertificateSection/index.tsx:23
 #: src/components/CertificateSection/index.tsx:65
@@ -2170,17 +2170,17 @@ msgstr "Abschnitt 2: Juristische Person"
 
 #: src/components/CertificateReview/ContactsReview.tsx:19
 #: src/components/CertificateSection/index.tsx:36
-#: src/components/Contacts/index.tsx:56
+#: src/components/Contacts/index.tsx:55
 msgid "Section 3: Contacts"
 msgstr "Abschnitt 3: Kontakte"
 
 #: src/components/CertificateReview/TrisaImplementationReview.tsx:19
 #: src/components/CertificateSection/index.tsx:41
-#: src/components/TrisaImplementation/index.tsx:60
+#: src/components/TrisaImplementation/index.tsx:59
 msgid "Section 4: TRISA Implementation"
 msgstr "Abschnitt 4: TRISA-Implementierung"
 
-#: src/components/CertificateReview/TrixoReview.tsx:34
+#: src/components/CertificateReview/TrixoReview.tsx:32
 #: src/components/CertificateSection/index.tsx:46
 #: src/components/TrixoQuestionnaire/index.tsx:55
 msgid "Section 5: TRIXO Questionnaire"
@@ -2211,7 +2211,7 @@ msgstr "VASP-Kategorie auswählen"
 msgid "Select a VASP from the Managed VASP List"
 msgstr ""
 
-#: src/components/CountryOfRegistration/index.tsx:28
+#: src/components/CountryOfRegistration/index.tsx:27
 msgid "Select a country"
 msgstr "Land auswählen"
 
@@ -2314,8 +2314,8 @@ msgstr ""
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:67
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:45
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:63
-#: src/components/Collaborators/index.tsx:162
-#: src/components/OrganizationProfile/TrisaDetail.tsx:76
+#: src/components/Collaborators/index.tsx:170
+#: src/components/OrganizationProfile/TrisaDetail.tsx:66
 #: src/modules/dashboard/member/components/MemberTable.tsx:31
 #: src/modules/dashboard/member/utils.ts:24
 msgid "Status"
@@ -2348,7 +2348,7 @@ msgid "Subject Details"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:39
-#: src/components/NeedsAttention/AttentionAlert.tsx:98
+#: src/components/NeedsAttention/AttentionAlert.tsx:97
 #: src/components/Section/PasswordResetForm.tsx:48
 #: src/hoc/withRHF.tsx:117
 msgid "Submit"
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Synga Bridge"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:188
+#: src/components/Section/SearchDirectory.tsx:195
 msgid "TESTNET DIRECTORY RECORD"
 msgstr "TESTNET VERZEICHNISAUFZEICHNUNG"
 
@@ -2394,7 +2394,7 @@ msgstr ""
 #~ msgid "TRISA Certificates"
 #~ msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:67
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:66
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:75
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:83
 msgid "TRISA Endpoint"
@@ -2404,7 +2404,7 @@ msgstr "TRISA Endpunkt"
 #~ msgid "TRISA Endpoint is a server address (e.g. trisa.myvasp.com:443) at which the VASP can be reached via secure channels. The Common Name typically matches the Endpoint, without the port number at the end (e.g. trisa.myvasp.com) and is used to identify the subject in the X.509 certificate."
 #~ msgstr "TRISA Endpunkt ist eine Serveradresse (z.B. trisa.myvasp.com:443), über die der VASP über sichere Kanäle erreicht werden kann. Der Common Name entspricht typischerweise dem Endpunkt, ohne die Portnummer am Ende (z.B. trisa.myvasp.com) und wird zur Identifizierung des Subjekts im X.509-Zertifikat verwendet."
 
-#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:149
+#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:150
 msgid "TRISA Endpoint: MainNet"
 msgstr "TRISA Endpunkt: MainNet"
 
@@ -2436,7 +2436,7 @@ msgstr ""
 msgid "TRISA Member Directory"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:233
+#: src/components/Section/SearchDirectory.tsx:235
 #: src/components/Section/SearchDirectory.tsx:301
 msgid "TRISA Member ID"
 msgstr "TRISA Mitglieds-ID"
@@ -2453,13 +2453,13 @@ msgstr ""
 msgid "TRISA Registration Request Submitted!"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:221
+#: src/components/Section/SearchDirectory.tsx:223
 #: src/components/Section/SearchDirectory.tsx:289
 msgid "TRISA Service Endpoint"
 msgstr "TRISA Dienst Endpunkt"
 
-#: src/components/Section/SearchDirectory.tsx:250
-#: src/components/Section/SearchDirectory.tsx:319
+#: src/components/Section/SearchDirectory.tsx:253
+#: src/components/Section/SearchDirectory.tsx:318
 msgid "TRISA Verification"
 msgstr "TRISA Verifizierung"
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Tax Identification Number"
 msgstr "Steueridentifikationsnummer"
 
-#: src/components/Contacts/ContactsForm.tsx:153
+#: src/components/Contacts/ContactsForm.tsx:154
 msgid "Technical Contact (required)"
 msgstr "Technischer Kontakt (erforderlich)"
 
@@ -2602,7 +2602,7 @@ msgid "Technical information about your endpoint for certificate issuance. Each 
 msgstr "Technische Informationen über Ihren Endpunkt für die Ausstellung von Zertifikaten. Jeder VASP muss einen TRISA-Endpunkt für die Kommunikation zwischen den VASPs einrichten."
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:33
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:52
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:71
 #: src/components/ReviewSubmit/index.tsx:132
 msgid "TestNet"
 msgstr "TestNet"
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
 msgstr "Vielen Dank. Wir haben Anweisungen zum Zurücksetzen Ihres Passworts an {0} gesendet. Der Link zum Zurücksetzen Ihres Passworts läuft in 24 Stunden ab."
 
-#: src/components/Section/SearchDirectory.tsx:145
+#: src/components/Section/SearchDirectory.tsx:144
 msgid ""
 "The Common Name typically matches the Endpoint, without the port number\n"
 "                            at the end (e.g. trisa.myvasp.com) and is used to identify the subject\n"
@@ -2700,7 +2700,7 @@ msgstr "The Travel Rule Information Sharing Architecture (TRISA)"
 msgid "The VASP Name is required."
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:72
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:71
 msgid "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
 msgstr "Die Adresse und der Port des TRISA-Endpunkts für Partner-VASPs zur Verbindung über gRPC."
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "The collaborator has not been updated"
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:58
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:57
 msgid "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
 msgstr "Der Common Name für das mTLS-Zertifikat. Dieser sollte in den meisten Fällen mit dem TRISA-Endpunkt ohne den Port übereinstimmen."
 
@@ -2728,18 +2728,18 @@ msgstr ""
 msgid "The link to reset your password expires in 24 hours."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:408
+#: src/components/TrixoQuestionnaireForm/index.tsx:407
 msgid "The minimum threshold above which your organization is required to collect/send Travel Rule information."
 msgstr "Der minimale Schwellenwert, ab dem Ihre Organisation verpflichtet ist, Reiseregelinformationen zu sammeln/zu senden."
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:48
 #: src/components/MemberDetails/index.tsx:177
-#: src/components/NameIdentifiers/index.tsx:38
-#: src/components/NameIdentifiers/index.tsx:45
+#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:44
 msgid "The name and type of name by which the legal person is known."
 msgstr "Der Name und die Art des Namens, unter dem die juristische Person bekannt ist."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:246
+#: src/components/TrixoQuestionnaireForm/index.tsx:245
 msgid "The name of primary regulator or supervisory authority for your national jurisdiction"
 msgstr "Der Name der primären Regulierungs- oder Aufsichtsbehörde für Ihre nationale Jurisdiktion"
 
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
 msgstr "Dieser Fragebogen soll TRISA-Mitgliedern dabei helfen, das regulatorische System Ihrer Organisation zu verstehen. Die bereitgestellten Informationen tragen dazu bei, dass der erforderliche Austausch von Informationen zur Einhaltung der Vorschriften korrekt und sicher durchgeführt wird. Alle verifizierten TRISA-Mitglieder haben Zugriff auf diese Informationen."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:353
+#: src/components/TrixoQuestionnaireForm/index.tsx:352
 msgid "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
 msgstr "Schwellenwert für die Durchführung von KYC, bevor dem Kunden erlaubt wird, Überweisungen von virtuellen Vermögenswerten zu senden/empfangen"
 
@@ -2864,8 +2864,8 @@ msgstr ""
 msgid "VERIFIED"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:255
-#: src/components/Section/SearchDirectory.tsx:324
+#: src/components/Section/SearchDirectory.tsx:258
+#: src/components/Section/SearchDirectory.tsx:323
 msgid "VERIFIED ON"
 msgstr "VERIFIZIERT AN"
 
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:70
+#: src/components/OrganizationProfile/TrisaDetail.tsx:60
 msgid "Verified On"
 msgstr "Verifiziert An"
 
@@ -2934,12 +2934,12 @@ msgstr ""
 msgid "What is IVMS101?"
 msgstr "Was ist IVMS101?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:193
-#: src/components/TrixoQuestionnaireForm/index.tsx:377
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:192
+#: src/components/TrixoQuestionnaireForm/index.tsx:376
 msgid "What is the minimum threshold for Travel Rule compliance?"
 msgstr "Welches ist die Mindestschwelle für die Einhaltung der Reiserichtlinien?"
 
-#: src/components/Section/SearchDirectory.tsx:157
+#: src/components/Section/SearchDirectory.tsx:156
 msgid "What’s a Common name or VASP ID?"
 msgstr "Was ist ein Common Name oder eine VASP ID?"
 
@@ -2973,12 +2973,12 @@ msgstr ""
 msgid "X.509 Identity Certificates"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "YES"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:34
 #: src/constants/trixo.ts:5
 msgid "Yes"
@@ -3034,7 +3034,7 @@ msgstr ""
 msgid "Your TRISA Implementation"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:46
+#: src/components/OrganizationProfile/TrisaDetail.tsx:44
 msgid "Your TRISA {type} Details"
 msgstr ""
 
@@ -3194,7 +3194,7 @@ msgid ""
 "                    testing purposes."
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:137
+#: src/components/Collaborators/index.tsx:145
 msgid "you do not have permission to invite a collaborator"
 msgstr ""
 

--- a/web/gds-user-ui/src/locales/en/messages.po
+++ b/web/gds-user-ui/src/locales/en/messages.po
@@ -124,7 +124,7 @@ msgstr "4 TRISA Implementation"
 msgid "5 TRIXO Questionnaire"
 msgstr "5 TRIXO Questionnaire"
 
-#: src/components/Contacts/ContactForm/index.tsx:30
+#: src/components/Contacts/ContactForm/index.tsx:29
 msgid "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
 msgstr "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
 
@@ -157,7 +157,7 @@ msgid "Action"
 msgstr "Action"
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:70
-#: src/components/Collaborators/index.tsx:171
+#: src/components/Collaborators/index.tsx:179
 #: src/modules/dashboard/member/components/MemberTable.tsx:34
 msgid "Actions"
 msgstr "Actions"
@@ -175,11 +175,11 @@ msgstr "Add"
 msgid "Add Address"
 msgstr "Add Address"
 
-#: src/components/NameIdentifiers/index.tsx:51
+#: src/components/NameIdentifiers/index.tsx:50
 msgid "Add Another Legal Name"
 msgstr "Add Another Legal Name"
 
-#: src/components/Collaborators/index.tsx:140
+#: src/components/Collaborators/index.tsx:148
 msgid "Add Contact"
 msgstr "Add Contact"
 
@@ -195,11 +195,11 @@ msgstr "Add Jurisdiction"
 msgid "Add Linked Account"
 msgstr "Add Linked Account"
 
-#: src/components/NameIdentifiers/index.tsx:54
+#: src/components/NameIdentifiers/index.tsx:53
 msgid "Add Local Name"
 msgstr "Add Local Name"
 
-#: src/components/NameIdentifiers/index.tsx:57
+#: src/components/NameIdentifiers/index.tsx:56
 msgid "Add Phonetic Names"
 msgstr "Add Phonetic Names"
 
@@ -231,13 +231,13 @@ msgstr "Address line 1 e.g. building name/number, street name (required)"
 msgid "Address line 2 e.g. apartment or suite number"
 msgstr "Address line 2 e.g. apartment or suite number"
 
-#: src/components/Addresses/index.tsx:11
+#: src/components/Addresses/index.tsx:10
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:118
 #: src/components/MemberDetails/index.tsx:244
 msgid "Addresses"
 msgstr "Addresses"
 
-#: src/components/Contacts/ContactsForm.tsx:158
+#: src/components/Contacts/ContactsForm.tsx:161
 msgid "Administrative Contact (optional)"
 msgstr "Administrative Contact (optional)"
 
@@ -253,7 +253,7 @@ msgstr "Administrative Contact Name"
 msgid "Administrative Contact Phone"
 msgstr "Administrative Contact Phone"
 
-#: src/components/Contacts/ContactsForm.tsx:159
+#: src/components/Contacts/ContactsForm.tsx:162
 msgid "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
 msgstr "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
 
@@ -291,7 +291,7 @@ msgstr "An error has occurred to load {type} metric"
 msgid "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
 msgstr "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
 
-#: src/components/NameIdentification/index.tsx:130
+#: src/components/NationalIdentification/index.tsx:129
 msgid "An identifier issued by an appropriate issuing authority"
 msgstr "An identifier issued by an appropriate issuing authority"
 
@@ -299,8 +299,8 @@ msgstr "An identifier issued by an appropriate issuing authority"
 msgid "App version {appVersion}"
 msgstr "App version {appVersion}"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:174
-#: src/components/TrixoQuestionnaireForm/index.tsx:417
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:173
+#: src/components/TrixoQuestionnaireForm/index.tsx:416
 msgid "Applicable Regulations"
 msgstr "Applicable Regulations"
 
@@ -312,13 +312,13 @@ msgstr "Apply to Become a TRISA-certified Virtual Asset Service Provider."
 msgid "At least 9 characters in length"
 msgstr "At least 9 characters in length"
 
-#: src/components/Addresses/index.tsx:14
+#: src/components/Addresses/index.tsx:13
 msgid "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
 msgstr "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:143
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:142
 #: src/components/MemberDetails/index.tsx:589
-#: src/components/TrixoQuestionnaireForm/index.tsx:322
+#: src/components/TrixoQuestionnaireForm/index.tsx:321
 msgid "At what threshold and currency does your organization conduct KYC checks?"
 msgstr "At what threshold and currency does your organization conduct KYC checks?"
 
@@ -351,11 +351,11 @@ msgstr "Become Travel Rule compliant."
 #~ msgid "Beware the Ides of March"
 #~ msgstr "Beware the Ides of March"
 
-#: src/components/Contacts/ContactsForm.tsx:163
+#: src/components/Contacts/ContactsForm.tsx:168
 msgid "Billing Contact (optional)"
 msgstr "Billing Contact (optional)"
 
-#: src/components/Contacts/ContactsForm.tsx:164
+#: src/components/Contacts/ContactsForm.tsx:169
 msgid "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
 msgstr "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
 
@@ -393,7 +393,7 @@ msgstr "Business or Compliance Office"
 msgid "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
 msgstr "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:282
+#: src/components/TrixoQuestionnaireForm/index.tsx:281
 msgid "CDD & Travel Rule Policies"
 msgstr "CDD & Travel Rule Policies"
 
@@ -409,7 +409,7 @@ msgstr "CDD and data protection policies"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:80
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:79
 msgid "Certificate Common Name"
 msgstr "Certificate Common Name"
 
@@ -500,7 +500,7 @@ msgstr "Click “Yes” if you have copied the PKCS12 password and have securely
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:158
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:198
-#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:74
+#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:75
 msgid "Close"
 msgstr "Close"
 
@@ -529,9 +529,9 @@ msgstr "Collaborators"
 #: src/components/CertificateDetails/CertificateDetails.tsx:286
 #: src/components/CertificateInventory/index.tsx:206
 #: src/components/CertificateInventory/index.tsx:269
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:63
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:83
-#: src/components/Section/SearchDirectory.tsx:215
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:62
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:82
+#: src/components/Section/SearchDirectory.tsx:217
 #: src/components/Section/SearchDirectory.tsx:283
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:79
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:89
@@ -542,7 +542,7 @@ msgstr "Common Name"
 #~ msgid "Common name or VASP ID"
 #~ msgstr "Common name or VASP ID"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:42
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:41
 msgid "Common name should match the TRISA endpoint without the port."
 msgstr "Common name should match the TRISA endpoint without the port."
 
@@ -603,7 +603,7 @@ msgstr "Compliance, Technical, Admininstrative, Billing"
 msgid "Comply with the Travel Rule"
 msgstr "Comply with the Travel Rule"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:313
+#: src/components/TrixoQuestionnaireForm/index.tsx:312
 msgid "Conducts KYC before virtual asset transfers"
 msgstr "Conducts KYC before virtual asset transfers"
 
@@ -615,7 +615,7 @@ msgstr "Confirm"
 msgid "Confirm New Password"
 msgstr "Confirm New Password"
 
-#: src/components/Collaborators/index.tsx:156
+#: src/components/Collaborators/index.tsx:164
 msgid "Contact Details"
 msgstr "Contact Details"
 
@@ -632,7 +632,7 @@ msgid "Contact information for representatives of your organization. Contacts in
 msgstr "Contact information for representatives of your organization. Contacts include Technical, Legal/Compliance, Administrative, and Billing persons."
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:21
-#: src/components/OrganizationProfile/OrganizationalDetail.tsx:157
+#: src/components/OrganizationProfile/OrganizationalDetail.tsx:158
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:165
 msgid "Contacts"
 msgstr "Contacts"
@@ -674,8 +674,8 @@ msgstr "Copy"
 #: src/components/CertificateDetails/CertificateDetails.tsx:292
 #: src/components/CertificateInventory/index.tsx:212
 #: src/components/CertificateInventory/index.tsx:275
-#: src/components/Section/SearchDirectory.tsx:239
-#: src/components/Section/SearchDirectory.tsx:308
+#: src/components/Section/SearchDirectory.tsx:242
+#: src/components/Section/SearchDirectory.tsx:307
 msgid "Country"
 msgstr "Country"
 
@@ -684,16 +684,16 @@ msgid "Country (required)"
 msgstr "Country (required)"
 
 #: src/components/MemberDetails/index.tsx:321
-#: src/components/NameIdentification/index.tsx:174
+#: src/components/NationalIdentification/index.tsx:173
 msgid "Country of Issue"
 msgstr "Country of Issue"
 
-#: src/components/NameIdentification/index.tsx:178
+#: src/components/NationalIdentification/index.tsx:177
 msgid "Country of Issue is reserved for National Identifiers of Natural Persons"
 msgstr "Country of Issue is reserved for National Identifiers of Natural Persons"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:138
-#: src/components/CountryOfRegistration/index.tsx:19
+#: src/components/CountryOfRegistration/index.tsx:18
 #: src/components/MemberDetails/index.tsx:271
 #: src/components/MemberDetails/index.tsx:331
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:137
@@ -756,11 +756,11 @@ msgstr "Created and maintained by"
 msgid "Current Name"
 msgstr "Current Name"
 
-#: src/components/Sidebar/MobileNav.tsx:83
+#: src/components/Sidebar/MobileNav.tsx:81
 msgid "Current Organization name"
 msgstr "Current Organization name"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:89
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:88
 msgid "Customer Due Diligence (CDD) & Travel Rule Policies"
 msgstr "Customer Due Diligence (CDD) & Travel Rule Policies"
 
@@ -772,8 +772,8 @@ msgstr "Customer Number"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:207
-#: src/components/TrixoQuestionnaireForm/index.tsx:429
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:206
+#: src/components/TrixoQuestionnaireForm/index.tsx:428
 msgid "Data Protection Policies"
 msgstr "Data Protection Policies"
 
@@ -841,11 +841,11 @@ msgstr "Directory Lookup"
 msgid "Documentation"
 msgstr "Documentation"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:307
+#: src/components/TrixoQuestionnaireForm/index.tsx:306
 msgid "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:123
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:122
 msgid "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 
@@ -861,7 +861,7 @@ msgstr ""
 "                      Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the\n"
 "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:297
+#: src/components/TrixoQuestionnaireForm/index.tsx:296
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money\n"
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
@@ -871,7 +871,7 @@ msgstr ""
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:99
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:98
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
@@ -879,11 +879,11 @@ msgstr ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:446
+#: src/components/TrixoQuestionnaireForm/index.tsx:445
 msgid "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
 msgstr "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:234
 msgid ""
 "Does your organization secure and protect Personally Identifiable\n"
 "                Information (PII), including Personally Identifiable\n"
@@ -915,7 +915,7 @@ msgstr "ERRORED"
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
 msgstr "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
 
-#: src/components/TrisaImplementation/index.tsx:66
+#: src/components/TrisaImplementation/index.tsx:65
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
 msgstr "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
 
@@ -931,7 +931,7 @@ msgid "Edit collaborator Role"
 msgstr "Edit collaborator Role"
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:129
-#: src/components/Contacts/ContactForm/index.tsx:67
+#: src/components/Contacts/ContactForm/index.tsx:66
 #: src/components/Form/LoginForm.tsx:52
 #: src/components/Form/SignupForm.tsx:53
 #: src/components/Section/PasswordResetForm.tsx:26
@@ -968,8 +968,8 @@ msgstr "Email is required."
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:181
 #: src/components/CertificateInventory/index.tsx:116
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:57
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:77
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:56
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:76
 msgid "Endpoint"
 msgstr "Endpoint"
 
@@ -985,7 +985,7 @@ msgstr "Enter New Password"
 msgid "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
 msgstr "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
 
-#: src/components/NameIdentifiers/index.tsx:31
+#: src/components/NameIdentifiers/index.tsx:30
 msgid "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
 msgstr "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
 
@@ -1049,7 +1049,7 @@ msgstr "Final review and form submission"
 msgid "First (Given) Name"
 msgstr "First (Given) Name"
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:67
+#: src/components/OrganizationProfile/TrisaDetail.tsx:57
 msgid "First Listed"
 msgstr "First Listed"
 
@@ -1061,7 +1061,7 @@ msgstr "Follow the instructions below to reset your TRISA password"
 msgid "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
 msgstr "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
 
-#: src/components/NameIdentification/index.tsx:32
+#: src/components/NationalIdentification/index.tsx:31
 msgid "For identifiers other than LEI specify the registration authority from the following list. See"
 msgstr "For identifiers other than LEI specify the registration authority from the following list. See"
 
@@ -1073,7 +1073,7 @@ msgstr "Foreign Investment Identity Number"
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
-#: src/components/Contacts/ContactForm/index.tsx:58
+#: src/components/Contacts/ContactForm/index.tsx:57
 msgid "Full Name"
 msgstr "Full Name"
 
@@ -1081,7 +1081,7 @@ msgstr "Full Name"
 msgid "Full name"
 msgstr "Full name"
 
-#: src/components/NameIdentification/index.tsx:40
+#: src/components/NationalIdentification/index.tsx:39
 msgid "GLEIF Registration Authorities"
 msgstr "GLEIF Registration Authorities"
 
@@ -1130,7 +1130,7 @@ msgstr "I acknowledge that requesting a new X.509 Identity Certificate will inva
 #~ msgid "I have a bad feeling about tomorrow."
 #~ msgstr "I have a bad feeling about tomorrow."
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:64
+#: src/components/OrganizationProfile/TrisaDetail.tsx:54
 msgid "ID"
 msgstr "ID"
 
@@ -1144,14 +1144,14 @@ msgstr "IVMS 101 data structure"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:165
 #: src/components/MemberDetails/index.tsx:303
-#: src/components/NameIdentification/index.tsx:127
+#: src/components/NationalIdentification/index.tsx:126
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:112
 msgid "Identification Number"
 msgstr "Identification Number"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:171
 #: src/components/MemberDetails/index.tsx:311
-#: src/components/NameIdentification/index.tsx:156
+#: src/components/NationalIdentification/index.tsx:155
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:120
 msgid "Identification Type"
 msgstr "Identification Type"
@@ -1164,7 +1164,7 @@ msgstr "Identity Card Number"
 msgid "Identity Certificates"
 msgstr "Identity Certificates"
 
-#: src/components/Contacts/ContactForm/index.tsx:41
+#: src/components/Contacts/ContactForm/index.tsx:40
 msgid "If supplied, use full phone number with country code"
 msgstr "If supplied, use full phone number with country code"
 
@@ -1242,16 +1242,16 @@ msgstr "Interoperable"
 #~ msgid "Invalid date."
 #~ msgstr "Invalid date."
 
-#: src/components/Collaborators/index.tsx:165
+#: src/components/Collaborators/index.tsx:173
 msgid "Invited"
 msgstr "Invited"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:67
-#: src/components/TrixoQuestionnaireForm/index.tsx:274
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:66
+#: src/components/TrixoQuestionnaireForm/index.tsx:273
 msgid "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
 msgstr "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:215
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:214
 msgid ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
@@ -1259,12 +1259,12 @@ msgstr ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:433
+#: src/components/TrixoQuestionnaireForm/index.tsx:432
 msgid "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
 msgstr "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:154
-#: src/components/TrixoQuestionnaireForm/index.tsx:363
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:153
+#: src/components/TrixoQuestionnaireForm/index.tsx:362
 msgid "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
 msgstr "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
 
@@ -1301,7 +1301,7 @@ msgstr "Join the TRISA network today."
 #~ msgid "Join us on Thursday Apr 28 for the TRISA Working Group."
 #~ msgstr "Join us on Thursday Apr 28 for the TRISA Working Group."
 
-#: src/components/Collaborators/index.tsx:168
+#: src/components/Collaborators/index.tsx:176
 #: src/modules/dashboard/member/components/MemberTable.tsx:22
 #: src/modules/dashboard/member/utils.ts:12
 msgid "Joined"
@@ -1319,7 +1319,7 @@ msgstr "Last Login"
 msgid "Last Login:"
 msgstr "Last Login:"
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:73
+#: src/components/OrganizationProfile/TrisaDetail.tsx:63
 #: src/modules/dashboard/member/components/MemberTable.tsx:25
 #: src/modules/dashboard/member/utils.ts:16
 msgid "Last Updated"
@@ -1378,7 +1378,7 @@ msgstr "Legal/ Compliance Contact (required)"
 msgid "Link Account"
 msgstr "Link Account"
 
-#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:36
 msgid "Local Name Identifiers"
 msgstr "Local Name Identifiers"
 
@@ -1426,7 +1426,7 @@ msgstr "Login"
 msgid "Login & Identity"
 msgstr "Login & Identity"
 
-#: src/components/Section/SearchDirectory.tsx:196
+#: src/components/Section/SearchDirectory.tsx:187
 msgid "MAINNET DIRECTORY RECORD"
 msgstr "MAINNET DIRECTORY RECORD"
 
@@ -1440,7 +1440,7 @@ msgid "MAINNET SUBMISSION"
 msgstr "MAINNET SUBMISSION"
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:53
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:72
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:51
 #: src/components/ReviewSubmit/index.tsx:224
 msgid "MainNet"
 msgstr "MainNet"
@@ -1508,16 +1508,16 @@ msgstr "Misc"
 #~ msgid "Missing required element"
 #~ msgstr "Missing required element"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:369
+#: src/components/TrixoQuestionnaireForm/index.tsx:368
 msgid "Must comply with Travel Rule"
 msgstr "Must comply with Travel Rule"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:439
+#: src/components/TrixoQuestionnaireForm/index.tsx:438
 msgid "Must safeguard PII"
 msgstr "Must safeguard PII"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "NO"
 msgstr "NO"
 
@@ -1527,7 +1527,7 @@ msgid "NO VERIFICATION"
 msgstr "NO VERIFICATION"
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:57
-#: src/components/NameIdentifier/index.tsx:118
+#: src/components/NameIdentifier/index.tsx:117
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:19
 msgid "Name"
 msgstr "Name"
@@ -1546,7 +1546,7 @@ msgstr "Name Identifier Type is required."
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:43
 #: src/components/MemberDetails/index.tsx:172
-#: src/components/NameIdentifiers/index.tsx:29
+#: src/components/NameIdentifiers/index.tsx:28
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:68
 msgid "Name Identifiers"
 msgstr "Name Identifiers"
@@ -1555,8 +1555,8 @@ msgstr "Name Identifiers"
 #~ msgid "Name identifiers"
 #~ msgstr "Name identifiers"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:43
-#: src/components/TrixoQuestionnaireForm/index.tsx:245
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:42
+#: src/components/TrixoQuestionnaireForm/index.tsx:244
 msgid "Name of Primary Regulator"
 msgstr "Name of Primary Regulator"
 
@@ -1566,7 +1566,7 @@ msgstr "Name, Addresss, Country, National Identifier"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:156
 #: src/components/MemberDetails/index.tsx:298
-#: src/components/NameIdentification/index.tsx:115
+#: src/components/NationalIdentification/index.tsx:114
 msgid "National Identification"
 msgstr "National Identification"
 
@@ -1612,7 +1612,7 @@ msgstr "Next"
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:26
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:33
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:31
 #: src/constants/trixo.ts:7
 msgid "No"
@@ -1686,7 +1686,7 @@ msgstr "Organization"
 
 #: src/components/BasicDetailsForm/index.tsx:120
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:30
-#: src/components/Section/SearchDirectory.tsx:209
+#: src/components/Section/SearchDirectory.tsx:211
 #: src/components/Section/SearchDirectory.tsx:277
 msgid "Organization Name"
 msgstr "Organization Name"
@@ -1715,8 +1715,8 @@ msgstr "Organization:"
 msgid "Organizational Details"
 msgstr "Organizational Details"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:49
-#: src/components/TrixoQuestionnaireForm/index.tsx:251
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:48
+#: src/components/TrixoQuestionnaireForm/index.tsx:250
 msgid "Other Jurisdictions"
 msgstr "Other Jurisdictions"
 
@@ -1765,11 +1765,11 @@ msgstr "Permission:"
 msgid "Permissions"
 msgstr "Permissions"
 
-#: src/components/Contacts/ContactForm/index.tsx:91
+#: src/components/Contacts/ContactForm/index.tsx:90
 msgid "Phone Number"
 msgstr "Phone Number"
 
-#: src/components/NameIdentifiers/index.tsx:44
+#: src/components/NameIdentifiers/index.tsx:43
 msgid "Phonetic Name Identifiers"
 msgstr "Phonetic Name Identifiers"
 
@@ -1777,7 +1777,7 @@ msgstr "Phonetic Name Identifiers"
 msgid "Please Provide the Name and Email Address"
 msgstr "Please Provide the Name and Email Address"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:254
+#: src/components/TrixoQuestionnaireForm/index.tsx:253
 msgid "Please add any other regulatory jurisdictions your organization complies with."
 msgstr "Please add any other regulatory jurisdictions your organization complies with."
 
@@ -1821,11 +1821,11 @@ msgstr "Please review the information provided, edit as needed, and submit to co
 msgid "Please select as many categories needed to represent the types of virtual asset services your organization provides."
 msgstr "Please select as many categories needed to represent the types of virtual asset services your organization provides."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:420
+#: src/components/TrixoQuestionnaireForm/index.tsx:419
 msgid "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
 msgstr "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
 
-#: src/components/NameIdentification/index.tsx:118
+#: src/components/NationalIdentification/index.tsx:117
 msgid "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
 msgstr "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
 
@@ -1833,15 +1833,15 @@ msgstr "Please supply a valid national identification number. TRISA recommends t
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
 msgstr "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
 
-#: src/components/Contacts/index.tsx:62
+#: src/components/Contacts/index.tsx:61
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 
-#: src/components/Contacts/ContactForm/index.tsx:23
+#: src/components/Contacts/ContactForm/index.tsx:22
 msgid "Please use the email address associated with your organization."
 msgstr "Please use the email address associated with your organization."
 
-#: src/components/Contacts/ContactForm/index.tsx:21
+#: src/components/Contacts/ContactForm/index.tsx:20
 msgid "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 
@@ -1860,7 +1860,7 @@ msgstr "Postal Code"
 msgid "Postal Code / Postcode / ZIP Code"
 msgstr "Postal Code / Postcode / ZIP Code"
 
-#: src/components/Contacts/ContactForm/index.tsx:59
+#: src/components/Contacts/ContactForm/index.tsx:58
 msgid "Preferred name for email communication."
 msgstr "Preferred name for email communication."
 
@@ -1868,12 +1868,12 @@ msgstr "Preferred name for email communication."
 msgid "Previous"
 msgstr "Previous"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:37
-#: src/components/TrixoQuestionnaireForm/index.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:36
+#: src/components/TrixoQuestionnaireForm/index.tsx:234
 msgid "Primary National Jurisdiction"
 msgstr "Primary National Jurisdiction"
 
-#: src/components/Contacts/ContactsForm.tsx:154
+#: src/components/Contacts/ContactsForm.tsx:155
 msgid "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
 msgstr "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
 
@@ -1930,12 +1930,12 @@ msgstr "Reg Authority"
 msgid "Region / Province / State (required)"
 msgstr "Region / Province / State (required)"
 
-#: src/components/Section/SearchDirectory.tsx:227
+#: src/components/Section/SearchDirectory.tsx:229
 #: src/components/Section/SearchDirectory.tsx:295
 msgid "Registered Directory"
 msgstr "Registered Directory"
 
-#: src/components/NameIdentification/index.tsx:196
+#: src/components/NationalIdentification/index.tsx:195
 msgid "Registration Authority"
 msgstr "Registration Authority"
 
@@ -1963,7 +1963,7 @@ msgstr "Regulator Name"
 msgid "Remove Linked Account"
 msgstr "Remove Linked Account"
 
-#: src/components/NameIdentifier/index.tsx:137
+#: src/components/NameIdentifier/index.tsx:136
 #: src/components/OtherJuridictions/index.tsx:58
 #: src/components/Regulations/index.tsx:31
 msgid "Remove line"
@@ -2009,7 +2009,7 @@ msgstr "Review"
 msgid "Review section"
 msgstr "Review section"
 
-#: src/components/Collaborators/index.tsx:159
+#: src/components/Collaborators/index.tsx:167
 #: src/components/UserProfile/UserDetails.tsx:22
 msgid "Role"
 msgstr "Role"
@@ -2026,7 +2026,7 @@ msgstr "SECURITY"
 msgid "SUBMITTED"
 msgstr "SUBMITTED"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:452
+#: src/components/TrixoQuestionnaireForm/index.tsx:451
 msgid "Safeguards PII"
 msgstr "Safeguards PII"
 
@@ -2058,7 +2058,7 @@ msgstr "Search the Directory Service"
 msgid "Section"
 msgstr "Section"
 
-#: src/components/BasicDetail/index.tsx:132
+#: src/components/BasicDetail/index.tsx:130
 #: src/components/CertificateReview/BasicDetailsReview.tsx:29
 #: src/components/CertificateSection/index.tsx:23
 #: src/components/CertificateSection/index.tsx:65
@@ -2073,17 +2073,17 @@ msgstr "Section 2: Legal Person"
 
 #: src/components/CertificateReview/ContactsReview.tsx:19
 #: src/components/CertificateSection/index.tsx:36
-#: src/components/Contacts/index.tsx:56
+#: src/components/Contacts/index.tsx:55
 msgid "Section 3: Contacts"
 msgstr "Section 3: Contacts"
 
 #: src/components/CertificateReview/TrisaImplementationReview.tsx:19
 #: src/components/CertificateSection/index.tsx:41
-#: src/components/TrisaImplementation/index.tsx:60
+#: src/components/TrisaImplementation/index.tsx:59
 msgid "Section 4: TRISA Implementation"
 msgstr "Section 4: TRISA Implementation"
 
-#: src/components/CertificateReview/TrixoReview.tsx:34
+#: src/components/CertificateReview/TrixoReview.tsx:32
 #: src/components/CertificateSection/index.tsx:46
 #: src/components/TrixoQuestionnaire/index.tsx:55
 msgid "Section 5: TRIXO Questionnaire"
@@ -2114,7 +2114,7 @@ msgstr "Select VASP category"
 msgid "Select a VASP from the Managed VASP List"
 msgstr "Select a VASP from the Managed VASP List"
 
-#: src/components/CountryOfRegistration/index.tsx:28
+#: src/components/CountryOfRegistration/index.tsx:27
 msgid "Select a country"
 msgstr "Select a country"
 
@@ -2218,8 +2218,8 @@ msgstr "Start trial"
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:67
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:45
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:63
-#: src/components/Collaborators/index.tsx:162
-#: src/components/OrganizationProfile/TrisaDetail.tsx:76
+#: src/components/Collaborators/index.tsx:170
+#: src/components/OrganizationProfile/TrisaDetail.tsx:66
 #: src/modules/dashboard/member/components/MemberTable.tsx:31
 #: src/modules/dashboard/member/utils.ts:24
 msgid "Status"
@@ -2252,7 +2252,7 @@ msgid "Subject Details"
 msgstr "Subject Details"
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:39
-#: src/components/NeedsAttention/AttentionAlert.tsx:98
+#: src/components/NeedsAttention/AttentionAlert.tsx:97
 #: src/components/Section/PasswordResetForm.tsx:48
 #: src/hoc/withRHF.tsx:117
 msgid "Submit"
@@ -2282,7 +2282,7 @@ msgstr "Switch Accounts"
 msgid "Synga Bridge"
 msgstr "Synga Bridge"
 
-#: src/components/Section/SearchDirectory.tsx:188
+#: src/components/Section/SearchDirectory.tsx:195
 msgid "TESTNET DIRECTORY RECORD"
 msgstr "TESTNET DIRECTORY RECORD"
 
@@ -2298,13 +2298,13 @@ msgstr "TRISA Certificate Types"
 #~ msgid "TRISA Certificates"
 #~ msgstr "TRISA Certificates"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:67
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:66
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:75
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:83
 msgid "TRISA Endpoint"
 msgstr "TRISA Endpoint"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:149
+#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:150
 msgid "TRISA Endpoint: MainNet"
 msgstr "TRISA Endpoint: MainNet"
 
@@ -2336,7 +2336,7 @@ msgstr "TRISA Implementations"
 msgid "TRISA Member Directory"
 msgstr "TRISA Member Directory"
 
-#: src/components/Section/SearchDirectory.tsx:233
+#: src/components/Section/SearchDirectory.tsx:235
 #: src/components/Section/SearchDirectory.tsx:301
 msgid "TRISA Member ID"
 msgstr "TRISA Member ID"
@@ -2353,13 +2353,13 @@ msgstr "TRISA Member ID:"
 msgid "TRISA Registration Request Submitted!"
 msgstr "TRISA Registration Request Submitted!"
 
-#: src/components/Section/SearchDirectory.tsx:221
+#: src/components/Section/SearchDirectory.tsx:223
 #: src/components/Section/SearchDirectory.tsx:289
 msgid "TRISA Service Endpoint"
 msgstr "TRISA Service Endpoint"
 
-#: src/components/Section/SearchDirectory.tsx:250
-#: src/components/Section/SearchDirectory.tsx:319
+#: src/components/Section/SearchDirectory.tsx:253
+#: src/components/Section/SearchDirectory.tsx:318
 msgid "TRISA Verification"
 msgstr "TRISA Verification"
 
@@ -2480,7 +2480,7 @@ msgstr ""
 msgid "Tax Identification Number"
 msgstr "Tax Identification Number"
 
-#: src/components/Contacts/ContactsForm.tsx:153
+#: src/components/Contacts/ContactsForm.tsx:154
 msgid "Technical Contact (required)"
 msgstr "Technical Contact (required)"
 
@@ -2509,7 +2509,7 @@ msgid "Technical information about your endpoint for certificate issuance. Each 
 msgstr "Technical information about your endpoint for certificate issuance. Each VASP is required to establish a TRISA endpoint for inter-VASP communication."
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:33
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:52
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:71
 #: src/components/ReviewSubmit/index.tsx:132
 msgid "TestNet"
 msgstr "TestNet"
@@ -2560,7 +2560,7 @@ msgstr "Thank you. We have sent instructions to reset your password to"
 msgid "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
 msgstr "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
 
-#: src/components/Section/SearchDirectory.tsx:145
+#: src/components/Section/SearchDirectory.tsx:144
 msgid ""
 "The Common Name typically matches the Endpoint, without the port number\n"
 "                            at the end (e.g. trisa.myvasp.com) and is used to identify the subject\n"
@@ -2610,7 +2610,7 @@ msgstr "The Travel Rule Information Sharing Architecture (TRISA)"
 msgid "The VASP Name is required."
 msgstr "The VASP Name is required."
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:72
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:71
 msgid "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
 msgstr "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
 
@@ -2622,7 +2622,7 @@ msgstr "The collaborator has not been deleted"
 msgid "The collaborator has not been updated"
 msgstr "The collaborator has not been updated"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:58
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:57
 msgid "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
 msgstr "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
 
@@ -2638,18 +2638,18 @@ msgstr "The following account will be removed from your profile. The linked acco
 msgid "The link to reset your password expires in 24 hours."
 msgstr "The link to reset your password expires in 24 hours."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:408
+#: src/components/TrixoQuestionnaireForm/index.tsx:407
 msgid "The minimum threshold above which your organization is required to collect/send Travel Rule information."
 msgstr "The minimum threshold above which your organization is required to collect/send Travel Rule information."
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:48
 #: src/components/MemberDetails/index.tsx:177
-#: src/components/NameIdentifiers/index.tsx:38
-#: src/components/NameIdentifiers/index.tsx:45
+#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:44
 msgid "The name and type of name by which the legal person is known."
 msgstr "The name and type of name by which the legal person is known."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:246
+#: src/components/TrixoQuestionnaireForm/index.tsx:245
 msgid "The name of primary regulator or supervisory authority for your national jurisdiction"
 msgstr "The name of primary regulator or supervisory authority for your national jurisdiction"
 
@@ -2673,7 +2673,7 @@ msgstr "This multi-section form is an important step in the registration and cer
 msgid "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
 msgstr "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:353
+#: src/components/TrixoQuestionnaireForm/index.tsx:352
 msgid "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
 msgstr "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
 
@@ -2770,8 +2770,8 @@ msgstr "VASPs have two options to integrate with TRISA."
 msgid "VERIFIED"
 msgstr "VERIFIED"
 
-#: src/components/Section/SearchDirectory.tsx:255
-#: src/components/Section/SearchDirectory.tsx:324
+#: src/components/Section/SearchDirectory.tsx:258
+#: src/components/Section/SearchDirectory.tsx:323
 msgid "VERIFIED ON"
 msgstr "VERIFIED ON"
 
@@ -2784,7 +2784,7 @@ msgstr "Verification Status:"
 msgid "Verified"
 msgstr "Verified"
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:70
+#: src/components/OrganizationProfile/TrisaDetail.tsx:60
 msgid "Verified On"
 msgstr "Verified On"
 
@@ -2840,12 +2840,12 @@ msgstr "We’ll be back soon."
 msgid "What is IVMS101?"
 msgstr "What is IVMS101?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:193
-#: src/components/TrixoQuestionnaireForm/index.tsx:377
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:192
+#: src/components/TrixoQuestionnaireForm/index.tsx:376
 msgid "What is the minimum threshold for Travel Rule compliance?"
 msgstr "What is the minimum threshold for Travel Rule compliance?"
 
-#: src/components/Section/SearchDirectory.tsx:157
+#: src/components/Section/SearchDirectory.tsx:156
 msgid "What’s a Common name or VASP ID?"
 msgstr "What’s a Common name or VASP ID?"
 
@@ -2879,12 +2879,12 @@ msgstr "X.509 Identity Certificate Inventory"
 msgid "X.509 Identity Certificates"
 msgstr "X.509 Identity Certificates"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "YES"
 msgstr "YES"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:34
 #: src/constants/trixo.ts:5
 msgid "Yes"
@@ -2934,7 +2934,7 @@ msgstr "You will receive"
 msgid "Your TRISA Implementation"
 msgstr "Your TRISA Implementation"
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:46
+#: src/components/OrganizationProfile/TrisaDetail.tsx:44
 msgid "Your TRISA {type} Details"
 msgstr "Your TRISA {type} Details"
 
@@ -3084,7 +3084,7 @@ msgstr ""
 "with detailed documentation, a reference implemenation, and “robot” VASPs for\n"
 "                    testing purposes."
 
-#: src/components/Collaborators/index.tsx:137
+#: src/components/Collaborators/index.tsx:145
 msgid "you do not have permission to invite a collaborator"
 msgstr "you do not have permission to invite a collaborator"
 

--- a/web/gds-user-ui/src/locales/es/messages.po
+++ b/web/gds-user-ui/src/locales/es/messages.po
@@ -1,38 +1,24 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-22 14:33+0000\n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language: en-dh\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2024-01-17 17:14-0500\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: \n"
-"MIME-Version: 1.0\n"
 "X-Generator: @lingui/cli\n"
-
-#: src/components/ReviewSubmit/index.tsx:103
-#~ msgid " Failure to click either confirmation will result in an incomplete registration"
-#~ msgstr "---"
+"Language: es\n"
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:67
 msgid ""
 " When you are verified you will be issued PKCS12 encrypted identity certificates\n"
 "                  for use in mTLS authentication between TRISA members. The password to decrypt\n"
 "                  those certificates is shown below:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:17
 msgid ""
 " create your TRISA account with your VASP email address. Add collaborators in your\n"
 "            organization."
-msgstr "---"
-
-#: src/components/ReviewSubmit/index.tsx:224
-#~ msgid " for MainNet registration so your MainNet certificate will be issued upon review by the validation team"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/InvalidFormPrompt.tsx:47
 msgid "\"Save & Next\" or \"Save & Previous\" button."
@@ -42,31 +28,23 @@ msgstr ""
 msgid "(1) <0>X.509 Identity Certificates:</0> X.509 Identity certificates are about <1>trust</1>. They prove the identity of the organization and are used to maintain a secure connection between TRISA members. X.509 Identity certificates must have an Endpoint and Common Name and may have Subject Alternative Names associated with them. TRISA’s X.509 Identity certificates are valid for one calendar year. TRISA’s X.509 Identity certificates expire after one year so member organizations must request a new X.509 Identity certificate upon expiration."
 msgstr ""
 
-#: src/components/CertificateManagement/index.tsx:60
-#~ msgid "(1)X.509 Identity Certificates"
-#~ msgstr "---"
-
 #: src/components/CertificateManagement/index.tsx:80
 msgid "(2) <0>Sealing Certificates:</0> Sealing certificates are for specific use cases such as <1>long-term data storage</1>. They are used to encrypt individual Secure Envelopes or batches of Secure Envelopes at the transactional level. Organizations may have multiple signing keys and multiple signing-key certificates for different clients, time periods, or use cases. In a compliance information transfer, the transactional sealing certificates are referred to as Envelope Seals. While an organization may use their X.509 Identity certificate as a sealing certificate, TRISA strongly recommends that transactional sealing certificates are different from X.509 Identity certificates for security purposes."
 msgstr ""
 
-#: src/components/CertificateManagement/index.tsx:72
-#~ msgid "(2)Sealing Certificates"
-#~ msgstr "---"
-
 #: src/components/CertificateSection/index.tsx:96
 #: src/components/SectionStatus/SavedSectionStatus.tsx:20
 msgid "(Saved)"
-msgstr "---"
+msgstr ""
 
 #: src/components/TravelRuleProviders/index.tsx:27
 #: src/components/TravelRuleProviders/index.tsx:33
 msgid "(not interoperable)"
-msgstr "---"
+msgstr ""
 
 #: src/components/SectionStatus/NotSavedSectionSection.tsx:20
 msgid "(not saved)"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/register.validation.ts:21
 msgid ""
@@ -77,53 +55,45 @@ msgid ""
 "* upper case letters (A-Z) \n"
 "* numbers (i.e. 0-9) \n"
 "* special characters (e.g. !@#$%^&*)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:97
 msgid "1 Basic Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:108
 msgid "2 Legal Person"
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:46
-#~ msgid "2022-03-14"
-#~ msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:40
-#~ msgid "2022-04-01"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:123
 msgid "3 Contacts"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:129
 #: src/components/TravelRuleProviders/index.tsx:9
 msgid "3rd Party Travel Rule Providers"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:133
 msgid "4 TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:142
 msgid "5 TRIXO Questionnaire"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:29
 msgid "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:20
 msgid "A component of"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:142
 #: src/components/ReviewSubmit/index.tsx:234
 msgid "A physical verification check in the form of a phone call"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:67
 msgid "APPEALED"
@@ -133,7 +103,7 @@ msgstr ""
 #: src/components/Header/LandingHeader.tsx:116
 #: src/components/Section/AboutUs.tsx:30
 msgid "About TRISA"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:63
 msgid "Account ID"
@@ -142,7 +112,7 @@ msgstr ""
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:48
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:66
 msgid "Action"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:70
 #: src/components/Collaborators/index.tsx:179
@@ -161,7 +131,7 @@ msgstr ""
 
 #: src/components/Addresses/AddressList.tsx:30
 msgid "Add Address"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:50
 msgid "Add Another Legal Name"
@@ -169,15 +139,11 @@ msgstr ""
 
 #: src/components/Collaborators/index.tsx:148
 msgid "Add Contact"
-msgstr "---"
+msgstr ""
 
 #: src/components/OtherJuridictions/index.tsx:67
 msgid "Add Jurisdiction"
-msgstr "---"
-
-#: src/components/NameIdentifiers/index.tsx:51
-#~ msgid "Add Legal Name"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/AddLinkedAccountModal.tsx:32
 msgid "Add Linked Account"
@@ -185,49 +151,45 @@ msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:53
 msgid "Add Local Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:56
 msgid "Add Phonetic Names"
-msgstr "---"
+msgstr ""
 
 #: src/components/Regulations/index.tsx:37
 msgid "Add Regulation"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:86
 msgid "Add new managed VASP"
 msgstr ""
 
-#: src/components/CollaboratorsSection/index.tsx:156
-#~ msgid "Added"
-#~ msgstr "---"
-
 #: src/components/Addresses/Address.tsx:17
 msgid "Address"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:117
 msgid "Address Type (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:40
 msgid "Address line 1 e.g. building name/number, street name (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:48
 msgid "Address line 2 e.g. apartment or suite number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Addresses/index.tsx:10
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:118
 #: src/components/MemberDetails/index.tsx:244
 msgid "Addresses"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:161
 msgid "Administrative Contact (optional)"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:67
 msgid "Administrative Contact Email"
@@ -243,37 +205,37 @@ msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:162
 msgid "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:13
 msgid "Alien Registration Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:55
 msgid "All TRISA members must complete TRISA’s VASP verification and due diligence process to become a Verified VASP."
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/SignupForm.tsx:85
 #: src/components/Section/IntegrateAndComply.tsx:198
 #: src/components/Section/VaspVerification.tsx:217
 msgid "Already have an account?"
-msgstr "---"
+msgstr ""
 
 #: src/components/NetworkAnnouncements/index.tsx:32
 msgid "An error has occurred to load announcements"
-msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/index.tsx:35
 msgid "An error has occurred to load attention data"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:19
 msgid "An error has occurred to load legal person data"
-msgstr "---"
+msgstr ""
 
 #: src/components/Metrics/index.tsx:18
 msgid "An error has occurred to load {type} metric"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:86
 msgid "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
@@ -281,56 +243,42 @@ msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:129
 msgid "An identifier issued by an appropriate issuing authority"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/Version.tsx:36
 msgid "App version {appVersion}"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:173
 #: src/components/TrixoQuestionnaireForm/index.tsx:416
 msgid "Applicable Regulations"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:32
 msgid "Apply to Become a TRISA-certified Virtual Asset Service Provider."
-msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:66
 msgid "At least 9 characters in length"
-msgstr "---"
+msgstr ""
 
 #: src/components/Addresses/index.tsx:13
 msgid "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:146
-#~ msgid "At what threshold and currency does your organization conduct KYC (Know your Counterparty)?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:142
 #: src/components/MemberDetails/index.tsx:589
 #: src/components/TrixoQuestionnaireForm/index.tsx:321
 msgid "At what threshold and currency does your organization conduct KYC checks?"
-msgstr "---"
-
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:140
-#: src/components/MemberDetails/index.tsx:580
-#: src/components/TrixoQuestionnaireForm/index.tsx:146
-#~ msgid "At what threshold and currency does your organization conduct KYC?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Footer/Version.tsx:42
 msgid "BFF & GDS version {bffAndGdsVersion}"
-msgstr "---"
+msgstr ""
 
 #: src/components/NotFound/index.tsx:25
 msgid "Back Home"
-msgstr "---"
-
-#: src/components/ReviewSubmit/index.tsx:298
-#~ msgid "Back to Review Page"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:323
 msgid "Back to Review section"
@@ -339,31 +287,27 @@ msgstr ""
 #: src/components/MemberDetails/index.tsx:90
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:159
 msgid "Basic Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:31
 msgid "Become Travel Rule compliant."
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:44
-#~ msgid "Beware the Ides of March"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:168
 msgid "Billing Contact (optional)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:169
 msgid "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
-msgstr "---"
+msgstr ""
 
 #: src/constants/address.ts:6
 msgid "Business"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:104
 msgid "Business Address"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:165
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:52
@@ -371,11 +315,11 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:27
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:24
 msgid "Business Category"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:9
 msgid "Business Details"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:110
 msgid "Business Entity"
@@ -385,19 +329,19 @@ msgstr ""
 #: src/components/Section/VaspVerification.tsx:120
 #: src/components/Section/VaspVerification.tsx:130
 msgid "Business or Compliance Office"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:9
 msgid "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:281
 msgid "CDD & Travel Rule Policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:34
 msgid "CDD and data protection policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:88
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:78
@@ -405,15 +349,15 @@ msgstr "---"
 #: src/components/UserProfile/AddLinkedAccountModal.tsx:48
 #: src/components/UserProfile/RemoveLinkedAccountModal.tsx:64
 msgid "Cancel"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:79
 msgid "Certificate Common Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:62
 msgid "Certificate Details"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:40
 msgid "Certificate Inventory"
@@ -422,25 +366,20 @@ msgstr ""
 #: src/components/CertificateManagement/index.tsx:31
 #: src/utils/menu.tsx:29
 msgid "Certificate Management"
-msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:191
 msgid "Certificate Progress"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/registration.tsx:26
 #: src/utils/menu.tsx:34
 msgid "Certificate Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/index.tsx:10
 msgid "Certificate Registration Process"
-msgstr "---"
-
-#: src/components/CertificateManagement/SealingCertificateTableRows.tsx:12
-#: src/components/CertificateManagement/X509TableRows.tsx:14
-#~ msgid "Change Permissions"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:165
 msgid "Change Role"
@@ -450,25 +389,21 @@ msgstr ""
 msgid "Check to delete user account."
 msgstr ""
 
-#: src/components/Section/IntegrateAndComply.tsx:134
-#~ msgid "CipherTrace Providers"
-#~ msgstr "---"
-
 #: src/components/Section/IntegrateAndComply.tsx:133
 msgid "CipherTrace Traveler"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:56
 msgid "City / Town / Municipality"
-msgstr "---"
+msgstr ""
 
 #: src/components/StepsButtons/index.tsx:63
 msgid "Clear & Reset Form"
-msgstr "---"
+msgstr ""
 
 #: src/components/Modal/ConfirmationResetFormModal.tsx:86
 msgid "Clear & Reset Registration Form"
-msgstr "---"
+msgstr ""
 
 #: src/components/Modal/ConfirmationResetFormModal.tsx:88
 #: src/components/StepsButtons/index.tsx:61
@@ -486,19 +421,15 @@ msgstr ""
 #: src/components/ReviewSubmit/index.tsx:130
 #: src/components/ReviewSubmit/index.tsx:222
 msgid "Click below to submit your"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:14
 msgid "Click “No” if you have not copied the PKCS12 password yet and would like to view and copy the password."
-msgstr "---"
-
-#: src/components/Modal/ConfirmationResetFormModal.tsx:62
-#~ msgid "Click “Reset” to clear and reset the registration form. All data will be deleted and you will be re-directed to the beginning of the form and you will be required to restart the registration process"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:19
 msgid "Click “Yes” if you have copied the PKCS12 password and have securely saved it."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:158
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:198
@@ -538,33 +469,16 @@ msgstr ""
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:79
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:89
 msgid "Common Name"
-msgstr "---"
-
-#: src/components/Section/SearchDirectory.tsx:91
-#~ msgid "Common name or VASP ID"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:41
 msgid "Common name should match the TRISA endpoint without the port."
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:40
-#~ msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:29
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:55
-#~ msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it and should have at least 2 characters after the periods"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:22
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:44
 msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it and should have at least 2 characters after the periods."
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:20
-#~ msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it, should have at least 2 characters after the periods"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/AttentionAlert.tsx:74
 msgid "Complete"
@@ -572,21 +486,21 @@ msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:34
 msgid "Complete Certficate Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:45
 msgid "Complete TRISA’s VASP Verfication Process"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:34
 msgid ""
 "Complete the multi-part TRISA verification form and due diligence process. Once\n"
 "            approved, gain access to the Testnet."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:19
 msgid "Complete the multi-part TRISA verification form and due diligence process. Once approved, gain access to the Testnet and MainNet."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:55
 msgid "Compliance / Legal Contact Email"
@@ -602,23 +516,23 @@ msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:151
 msgid "Compliance Officer"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:149
 msgid "Compliance officer or legal contact for requests about the compliance requirements and legal status of your organization. A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:22
 msgid "Compliance, Technical, Admininstrative, Billing"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:50
 msgid "Comply with the Travel Rule"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:312
 msgid "Conducts KYC before virtual asset transfers"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/RemoveLinkedAccountModal.tsx:61
 msgid "Confirm"
@@ -638,25 +552,25 @@ msgstr ""
 
 #: src/components/Section/UserEmailConfirmation.tsx:27
 msgid "Contact Verified"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:124
 msgid "Contact information for representatives of your organization. Contacts include Technical, Legal/Compliance, Administrative, and Billing persons."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:21
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:158
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:165
 msgid "Contacts"
-msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:71
 msgid "Contain at least 3 of the following 4 types of characters"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:34
 msgid "Continue"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:88
 #: src/components/Section/Login.tsx:75
@@ -666,7 +580,7 @@ msgstr ""
 #: src/components/Section/CreateAccount.tsx:62
 #: src/components/Section/Login.tsx:49
 msgid "Continue with Google"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:114
 #: src/components/Section/Login.tsx:101
@@ -676,12 +590,12 @@ msgstr ""
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:85
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:101
 msgid "Copied"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:87
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:105
 msgid "Copy"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:229
 #: src/components/CertificateDetails/CertificateDetails.tsx:292
@@ -690,20 +604,20 @@ msgstr "---"
 #: src/components/Section/SearchDirectory.tsx:242
 #: src/components/Section/SearchDirectory.tsx:307
 msgid "Country"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:97
 msgid "Country (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/MemberDetails/index.tsx:321
 #: src/components/NationalIdentification/index.tsx:173
 msgid "Country of Issue"
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:177
 msgid "Country of Issue is reserved for National Identifiers of Natural Persons"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:138
 #: src/components/CountryOfRegistration/index.tsx:18
@@ -713,23 +627,15 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:35
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:48
 msgid "Country of Registration"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:10
-#~ msgid "Country of registration is required"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:12
-#~ msgid "Country of registration is required."
-#~ msgstr ""
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:52
 msgid "Country:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:13
 msgid "Create Account"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/SignupForm.tsx:82
 msgid "Create Your Account"
@@ -739,11 +645,7 @@ msgstr ""
 #: src/components/Section/IntegrateAndComply.tsx:195
 #: src/components/Section/VaspVerification.tsx:213
 msgid "Create account"
-msgstr "---"
-
-#: src/components/Form/SignupForm.tsx:78
-#~ msgid "Create an Account"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:30
 msgid "Create your TRISA account"
@@ -751,19 +653,15 @@ msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:12
 msgid "Create your TRISA account with your VASP email address. Add collaborators in your organization."
-msgstr "---"
-
-#: src/components/Section/CreateAccount.tsx:41
-#~ msgid "Create your TRISA account."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:62
 msgid "Create your account today."
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:29
 msgid "Created and maintained by"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/ChangeNameForm.tsx:84
 msgid "Current Name"
@@ -775,49 +673,40 @@ msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:88
 msgid "Customer Due Diligence (CDD) & Travel Rule Policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/CustomerNumber/index.tsx:17
 msgid "Customer Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Navbar/Landing/MobileNav.tsx:69
 msgid "Dashboard"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:206
 #: src/components/TrixoQuestionnaireForm/index.tsx:428
 msgid "Data Protection Policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:144
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:59
 #: src/components/MemberDetails/index.tsx:117
 msgid "Date of Incorporation / Establishment"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:42
 msgid "Date of incorporation / establishment must be earlier than current date."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:33
 #: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:39
 msgid "Date of incorporation / establishment must be later than"
 msgstr ""
 
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:29
-#~ msgid "Date of incorporation / establishment must be later than {0}."
-#~ msgstr "---"
-
-#: src/components/CertificateManagement/SealingCertificateTableRows.tsx:15
-#: src/components/CertificateManagement/X509TableRows.tsx:17
-#~ msgid "Deactivate"
-#~ msgstr "---"
-
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:155
 #: src/components/ui/DeleteButton.tsx:15
 msgid "Delete"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:116
 msgid "Delete Collaborator"
@@ -825,7 +714,7 @@ msgstr ""
 
 #: src/components/Addresses/Address.tsx:26
 msgid "Delete the address line"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:121
 msgid "Delete the following collaborator from the VASP account. The collaborator will no longer have access to the account."
@@ -833,17 +722,17 @@ msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:60
 msgid "Description"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:41
 #: src/components/Tables/MembersRow.tsx:50
 msgid "Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:97
 #: src/components/Section/SearchDirectory.tsx:91
 msgid "Directory Lookup"
-msgstr "---"
+msgstr ""
 
 #: src/components/Header/LandingHeader.tsx:82
 #: src/components/Header/LandingHeader.tsx:119
@@ -852,34 +741,15 @@ msgstr "---"
 #: src/components/OpenSourceResources/index.tsx:20
 #: src/components/Section/IntegrateAndComply.tsx:155
 msgid "Documentation"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:306
 msgid "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
-msgstr "---"
-
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:124
-#~ msgid ""
-#~ "Does your organization conduct Know your Counterparty/Customer Due\n"
-#~ "                Diligence (KYC/CDD) before permitting its customers to send/receive virtual asset transfers?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:122
 msgid "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:123
-#~ msgid "Does your organization have a programme that sets minimum AML, CFT, KYC/CDD and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-#~ msgstr "---"
-
-#: src/components/MemberDetails/index.tsx:543
-#~ msgid ""
-#~ "Does your organization have a programme that sets minimum Anti-Money\n"
-#~ "                      Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
-#~ "                      Counterparty/Customer Due Diligence (KYC/CDD) (Know your Counterparty/Customer\n"
-#~ "                      Due Diligence) and Sanctions standards per the requirements of the\n"
-#~ "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/MemberDetails/index.tsx:543
 msgid ""
@@ -887,41 +757,41 @@ msgid ""
 "                      Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "                      Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the\n"
 "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:296
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money\n"
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:98
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:445
 msgid "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:234
 msgid ""
 "Does your organization secure and protect Personally Identifiable\n"
 "                Information (PII), including Personally Identifiable\n"
 "                Information (PII) received from other VASPs under the Travel Rule?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:189
 #: src/components/CertificateInventory/index.tsx:124
 #: src/components/TrisaVerifiedLogo/index.tsx:49
 msgid "Download"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:12
 msgid "Driver's License Number"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:52
 msgid "EMAIL VERIFIED"
@@ -933,18 +803,18 @@ msgstr ""
 
 #: src/components/CertificateSection/index.tsx:42
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/index.tsx:65
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:96
 #: src/components/CertificateInventory/index.tsx:51
 #: src/components/CertificateReview/CertificateReviewHeader.tsx:26
 #: src/components/Tables/CertificateRegistrationRow.tsx:102
 msgid "Edit"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:142
 msgid "Edit collaborator Role"
@@ -957,15 +827,7 @@ msgstr ""
 #: src/components/Section/PasswordResetForm.tsx:26
 #: src/components/UserProfile/index.tsx:57
 msgid "Email Address"
-msgstr "---"
-
-#: src/contexts/LanguageContext.tsx:21
-#: src/modules/auth/register/register.validation.ts:15
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:12
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:21
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:28
-#~ msgid "Email is not valid"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorFormValidation.ts:13
 #: src/contexts/LanguageContext.tsx:21
@@ -975,11 +837,6 @@ msgstr "---"
 #: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:26
 msgid "Email is not valid."
 msgstr ""
-
-#: src/modules/auth/register/register.validation.ts:16
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:22
-#~ msgid "Email is required"
-#~ msgstr "---"
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorFormValidation.ts:14
 #: src/modules/auth/register/register.validation.ts:16
@@ -991,7 +848,7 @@ msgstr ""
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:56
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:76
 msgid "Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/ChangePasswordModal.tsx:44
 msgid "Enter Current Password"
@@ -1003,25 +860,25 @@ msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:80
 msgid "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:30
 msgid "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordReset.tsx:77
 msgid "Enter your email address"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/index.tsx:70
 msgid "Error Submitting Certificate"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:35
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:64
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:42
 msgid "Expiration Date"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:149
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:98
@@ -1035,7 +892,7 @@ msgstr ""
 
 #: src/components/DetailsCard/index.tsx:84
 msgid "Expiry Date:"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberHeader.tsx:25
 msgid "Export"
@@ -1043,7 +900,7 @@ msgstr ""
 
 #: src/components/CertificateReview/ReviewsSummary.tsx:107
 msgid "Export Data"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/overview/index.tsx:37
 msgid "Failed to load Network announcement , please reload"
@@ -1055,15 +912,15 @@ msgstr ""
 
 #: src/components/FileUpload/index.tsx:68
 msgid "Files is required"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:162
 msgid "Final Confirmation"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:40
 msgid "Final review and form submission"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/ChangeNameForm.tsx:95
 msgid "First (Given) Name"
@@ -1071,31 +928,31 @@ msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:57
 msgid "First Listed"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordReset.tsx:72
 msgid "Follow the instructions below to reset your TRISA password"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:165
 msgid "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:31
 msgid "For identifiers other than LEI specify the registration authority from the following list. See"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:8
 msgid "Foreign Investment Identity Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/LoginForm.tsx:96
 msgid "Forgot password?"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:57
 msgid "Full Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:87
 msgid "Full name"
@@ -1103,27 +960,19 @@ msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:39
 msgid "GLEIF Registration Authorities"
-msgstr "---"
+msgstr ""
 
 #: src/constants/address.ts:7
 msgid "Geographic"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:288
-#~ msgid "Getting Started Help Guide"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Footer/Version.tsx:39
 msgid "Git Revision"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:98
 msgid "GitHub repository"
-msgstr "---"
-
-#: src/components/Sidebar/SidebarContent.tsx:48
-#~ msgid "Global Directory Service"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:107
 msgid "Government Entity"
@@ -1131,62 +980,58 @@ msgstr ""
 
 #: src/components/Sidebar/MobileNav.tsx:95
 msgid "Guest"
-msgstr "---"
+msgstr ""
 
 #: src/components/Navbar/Landing/MobileNav.tsx:70
 #: src/components/Navbar/Landing/Nav.tsx:20
 msgid "Home"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:117
 msgid "How to set up your own node?"
-msgstr "---"
+msgstr ""
 
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:54
 msgid "I acknowledge that requesting a new X.509 Identity Certificate will invalidate and revoke my organization’s current X.509 Identity Certificate."
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:45
-#~ msgid "I have a bad feeling about tomorrow."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:54
 msgid "ID"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:106
 msgid "ID:"
-msgstr "---"
+msgstr ""
 
 #: src/components/LegalPerson/index.tsx:71
 msgid "IVMS 101 data structure"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:165
 #: src/components/MemberDetails/index.tsx:303
 #: src/components/NationalIdentification/index.tsx:126
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:112
 msgid "Identification Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:171
 #: src/components/MemberDetails/index.tsx:311
 #: src/components/NationalIdentification/index.tsx:155
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:120
 msgid "Identification Type"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:11
 msgid "Identity Card Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Metrics/index.tsx:23
 msgid "Identity Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:40
 msgid "If supplied, use full phone number with country code"
-msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/InvalidFormPrompt.tsx:41
 msgid "If you continue, your changes will be lost. To save your changes, click Cancel and then click on the"
@@ -1198,12 +1043,12 @@ msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:28
 msgid "If you lose the PKCS12 password, you will have to the start the registration process from the beginning."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:155
 #: src/components/ReviewSubmit/index.tsx:246
 msgid "If you would like to edit your registration form before submitting, please return to the"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:258
 msgid "If you would like to register for MainNet, please provide a <0>MainNet Endpoint and Common Name</0>."
@@ -1211,7 +1056,7 @@ msgstr ""
 
 #: src/components/ReviewSubmit/MainNetWarningBox.tsx:9
 msgid "If you would like to register for MainNet, please provide a MainNet Endpoint and Common Name."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:168
 msgid "If you would like to register for TestNet, please provide a <0>TestNet Endpoint and Common Name</0>."
@@ -1219,56 +1064,44 @@ msgstr ""
 
 #: src/components/ReviewSubmit/TestNetWarningBox.tsx:10
 msgid "If you would like to register for TestNet, please provide a TestNet Endpoint and Common Name."
-msgstr "---"
+msgstr ""
 
 #: src/components/FileUpload/index.tsx:96
 msgid "Import File"
-msgstr "---"
+msgstr ""
 
 #: src/components/Tables/CertificateRegistrationRow.tsx:92
 msgid "Incomplete"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:98
 msgid "Incorporation Date"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:98
 msgid "Information about the VASP such as website, incorporation date, business and VASP category."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:109
 msgid "Information that identifies your organization as a Legal Person. This section represents the IVMS 101 data structure for legal persons and is strongly suggested for use as KYC information exchanged in TRISA transfers."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:143
 msgid "Information to ensure that required compliance information exchanges are conducted correctly and safely. This includes information about jurisdiction and national regulator, Customer Due Diligence(CDD) and Travel Rule policies, and data protection policies."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:50
 #: src/components/Section/MembershipGuide.tsx:25
 msgid "Integrate and Comply"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:43
 msgid "Integrate with TRISA."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:48
 msgid "Interoperable"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:18
-#~ msgid "Invalid date"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:19
-#~ msgid "Invalid date / year must be 4 digit"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:35
-#~ msgid "Invalid date."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/index.tsx:173
 msgid "Invited"
@@ -1277,41 +1110,32 @@ msgstr ""
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:66
 #: src/components/TrixoQuestionnaireForm/index.tsx:273
 msgid "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:258
-#~ msgid "Is your organization required by law to safeguard PII (Personally Identifiable Information)?"
-#~ msgstr "---"
-
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:231
-#: src/components/TrixoQuestionnaireForm/index.tsx:257
-#~ msgid "Is your organization required by law to safeguard PII?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:214
 msgid ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:432
 msgid "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:153
 #: src/components/TrixoQuestionnaireForm/index.tsx:362
 msgid "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:32
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:61
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:39
 msgid "Issue Date"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:76
 msgid "Issue Date:"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:169
 #: src/components/CertificateInventory/index.tsx:104
@@ -1320,21 +1144,17 @@ msgstr ""
 
 #: src/components/Maintenance/index.tsx:26
 msgid "Join"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:114
 msgid "Join Today"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/Login.tsx:117
 #: src/components/Section/PasswordResetFail.tsx:36
 #: src/components/Section/SearchDirectory.tsx:84
 msgid "Join the TRISA network today."
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:33
-#~ msgid "Join us on Thursday Apr 28 for the TRISA Working Group."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/index.tsx:176
 #: src/modules/dashboard/member/components/MemberTable.tsx:22
@@ -1352,18 +1172,18 @@ msgstr ""
 
 #: src/components/UserDetails/index.tsx:39
 msgid "Last Login:"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:63
 #: src/modules/dashboard/member/components/MemberTable.tsx:25
 #: src/modules/dashboard/member/utils.ts:16
 msgid "Last Updated"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:180
 #: src/components/Section/VaspVerification.tsx:182
 msgid "Learn How TRISA Works"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:19
 #: src/components/Section/GettingStarted.tsx:42
@@ -1371,34 +1191,34 @@ msgstr "---"
 #: src/components/Section/MembershipGuide.tsx:20
 #: src/components/Section/MembershipGuide.tsx:27
 msgid "Learn More"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:57
 msgid "Learn about the three-step process to become a member and verified VASP."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:76
 msgid "Learn how TRISA works."
-msgstr "---"
+msgstr ""
 
 #: src/constants/name-identifiers.ts:4
 msgid "Legal"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:4
 msgid "Legal Entity Identifier (LEI)"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:15
 #: src/components/MemberDetails/index.tsx:152
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:162
 #: src/components/RegistrationForm/StepLabel.tsx:29
 msgid "Legal Person"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:53
 msgid "Legal name is required"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:19
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:36
@@ -1407,7 +1227,7 @@ msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:148
 msgid "Legal/ Compliance Contact (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/AddLinkedAccountModal.tsx:45
 msgid "Link Account"
@@ -1415,7 +1235,7 @@ msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:36
 msgid "Local Name Identifiers"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:235
 #: src/components/CertificateDetails/CertificateDetails.tsx:298
@@ -1427,35 +1247,31 @@ msgstr ""
 #: src/components/Form/LoginForm.tsx:87
 #: src/components/Section/UserEmailConfirmation.tsx:41
 msgid "Log In"
-msgstr "---"
+msgstr ""
 
 #: src/components/Navbar/Landing/MobileNav.tsx:73
 #: src/components/Navbar/Landing/Nav.tsx:23
 msgid "Log in"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/success.tsx:36
 msgid "Log in to TRISA’s Global Directory Service"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/SignupForm.tsx:91
 #: src/components/Section/IntegrateAndComply.tsx:202
 #: src/components/Section/VaspVerification.tsx:221
 msgid "Log in."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/Login.tsx:24
 msgid "Log into your TRISA account"
 msgstr ""
 
-#: src/components/Section/Login.tsx:25
-#~ msgid "Log into your TRISA account."
-#~ msgstr "---"
-
 #: src/components/Header/LandingHeader.tsx:88
 #: src/components/Header/LandingHeader.tsx:125
 msgid "Login"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:52
 msgid "Login & Identity"
@@ -1463,7 +1279,7 @@ msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:187
 msgid "MAINNET DIRECTORY RECORD"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:93
 #: src/components/CertificateInventory/index.tsx:48
@@ -1472,17 +1288,17 @@ msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:219
 msgid "MAINNET SUBMISSION"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:53
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:51
 #: src/components/ReviewSubmit/index.tsx:224
 msgid "MainNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:64
 msgid "MainNet Certificate Common Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:102
 #: src/components/CertificateInventory/index.tsx:57
@@ -1492,7 +1308,7 @@ msgstr ""
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:37
 #: src/components/CertificateManagement/index.tsx:109
 msgid "MainNet Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:45
 msgid "MainNet Identity Certificates"
@@ -1500,23 +1316,23 @@ msgstr ""
 
 #: src/components/MetricsTabs/index.tsx:28
 msgid "MainNet Network Metrics"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:58
 msgid "MainNet TRISA Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/FileUpload/index.tsx:73
 msgid "Max file size 10mb"
-msgstr "---"
+msgstr ""
 
 #: src/components/OpenSourceResources/index.tsx:32
 msgid "Meet Alice VASP, Bob VASP and Evil VASP"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:167
 msgid "Meet Alice VASP, Bob VASP, and “Evil” VASP"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:54
 msgid "Member Directory"
@@ -1533,32 +1349,24 @@ msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:130
 msgid "Message from server:"
-msgstr "---"
+msgstr ""
 
 #: src/constants/name-identifiers.ts:7
 msgid "Misc"
-msgstr "---"
-
-#: src/components/TestnetProgress/CertificateStepLabel.tsx:123
-#~ msgid "Missing required element"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:368
 msgid "Must comply with Travel Rule"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:438
 msgid "Must safeguard PII"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:264
-#~ msgid "Must safeguard PII (Personally Identifiable Information)"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "NO"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:46
 #: src/modules/dashboard/member/utils.ts:72
@@ -1569,13 +1377,7 @@ msgstr ""
 #: src/components/NameIdentifier/index.tsx:117
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:19
 msgid "Name"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:25
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:42
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:59
-#~ msgid "Name Identifier Type is required"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:26
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:43
@@ -1588,35 +1390,31 @@ msgstr ""
 #: src/components/NameIdentifiers/index.tsx:28
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:68
 msgid "Name Identifiers"
-msgstr "---"
-
-#: src/components/NameIdentifiers/index.tsx:29
-#~ msgid "Name identifiers"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:42
 #: src/components/TrixoQuestionnaireForm/index.tsx:244
 msgid "Name of Primary Regulator"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:16
 msgid "Name, Addresss, Country, National Identifier"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:156
 #: src/components/MemberDetails/index.tsx:298
 #: src/components/NationalIdentification/index.tsx:114
 msgid "National Identification"
-msgstr "---"
+msgstr ""
 
 #: src/components/OtherJuridictions/index.tsx:39
 msgid "National Jurisdiction"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:176
 #: src/components/Section/VaspVerification.tsx:176
 msgid "Need to Learn More?"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberTable.tsx:28
 #: src/modules/dashboard/member/utils.ts:20
@@ -1625,12 +1423,12 @@ msgstr ""
 
 #: src/components/NetworkAnnouncements/caroussels.tsx:116
 msgid "Network Announcement"
-msgstr "---"
+msgstr ""
 
 #: src/components/NetworkStatus/index.tsx:15
 #: src/components/StatusCard/index.tsx:26
 msgid "Network Status"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/UnverifiedMember.tsx:15
 msgid "Network directory member list not available because you are not a verified contact for this network. Please complete the registration process."
@@ -1638,16 +1436,16 @@ msgstr ""
 
 #: src/components/Metrics/index.tsx:24
 msgid "New Members"
-msgstr "---"
+msgstr ""
 
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:41
 msgid "New X.509 Identity Certificate Request"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:85
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:74
 msgid "Next"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:26
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:33
@@ -1655,7 +1453,7 @@ msgstr "---"
 #: src/components/ReviewSubmit/ModalAlert.tsx:31
 #: src/constants/trixo.ts:7
 msgid "No"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:117
 msgid "No Certificate available"
@@ -1664,10 +1462,6 @@ msgstr ""
 #: src/components/NoData/NoData.tsx:14
 msgid "No Data"
 msgstr ""
-
-#: src/modules/dashboard/certificate/registration.tsx:298
-#~ msgid "No information is sent until you complete Section 6 - Review & Submit"
-#~ msgstr "---"
 
 #: src/modules/dashboard/certificate/registration.tsx:52
 msgid "No information is sent until you submit for a TestNet and/or MainNet Certificate after the Review section."
@@ -1679,38 +1473,38 @@ msgstr ""
 
 #: src/components/CertificateSection/index.tsx:87
 msgid "Not Saved"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:16
 msgid "Not Verified"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/Login.tsx:111
 #: src/components/Section/PasswordResetFail.tsx:34
 msgid "Not a TRISA Member?"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:26
 #: src/components/ReviewSubmit/index.tsx:100
 msgid "Note:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:39
 msgid "Open Source"
-msgstr "---"
+msgstr ""
 
 #: src/components/OpenSourceResources/index.tsx:9
 #: src/components/Section/IntegrateAndComply.tsx:146
 msgid "Open Source Resources"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:88
 msgid "Option 1. Set Up Your Own TRISA Node"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:107
 msgid "Option 2. Use a 3rd-party Solution"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:241
 #: src/components/CertificateDetails/CertificateDetails.tsx:304
@@ -1719,20 +1513,16 @@ msgstr "---"
 msgid "Organization"
 msgstr ""
 
-#: src/components/CollaboratorsSection/index.tsx:142
-#~ msgid "Organization Collaborators"
-#~ msgstr "---"
-
 #: src/components/BasicDetailsForm/index.tsx:120
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:30
 #: src/components/Section/SearchDirectory.tsx:211
 #: src/components/Section/SearchDirectory.tsx:277
 msgid "Organization Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:76
 msgid "Organization Type"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:247
 #: src/components/CertificateDetails/CertificateDetails.tsx:310
@@ -1741,27 +1531,23 @@ msgstr "---"
 msgid "Organization Unit"
 msgstr ""
 
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:40
-#~ msgid "Organization name is required"
-#~ msgstr "---"
-
 #: src/components/DetailsCard/index.tsx:68
 msgid "Organization:"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:30
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:63
 msgid "Organizational Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:48
 #: src/components/TrixoQuestionnaireForm/index.tsx:250
 msgid "Other Jurisdictions"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:23
 msgid "Overview"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:55
 msgid "PENDING REVIEW"
@@ -1769,36 +1555,32 @@ msgstr ""
 
 #: src/components/NotFound/index.tsx:15
 msgid "Page Not Found"
-msgstr "---"
+msgstr ""
 
 #: src/constants/trixo.ts:6
 msgid "Partially"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:53
 msgid "Participate in verified VASP-to-VASP Travel Rule exchanges."
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:10
 msgid "Passport Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/LoginForm.tsx:64
 #: src/components/Form/SignupForm.tsx:62
 msgid "Password"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:30
 msgid "Peer-to-Peer"
-msgstr "---"
-
-#: src/components/CollaboratorsSection/index.tsx:153
-#~ msgid "Permission"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserDetails/index.tsx:36
 msgid "Permission:"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/UserDetails.tsx:31
 msgid "Permissions"
@@ -1806,11 +1588,11 @@ msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:90
 msgid "Phone Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:43
 msgid "Phonetic Name Identifiers"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:81
 msgid "Please Provide the Name and Email Address"
@@ -1818,29 +1600,24 @@ msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:253
 msgid "Please add any other regulatory jurisdictions your organization complies with."
-msgstr "---"
+msgstr ""
 
 #: src/components/MissingRequire/index.tsx:14
 msgid "Please complete all details"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:98
 msgid "Please copy and paste this password and store somewhere safe!"
-msgstr "---"
+msgstr ""
 
 #: src/components/LegalPerson/index.tsx:65
 msgid "Please enter the information that identifies your organization as a Legal Person. This form represents the"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:28
 #: src/components/CertificateSection/index.tsx:52
 msgid "Please enter the information that identifies your organization as a Legal Person. This form represents the {0} data structure for legal persons and is strongly suggested for use as KYC (Know your Counterparty) or CDD (Customer Due Diligence) information exchanged in TRISA transfers."
-msgstr "---"
-
-#: src/components/CertificateSection/index.tsx:28
-#: src/components/CertificateSection/index.tsx:52
-#~ msgid "Please enter the information that identifies your organization as a Legal Person. This form represents the {0} data structure for legal persons and is strongly suggested for use as KYC or CDD information exchanged in TRISA transfers."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:25
 msgid "Please input the name of the new managed Virtual Asset Service Provider (VASP). When the entity is created, you will have the ability to add collaborators, start and complete the certificate registration process, and manage the VASP account. Please acknowledge below and provide the name of the entity."
@@ -1851,31 +1628,31 @@ msgstr ""
 #: src/components/ReviewSubmit/index.tsx:180
 #: src/components/ReviewSubmit/index.tsx:270
 msgid "Please note that TestNet and MainNet are separate networks that require different X.509 Identity Certificates."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:47
 msgid "Please review the information provided, edit as needed, and submit to complete the registration form. After the information is reviewed, emails will be sent to the provided contacts for verification. Once verified, your TestNet certificate will be issued."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ReviewsSummary.tsx:113
 msgid "Please review the information provided, edit as needed, and submit to complete the registration form. After the information is reviewed, you will be contacted to verify details. Once verified, your TestNet certificate will be issued."
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:189
 msgid "Please select as many categories needed to represent the types of virtual asset services your organization provides."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:419
 msgid "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:117
 msgid "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:37
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/index.tsx:61
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
@@ -1883,15 +1660,11 @@ msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:22
 msgid "Please use the email address associated with your organization."
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:20
 msgid "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
-
-#: src/components/Contacts/ContactForm/index.tsx:64
-#~ msgid "Please use the email address associated with your organization.Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored"
-#~ msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:253
 #: src/components/CertificateDetails/CertificateDetails.tsx:316
@@ -1902,24 +1675,24 @@ msgstr ""
 
 #: src/components/AddressForm/index.tsx:75
 msgid "Postal Code / Postcode / ZIP Code"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:58
 msgid "Preferred name for email communication."
-msgstr "---"
+msgstr ""
 
 #: src/components/StepsButtons/index.tsx:52
 msgid "Previous"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:36
 #: src/components/TrixoQuestionnaireForm/index.tsx:234
 msgid "Primary National Jurisdiction"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:155
 msgid "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:104
 msgid "Private Organization"
@@ -1935,7 +1708,7 @@ msgstr ""
 
 #: src/components/UserDetails/index.tsx:30
 msgid "Profile Created:"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:69
 msgid "Provider"
@@ -1963,45 +1736,37 @@ msgstr ""
 #: src/components/OpenSourceResources/index.tsx:27
 #: src/components/Section/IntegrateAndComply.tsx:162
 msgid "Reference implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:190
 #: src/components/MemberDetails/index.tsx:337
 msgid "Reg Authority"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:66
 msgid "Region / Province / State (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:229
 #: src/components/Section/SearchDirectory.tsx:295
 msgid "Registered Directory"
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:195
 msgid "Registration Authority"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:6
 msgid "Registration Authority Identifier"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:87
-#~ msgid "Registration Authority cannot be left empty"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:96
-#~ msgid "Registration Authority cannot be left empty."
-#~ msgstr ""
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:90
 msgid "Registration Submission"
-msgstr "---"
+msgstr ""
 
 #: src/components/OtherJuridictions/index.tsx:47
 msgid "Regulator Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/RemoveLinkedAccountModal.tsx:37
 msgid "Remove Linked Account"
@@ -2011,42 +1776,33 @@ msgstr ""
 #: src/components/OtherJuridictions/index.tsx:58
 #: src/components/Regulations/index.tsx:31
 msgid "Remove line"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:51
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:26
 msgid "Request New Identity Certificate"
-msgstr "---"
+msgstr ""
 
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:47
 msgid "Requesting a new X.509 Identity Certificate will invalidate and revoke your current X.509 Identity Certificate."
-msgstr "---"
+msgstr ""
 
 #: src/components/Modal/ConfirmationResetFormModal.tsx:128
 msgid "Reset"
-msgstr "---"
+msgstr ""
 
 #: src/constants/address.ts:5
 msgid "Residential"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/success.tsx:60
 msgid "Return to vaspdirectory.net"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ReviewsSummary.tsx:95
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:174
 msgid "Review"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:337
-#~ msgid "Review & Submit"
-#~ msgstr "---"
-
-#: src/components/ReviewSubmit/index.tsx:151
-#: src/components/ReviewSubmit/index.tsx:235
-#~ msgid "Review page"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:160
 #: src/components/ReviewSubmit/index.tsx:251
@@ -2056,11 +1812,7 @@ msgstr ""
 #: src/components/Collaborators/index.tsx:167
 #: src/components/UserProfile/UserDetails.tsx:22
 msgid "Role"
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:38
-#~ msgid "Routine Maintenance Scheduled"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/UserProfilePassword.tsx:52
 msgid "SECURITY"
@@ -2072,11 +1824,7 @@ msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:451
 msgid "Safeguards PII"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:277
-#~ msgid "Safeguards Personally Identifiable Information (PII)"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:190
 msgid "Save"
@@ -2084,15 +1832,15 @@ msgstr ""
 
 #: src/components/StepsButtons/index.tsx:56
 msgid "Save & Next"
-msgstr "---"
+msgstr ""
 
 #: src/components/StepsButtons/index.tsx:52
 msgid "Save & Previous"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:59
 msgid "Sealing Certificate Inventory"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:15
 msgid "Sealing Certificates"
@@ -2100,55 +1848,55 @@ msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:77
 msgid "Search the Directory Service"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:54
 msgid "Section"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetail/index.tsx:130
 #: src/components/CertificateReview/BasicDetailsReview.tsx:29
 #: src/components/CertificateSection/index.tsx:23
 #: src/components/CertificateSection/index.tsx:65
 msgid "Section 1: Basic Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReview.tsx:19
 #: src/components/CertificateSection/index.tsx:27
 #: src/components/LegalPerson/index.tsx:59
 msgid "Section 2: Legal Person"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ContactsReview.tsx:19
 #: src/components/CertificateSection/index.tsx:36
 #: src/components/Contacts/index.tsx:55
 msgid "Section 3: Contacts"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReview.tsx:19
 #: src/components/CertificateSection/index.tsx:41
 #: src/components/TrisaImplementation/index.tsx:59
 msgid "Section 4: TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReview.tsx:32
 #: src/components/CertificateSection/index.tsx:46
 #: src/components/TrixoQuestionnaire/index.tsx:55
 msgid "Section 5: TRIXO Questionnaire"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:51
 #: src/components/CertificateSection/index.tsx:60
 msgid "Section 6: Review & Submit"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:89
 msgid "Sections & Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:21
 msgid "Secure"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberNetworkSelect.tsx:15
 msgid "Select Network"
@@ -2156,7 +1904,7 @@ msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:181
 msgid "Select VASP category"
-msgstr "---"
+msgstr ""
 
 #: src/components/ChooseAnOrganization/index.tsx:61
 msgid "Select a VASP from the Managed VASP List"
@@ -2164,11 +1912,11 @@ msgstr ""
 
 #: src/components/CountryOfRegistration/index.tsx:27
 msgid "Select a country"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:166
 msgid "Select business category"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:147
 msgid "Select the collaborator’s role and save."
@@ -2191,52 +1939,52 @@ msgstr ""
 msgid ""
 "Set up your TRISA node or integrate with a 3rd-party Travel Rule solution. Complete\n"
 "            testing and move to production."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:26
 msgid "Set up your TRISA node or integrate with a 3rd-party Travel Rule solution. Complete testing and move to production."
-msgstr "---"
+msgstr ""
 
 #: src/constants/name-identifiers.ts:5
 msgid "Short"
-msgstr "---"
+msgstr ""
 
 #: src/components/Sidebar/MobileNav.tsx:121
 msgid "Sign out"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:29
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:36
 msgid "Signature ID"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:89
 msgid ""
 "Since TRISA is an open source, peer-to-peer Travel Rule solution, VASPs can set\n"
 "                    up and maintain their own TRISA server to exhange encrypted Travel Rule\n"
 "                    compliance data. TRISA maintains an"
-msgstr "---"
+msgstr ""
 
 #: src/components/YourImplementation/index.tsx:11
 msgid "Since TRISA is an open source, peer-to-peer Travel Rule solution, VASPs can set up and maintain their own TRISA server to exhange encrypted Travel Rule compliance data. At the same time, TRISA is designed to be interoperable. There are several Travel Rule solutions providers available on the market. If you are a customer, work with your Travel Ruie provider to integrate TRISA into your Travel Rule compliance workflow."
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:9
 msgid "Social Security Number"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/login/user.slice.ts:124
 #: src/modules/auth/login/user.slice.ts:124
 msgid "Something went wrong. Please try again later."
-msgstr "---"
+msgstr ""
 
 #: src/components/NotFound/index.tsx:19
 msgid "Sorry, the page you are looking for doesn't exist or has been moved"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordResetFail.tsx:21
 msgid "Sorry. We could not find a user account with the email address"
-msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/AttentionAlert.tsx:50
 msgid "Start"
@@ -2245,15 +1993,15 @@ msgstr ""
 #: src/components/TechnicalResources/index.tsx:19
 #: src/modules/dashboard/overview/index.tsx:32
 msgid "Start Certificate Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:83
 msgid "Start Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/ui/Button.tsx:8
 msgid "Start trial"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:131
 #: src/components/CertificateInventory/index.tsx:86
@@ -2266,16 +2014,16 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberTable.tsx:31
 #: src/modules/dashboard/member/utils.ts:24
 msgid "Status"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserDetails/index.tsx:33
 msgid "Status:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:11
 #: src/components/Section/GettingStarted.tsx:47
 msgid "Step 1"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:271
 #: src/components/CertificateDetails/CertificateDetails.tsx:334
@@ -2299,23 +2047,23 @@ msgstr ""
 #: src/components/Section/PasswordResetForm.tsx:48
 #: src/hoc/withRHF.tsx:117
 msgid "Submit"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:302
 msgid "Submit MainNet Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:212
 msgid "Submit TestNet Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:105
 msgid "Submitted"
-msgstr "---"
+msgstr ""
 
 #: src/components/Sidebar/SidebarContent.tsx:111
 msgid "Support"
-msgstr "---"
+msgstr ""
 
 #: src/components/Sidebar/MobileNav.tsx:116
 msgid "Switch Accounts"
@@ -2323,61 +2071,53 @@ msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:138
 msgid "Synga Bridge"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:195
 msgid "TESTNET DIRECTORY RECORD"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:127
 msgid "TESTNET SUBMISSION"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:53
 msgid "TRISA Certificate Types"
 msgstr ""
 
-#: src/components/CertificateManagement/index.tsx:52
-#~ msgid "TRISA Certificates"
-#~ msgstr "---"
-
-#: src/components/OrganizationProfile/TrisaDetail.tsx:20
-#~ msgid "TRISA Details"
-#~ msgstr "---"
-
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:66
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:75
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:83
 msgid "TRISA Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm.tsx:150
 msgid "TRISA Endpoint: MainNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm.tsx:144
 msgid "TRISA Endpoint: TestNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/OpenSourceResources/index.tsx:15
 msgid "TRISA GitHub repo"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:24
 msgid "TRISA Global Directory Service"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:92
 msgid "TRISA Identity Signature:"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:27
 msgid "TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:20
 msgid "TRISA Implementations"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/index.tsx:14
 msgid "TRISA Member Directory"
@@ -2386,46 +2126,37 @@ msgstr ""
 #: src/components/Section/SearchDirectory.tsx:235
 #: src/components/Section/SearchDirectory.tsx:301
 msgid "TRISA Member ID"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:36
 msgid "TRISA Member ID:"
-msgstr "---"
-
-#: src/components/OrganizationProfile/OrganizationalDetail.tsx:55
-#~ msgid "TRISA Organization Profile"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:52
 msgid "TRISA Registration Request Submitted!"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:223
 #: src/components/Section/SearchDirectory.tsx:289
 msgid "TRISA Service Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:253
 #: src/components/Section/SearchDirectory.tsx:318
 msgid "TRISA Verification"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:44
 msgid "TRISA Verification:"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaVerifiedLogo/index.tsx:11
 msgid "TRISA Verified Logo"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:28
 msgid "TRISA endpoint for communication"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:22
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:48
-#~ msgid "TRISA endpoint is not valid"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:18
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:40
@@ -2434,15 +2165,15 @@ msgstr ""
 
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:168
 msgid "TRISA implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:32
 msgid "TRISA is a decentralized network where VASPs communicate directly with each other."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:67
 msgid "TRISA is a global, open source, peer-to-peer and secure Travel Rule architecture and network designed to be accessible and interoperable. Become a TRISA-certified VASP today."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:145
 msgid "TRISA is a network of trusted members. I acknowledge that the contact is authorized to access the organization’s TRISA account information."
@@ -2454,59 +2185,59 @@ msgstr ""
 
 #: src/components/Section/JoinUs.tsx:50
 msgid "TRISA is designed to be interoperable with other Travel Rule solutions."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:108
 msgid ""
 "TRISA is designed to be interoperable. There are several Travel Rule solutions\n"
 "                    providers available on the market. If you are a customer, work with them to\n"
 "                    integrate TRISA into your Travel Rule compliance workflow."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:41
 msgid "TRISA is open source and available to implement by any VASP."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:59
 msgid "TRISA issues two types of certificates:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:66
 msgid "TRISA members must complete a comprehensive multi-part verification form and due diligence process. Once verified, TRISA will issue TestNet and MainNet certificates for secure Travel Rule compliance."
-msgstr "---"
+msgstr ""
 
 #: src/components/CustomerNumber/index.tsx:23
 msgid "TRISA specific identity number (UUID), only supplied if you're updating an existing registration request"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:23
 msgid "TRISA uses public-key cryptography for encrypting data in flight and at rest."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaVerifiedLogo/index.tsx:17
 msgid "TRISA verified members may download and display a “TRISA Verified VASP” logo on their website. The logo is unique to your VASP and non-reproducible. Members may download their logo after verification is complete and their certificate has been issued. The logo is in .svg fotmat"
-msgstr "---"
+msgstr ""
 
 #: src/components/Maintenance/index.tsx:32
 msgid "TRISA's Slack channel"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:150
 msgid "TRISA’s Github repo"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/AboutUs.tsx:57
 msgid "TRISA’s Global Directory Service (GDS) is a network of vetted VASPs that can securely exchange Travel Rule compliance data with each other."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:75
 msgid "TRISA’s verification form includes five sections and may require information from several parties in your organization."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:33
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:171
 msgid "TRIXO Questionnaire"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:118
 msgid ""
@@ -2514,15 +2245,15 @@ msgid ""
 "                    resources to integrate TRISA with your system. Have members of your technical\n"
 "                    team integrate your systems with TRISA. Or work with a solutions provider that\n"
 "                    can help your VASP set up your TRISA server and maintain it."
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:5
 msgid "Tax Identification Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:154
 msgid "Technical Contact (required)"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:43
 msgid "Technical Contact Email"
@@ -2538,30 +2269,30 @@ msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:140
 msgid "Technical Officer"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:60
 msgid "Technical Resources"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:134
 msgid "Technical information about your endpoint for certificate issuance. Each VASP is required to establish a TRISA endpoint for inter-VASP communication."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:33
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:71
 #: src/components/ReviewSubmit/index.tsx:132
 msgid "TestNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:44
 msgid "TestNet Certificate Common Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:40
 #: src/components/CertificateManagement/index.tsx:112
 msgid "TestNet Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:47
 msgid "TestNet Identity Certificates"
@@ -2569,15 +2300,11 @@ msgstr ""
 
 #: src/components/MetricsTabs/index.tsx:38
 msgid "TestNet Network Metrics"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:38
 msgid "TestNet TRISA Endpoint"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:39
-#~ msgid "TestNet and MainNet endpoints should not be the same"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:31
 msgid "TestNet and MainNet endpoints should not be the same."
@@ -2586,26 +2313,26 @@ msgstr ""
 #: src/components/Section/UserEmailVerification.tsx:17
 #: src/modules/auth/register/success.tsx:17
 msgid "Thank you for creating your TRISA account."
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/success.tsx:23
 msgid "Thank you for creating your TRISA account. You must verify your email address. An email with verification instructions has been sent to your email address. Please complete the email verification process in 24 hours. The email verification link will expire in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordResetConfirmation.tsx:15
 msgid "Thank you. We have sent instructions to reset your password to"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordReset.tsx:44
 msgid "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:144
 msgid ""
 "The Common Name typically matches the Endpoint, without the port number\n"
 "                            at the end (e.g. trisa.myvasp.com) and is used to identify the subject\n"
 "                            in the X.509 certificate."
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:25
 msgid "The Domain Name is invalid."
@@ -2614,10 +2341,6 @@ msgstr ""
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:26
 msgid "The Domain Name is required."
 msgstr ""
-
-#: src/components/NetworkAnnouncements/index.tsx:39
-#~ msgid "The GDS will be undergoing routine maintenance on Apr 7."
-#~ msgstr "---"
 
 #: src/components/CertificateManagement/CertificateValidityAlert.tsx:51
 msgid "The Organization has a current and valid <0>Mainnet</0> Identity Certificate."
@@ -2633,7 +2356,7 @@ msgstr ""
 
 #: src/components/Maintenance/index.tsx:16
 msgid "The TRISA Global Directory Service (GDS) is temporarily undergoing maintenance. Please try again later."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/DirectoryNotification.tsx:11
 msgid "The TRISA Member Directory is for informational purposes and is meant to foster collaboration between members. It is available to verified TRISA contacts only. If you cannot view the list, please complete the registration process. You can view the member list after verification is complete."
@@ -2641,7 +2364,7 @@ msgstr ""
 
 #: src/components/Section/AboutUs.tsx:37
 msgid "The Travel Rule Information Sharing Architecture (TRISA)"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:23
 msgid "The VASP Name is required."
@@ -2649,7 +2372,7 @@ msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:71
 msgid "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:89
 msgid "The collaborator has not been deleted"
@@ -2661,7 +2384,7 @@ msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:57
 msgid "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:84
 msgid "The contact will receive an email to create a TRISA Global Directory Service (GDS) account or join this organization if the contact already has a TRISA GDS account. The invitation to join is valid for 7 calendar days. The contact will be added as a member for the VASP. The contact will have the ability to contribute to certificate requests, check on the status of certificate requests, and complete other actions related to the organization’s TRISA membership."
@@ -2673,22 +2396,22 @@ msgstr ""
 
 #: src/components/Section/PasswordResetConfirmation.tsx:22
 msgid "The link to reset your password expires in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:407
 msgid "The minimum threshold above which your organization is required to collect/send Travel Rule information."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:48
 #: src/components/MemberDetails/index.tsx:177
 #: src/components/NameIdentifiers/index.tsx:37
 #: src/components/NameIdentifiers/index.tsx:44
 msgid "The name and type of name by which the legal person is known."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:245
 msgid "The name of primary regulator or supervisory authority for your national jurisdiction"
-msgstr "---"
+msgstr ""
 
 #: src/components/ErrorComponent/RequiredElementMissing.tsx:32
 msgid "There is an error or missing data in this section. Please edit the section."
@@ -2696,11 +2419,7 @@ msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:93
 msgid "This is the only time the PKCS12 password is shown during the registration process."
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:281
-#~ msgid "This multi-section form is an important step in the registration and certificate issuance process. The information you provide will be used to verify the legal entity that you represent and, where appropriate, will be available to verified TRISA members to facilitate compliance decisions. If you need guidance, see the"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/registration.tsx:34
 msgid "This multi-section form is an important step in the registration and certificate issuance process. The information you provide will be used to verify the legal entity that you represent and, where appropriate, will be available to verified TRISA members to facilitate compliance decisions. If you need guidance, see the <0>Getting Started</0> Help Guide."
@@ -2708,15 +2427,11 @@ msgstr ""
 
 #: src/components/TrixoQuestionnaire/index.tsx:61
 msgid "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:352
 msgid "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:292
-#~ msgid "To assist in completing the registration form, the form is divided into multiple sections"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/registration.tsx:46
 msgid "To assist in completing the registration form, the form is divided into multiple sections. Navigate through the form by clicking on each section of the progress bar or the buttons at the bottom of each section."
@@ -2724,19 +2439,15 @@ msgstr ""
 
 #: src/constants/name-identifiers.ts:6
 msgid "Trading"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/UserDetails.tsx:12
 msgid "USER DETAILS"
 msgstr ""
 
-#: src/hooks/useCertificateStepper.tsx:108
-#~ msgid "Under TRISA Implementation, please provide an Endpoint or Common Name for TestNet and/or MainNet"
-#~ msgstr "---"
-
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:140
 msgid "Understood"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:115
 msgid "Unknown Entity"
@@ -2749,29 +2460,21 @@ msgstr ""
 #: src/constants/address.ts:4
 #: src/constants/national-identification.ts:7
 msgid "Unspecified"
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:32
-#~ msgid "Upcoming TRISA Working Group Call"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:66
 msgid "Upon verification, integrate with TRISA to begin exchanging Travel Rule compliance data."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:217
 #: src/components/CertificateInventory/index.tsx:200
 #: src/components/UserDetails/index.tsx:24
 msgid "User Details"
-msgstr "---"
-
-#: src/components/CollaboratorsSection/index.tsx:147
-#~ msgid "User ID"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserDetails/index.tsx:27
 msgid "User ID:"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:48
 msgid "User Profile"
@@ -2788,7 +2491,7 @@ msgstr ""
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:31
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:32
 msgid "VASP Category"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:59
 msgid "VASP Domain"
@@ -2801,7 +2504,7 @@ msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:74
 msgid "VASPs have two options to integrate with TRISA."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:61
 msgid "VERIFIED"
@@ -2810,25 +2513,25 @@ msgstr ""
 #: src/components/Section/SearchDirectory.tsx:258
 #: src/components/Section/SearchDirectory.tsx:323
 msgid "VERIFIED ON"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:116
 msgid "Verification Status:"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:22
 #: src/components/TrisaVerifiedLogo/index.tsx:36
 msgid "Verified"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:60
 msgid "Verified On"
-msgstr "---"
+msgstr ""
 
 #: src/components/Metrics/index.tsx:22
 #: src/components/StatCard/index.tsx:35
 msgid "Verified VASPs"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:130
 msgid "View Member List"
@@ -2842,11 +2545,11 @@ msgstr ""
 
 #: src/modules/auth/register/success.tsx:48
 msgid "Visit Getting Started with TRISA"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:33
 msgid "We recommend that a senior compliance officer initially creates the account for the VASP. Additional accounts can be created later."
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:131
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:37
@@ -2854,41 +2557,37 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:23
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:18
 msgid "Website"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:17
-#~ msgid "Website is a required field"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:10
 msgid "Website, incorporation Date, VASP Category"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:52
 msgid "Welcome to TRISA’s network of Certified VASPs."
-msgstr "---"
+msgstr ""
 
 #: src/components/Maintenance/index.tsx:13
 msgid "We’ll be back soon."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:185
 #: src/components/Section/VaspVerification.tsx:187
 msgid "What is IVMS101?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:192
 #: src/components/TrixoQuestionnaireForm/index.tsx:376
 msgid "What is the minimum threshold for Travel Rule compliance?"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:156
 msgid "What’s a Common name or VASP ID?"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:92
 msgid "Who to Ask"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:104
 #: src/components/Section/VaspVerification.tsx:119
@@ -2896,11 +2595,11 @@ msgstr "---"
 #: src/components/Section/VaspVerification.tsx:139
 #: src/components/Section/VaspVerification.tsx:150
 msgid "Who to ask"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:64
 msgid "Why Join TRISA"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:82
 #: src/components/CertificateInventory/index.tsx:37
@@ -2910,22 +2609,22 @@ msgstr ""
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:29
 #: src/components/CertificateManagement/index.tsx:103
 msgid "X.509 Identity Certificate Inventory"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:23
 msgid "X.509 Identity Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "YES"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:34
 #: src/constants/trixo.ts:5
 msgid "Yes"
-msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/InvalidFormPrompt.tsx:34
 msgid "You have unsaved changes. Are you sure you want to continue without saving?"
@@ -2939,57 +2638,47 @@ msgstr ""
 msgid "You must click on each confirmation link to complete the registration process."
 msgstr ""
 
-#: src/hooks/useCertificateStepper.tsx:109
-#~ msgid ""
-#~ "You must provide an Endpoint and Common Name for at least one network to proceed to the final step and submit the registration form.\n"
-#~ "Please note that TestNet and MainNet are separate networks that require different X.509 Identity Certificates."
-#~ msgstr "---"
-
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:23
 msgid "You must request a new X.509 Identity Certificate to change your Endpoint and Common Name."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:96
 msgid "You must submit your registration for TestNet and MainNet separately."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/UserEmailVerification.tsx:22
 msgid "You must verify your email address. An email with verification instructions has been sent to your email address. Please complete the email verification process in 24 hours. The email verification link will expire in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:102
 msgid "You will receive"
 msgstr ""
 
-#: src/components/ReviewSubmit/index.tsx:98
-#~ msgid "You will receive two separate emails with confirmation links for each registration. You must click on each confirmation link to complete the registration process."
-#~ msgstr "---"
-
 #: src/components/YourImplementation/index.tsx:8
 msgid "Your TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:44
 msgid "Your TRISA {type} Details"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/login/user.slice.ts:128
 #: src/modules/auth/login/user.slice.ts:128
 msgid "Your account has not been verified. Please check your email to verify your account."
-msgstr "---"
+msgstr ""
 
 #: src/components/Header/LandingHeader.tsx:94
 #: src/components/Header/LandingHeader.tsx:131
 msgid "Your dashboard"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:61
 msgid "Your registration form has been successfully submitted. You will receive a confirmation email from admin@trisa.io. In the email, you will receive instructions on next steps. Return to your dashboard to monitor the status of your registration and certificate."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:59
 msgid "Your registration request has been successfully received by the Directory Service. Verification emails have been sent to all contacts listed. Once your contact information has been verified, the registration form will be sent to the TRISA review board to verify your membership in the TRISA network."
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:47
 msgid "Your {0} TRISA Organization Profile:"
@@ -2998,31 +2687,27 @@ msgstr ""
 #: src/components/Navbar/Landing/MobileNav.tsx:71
 #: src/components/Navbar/Landing/Nav.tsx:21
 msgid "about us"
-msgstr "---"
-
-#: src/components/TrisaImplementationForm/index.tsx:43
-#~ msgid "common name should match the TRISA endpoint without the port"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:18
 msgid "complete VASP verification"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/AboutUs.tsx:50
 msgid "compliance. TRISA helps Virtual Asset Service Providers (VASPs) comply with the Travel Rule for cross-border cryptocurrency transactions. TRISA is designed to be interoperable."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:25
 msgid "create account"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:11
 msgid "create your account"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:24
 msgid "for Cryptocurrency Travel Rule compliance."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:240
 msgid "for MainNet registration so your MainNet certificate will be issued after the verification phone call has been completed by the validation team."
@@ -3030,47 +2715,39 @@ msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:148
 msgid "for TestNet registration so your TestNet certificate will be issued upon review by the validation team"
-msgstr "---"
+msgstr ""
 
 #: src/components/LegalPerson/index.tsx:73
 msgid "for legal persons and is strongly suggested for use as KYC or CDD (Know your Counterparty) information exchanged in TRISA transfers."
-msgstr "---"
-
-#: src/components/LegalPerson/index.tsx:36
-#~ msgid "for legal persons and is strongly suggested for use as KYC or CDD information exchanged in TRISA transfers."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:34
 msgid "in partnership with"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/AboutUs.tsx:41
 msgid "is a global, open source, secure, and peer-to-peer protocol for"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:146
 msgid "is not required"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:238
 msgid "is required"
-msgstr "---"
-
-#: src/components/NameIdentifiers/index.tsx:30
-#~ msgid "legal"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:90
 msgid "lower case letters (a-z)"
-msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:121
 msgid "numbers (i.e. 0-9)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:39
 msgid "on behalf of"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:23
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:24
@@ -3080,7 +2757,7 @@ msgstr ""
 #: src/components/ReviewSubmit/index.tsx:134
 #: src/components/ReviewSubmit/index.tsx:226
 msgid "registration. Upon submission, you will receive an email with a confirmation link. You must click the confirmation link to complete the registration process. Failure to click the confirmation link will result in an incomplete registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:45
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:61
@@ -3091,15 +2768,15 @@ msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:135
 msgid "special characters (e.g. !@#$%^&*)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:22
 msgid "the TRISA architecture"
-msgstr "---"
+msgstr ""
 
 #: src/components/Maintenance/index.tsx:34
 msgid "to receive maintenance and outage notifications. If you have an immediate concern, please email support@rotational.io."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:106
 msgid "two separate emails with confirmation links for each registration."
@@ -3107,7 +2784,7 @@ msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:107
 msgid "upper case letters (A-Z)"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:105
 #: src/components/CertificateManagement/SealingCertificateTableRows.tsx:16
@@ -3123,7 +2800,7 @@ msgstr ""
 msgid ""
 "with detailed documentation, a reference implemenation, and “robot” VASPs for\n"
 "                    testing purposes."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/index.tsx:145
 msgid "you do not have permission to invite a collaborator"
@@ -3135,12 +2812,12 @@ msgstr ""
 #: src/components/UserProfile/UserDetails.tsx:25
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:56
 msgid "{0}"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ContactsReviewDataTable.tsx:28
 msgid "{0} Contact"
-msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/AttentionAlert.tsx:85
 msgid "{message}"
-msgstr "---"
+msgstr ""

--- a/web/gds-user-ui/src/locales/fr/messages.po
+++ b/web/gds-user-ui/src/locales/fr/messages.po
@@ -119,7 +119,7 @@ msgstr "4 Mise en œuvre de TRISA"
 msgid "5 TRIXO Questionnaire"
 msgstr "5 Questionnaire TRIXO"
 
-#: src/components/Contacts/ContactForm/index.tsx:30
+#: src/components/Contacts/ContactForm/index.tsx:29
 msgid "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
 msgstr "Un numéro de téléphone professionnel est nécessaire pour effectuer la vérification physique pour l'enregistrement MainNet. Veuillez fournir un numéro de téléphone où le contact juridique/conformité peut être joint"
 
@@ -152,7 +152,7 @@ msgid "Action"
 msgstr "Action"
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:70
-#: src/components/Collaborators/index.tsx:171
+#: src/components/Collaborators/index.tsx:179
 #: src/modules/dashboard/member/components/MemberTable.tsx:34
 msgid "Actions"
 msgstr ""
@@ -170,11 +170,11 @@ msgstr ""
 msgid "Add Address"
 msgstr "Ajouter une adresse"
 
-#: src/components/NameIdentifiers/index.tsx:51
+#: src/components/NameIdentifiers/index.tsx:50
 msgid "Add Another Legal Name"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:140
+#: src/components/Collaborators/index.tsx:148
 msgid "Add Contact"
 msgstr ""
 
@@ -190,11 +190,11 @@ msgstr "Ajouter une juridiction"
 msgid "Add Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:54
+#: src/components/NameIdentifiers/index.tsx:53
 msgid "Add Local Name"
 msgstr "Ajouter un nom local"
 
-#: src/components/NameIdentifiers/index.tsx:57
+#: src/components/NameIdentifiers/index.tsx:56
 msgid "Add Phonetic Names"
 msgstr "Ajouter des noms phonétiques"
 
@@ -226,13 +226,13 @@ msgstr "Ligne d'adresse 1, par exemple nom/numéro du bâtiment, nom de la rue (
 msgid "Address line 2 e.g. apartment or suite number"
 msgstr "Ligne d'adresse 2, par exemple le numéro d'appartement ou de suite"
 
-#: src/components/Addresses/index.tsx:11
+#: src/components/Addresses/index.tsx:10
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:118
 #: src/components/MemberDetails/index.tsx:244
 msgid "Addresses"
 msgstr "Adresses"
 
-#: src/components/Contacts/ContactsForm.tsx:158
+#: src/components/Contacts/ContactsForm.tsx:161
 msgid "Administrative Contact (optional)"
 msgstr "Contact administratif (facultatif)"
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Administrative Contact Phone"
 msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:159
+#: src/components/Contacts/ContactsForm.tsx:162
 msgid "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
 msgstr "Contact administratif ou exécutif de votre organisation pour répondre aux demandes ou requêtes de haut niveau. (Fortement recommandé)"
 
@@ -286,7 +286,7 @@ msgstr ""
 msgid "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:130
+#: src/components/NationalIdentification/index.tsx:129
 msgid "An identifier issued by an appropriate issuing authority"
 msgstr "Un identifiant délivré par une autorité émettrice appropriée"
 
@@ -294,8 +294,8 @@ msgstr "Un identifiant délivré par une autorité émettrice appropriée"
 msgid "App version {appVersion}"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:174
-#: src/components/TrixoQuestionnaireForm/index.tsx:417
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:173
+#: src/components/TrixoQuestionnaireForm/index.tsx:416
 msgid "Applicable Regulations"
 msgstr "Règlements applicables"
 
@@ -307,13 +307,13 @@ msgstr "Postulez pour devenir un fournisseur de services d'actifs virtuels certi
 msgid "At least 9 characters in length"
 msgstr "Contient au moins 9 caractères"
 
-#: src/components/Addresses/index.tsx:14
+#: src/components/Addresses/index.tsx:13
 msgid "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
 msgstr "Au moins une adresse géographique est requise. Saisissez l'adresse géographique principale de l'organisation. Les organisations peuvent saisir des adresses supplémentaires si elles opèrent dans plusieurs juridictions."
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:143
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:142
 #: src/components/MemberDetails/index.tsx:589
-#: src/components/TrixoQuestionnaireForm/index.tsx:322
+#: src/components/TrixoQuestionnaireForm/index.tsx:321
 msgid "At what threshold and currency does your organization conduct KYC checks?"
 msgstr "À quel seuil et dans quelle monnaie votre organisation effectue-t-elle le KYC ?"
 
@@ -346,11 +346,11 @@ msgstr "Devenir conforme à la réglementation sur les voyages"
 #~ msgid "Beware the Ides of March"
 #~ msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:163
+#: src/components/Contacts/ContactsForm.tsx:168
 msgid "Billing Contact (optional)"
 msgstr "Contact de facturation (facultatif)"
 
-#: src/components/Contacts/ContactsForm.tsx:164
+#: src/components/Contacts/ContactsForm.tsx:169
 msgid "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
 msgstr "Contact de facturation de votre organisation pour traiter les demandes de compte et de facture ou les questions relatives au fonctionnement du réseau TRISA."
 
@@ -388,7 +388,7 @@ msgstr "Bureau d'affaires ou de conformité"
 msgid "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:282
+#: src/components/TrixoQuestionnaireForm/index.tsx:281
 msgid "CDD & Travel Rule Policies"
 msgstr "Politiques du CDD et de la réglementation sur les voyages"
 
@@ -404,7 +404,7 @@ msgstr "Politiques de CDD et de protection des données"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:80
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:79
 msgid "Certificate Common Name"
 msgstr "Nom commun du certificat"
 
@@ -495,7 +495,7 @@ msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:158
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:198
-#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:74
+#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:75
 msgid "Close"
 msgstr ""
 
@@ -524,9 +524,9 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:286
 #: src/components/CertificateInventory/index.tsx:206
 #: src/components/CertificateInventory/index.tsx:269
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:63
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:83
-#: src/components/Section/SearchDirectory.tsx:215
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:62
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:82
+#: src/components/Section/SearchDirectory.tsx:217
 #: src/components/Section/SearchDirectory.tsx:283
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:79
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:89
@@ -537,7 +537,7 @@ msgstr "Nom commun"
 #~ msgid "Common name or VASP ID"
 #~ msgstr "Nom commun VASP ou l'ID VASP"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:42
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:41
 msgid "Common name should match the TRISA endpoint without the port."
 msgstr "le nom commun doit correspondre au point de terminaison TRISA sans le port"
 
@@ -602,7 +602,7 @@ msgstr "Conformité, technique, administratif, facturation"
 msgid "Comply with the Travel Rule"
 msgstr "Se conformer à la réglementation sur les voyages"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:313
+#: src/components/TrixoQuestionnaireForm/index.tsx:312
 msgid "Conducts KYC before virtual asset transfers"
 msgstr "Effectue un KYC avant les transferts d'actifs virtuels"
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Confirm New Password"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:156
+#: src/components/Collaborators/index.tsx:164
 msgid "Contact Details"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid "Contact information for representatives of your organization. Contacts in
 msgstr "Les coordonnées des représentants de votre organisation. Les contacts comprennent les personnes suivantes : technique, juridique/conformité, administratif et facturation."
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:21
-#: src/components/OrganizationProfile/OrganizationalDetail.tsx:157
+#: src/components/OrganizationProfile/OrganizationalDetail.tsx:158
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:165
 msgid "Contacts"
 msgstr "Contacts"
@@ -673,8 +673,8 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:292
 #: src/components/CertificateInventory/index.tsx:212
 #: src/components/CertificateInventory/index.tsx:275
-#: src/components/Section/SearchDirectory.tsx:239
-#: src/components/Section/SearchDirectory.tsx:308
+#: src/components/Section/SearchDirectory.tsx:242
+#: src/components/Section/SearchDirectory.tsx:307
 msgid "Country"
 msgstr "Pays"
 
@@ -683,16 +683,16 @@ msgid "Country (required)"
 msgstr "Pays (obligatoire)"
 
 #: src/components/MemberDetails/index.tsx:321
-#: src/components/NameIdentification/index.tsx:174
+#: src/components/NationalIdentification/index.tsx:173
 msgid "Country of Issue"
 msgstr "Pays de délivrance"
 
-#: src/components/NameIdentification/index.tsx:178
+#: src/components/NationalIdentification/index.tsx:177
 msgid "Country of Issue is reserved for National Identifiers of Natural Persons"
 msgstr "Le pays de délivrance est réservé aux identifiants nationaux des personnes physiques"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:138
-#: src/components/CountryOfRegistration/index.tsx:19
+#: src/components/CountryOfRegistration/index.tsx:18
 #: src/components/MemberDetails/index.tsx:271
 #: src/components/MemberDetails/index.tsx:331
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:137
@@ -755,11 +755,11 @@ msgstr "Créé et maintenu par"
 msgid "Current Name"
 msgstr ""
 
-#: src/components/Sidebar/MobileNav.tsx:83
+#: src/components/Sidebar/MobileNav.tsx:81
 msgid "Current Organization name"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:89
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:88
 msgid "Customer Due Diligence (CDD) & Travel Rule Policies"
 msgstr "Les politiques de Customer Due Diligence(CDD) et de Travel Rule"
 
@@ -771,8 +771,8 @@ msgstr "Numéro de client"
 msgid "Dashboard"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:207
-#: src/components/TrixoQuestionnaireForm/index.tsx:429
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:206
+#: src/components/TrixoQuestionnaireForm/index.tsx:428
 msgid "Data Protection Policies"
 msgstr "Politiques de protection des données"
 
@@ -840,11 +840,11 @@ msgstr "Recherche dans l'annuaire"
 msgid "Documentation"
 msgstr "Documentation"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:307
+#: src/components/TrixoQuestionnaireForm/index.tsx:306
 msgid "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr "Votre organisation effectue-t-elle un KYC/CDD avant de permettre à ses clients d'envoyer/recevoir des transferts d'actifs virtuels ?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:123
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:122
 msgid "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr "Votre organisation effectue-t-elle un KYC/CDD avant de permettre à ses clients d'envoyer/recevoir des transferts d'actifs virtuels ?"
 
@@ -860,7 +860,7 @@ msgstr ""
 "                       conformément aux exigences des régimes réglementaires de la ou\n"
 "                       des juridictions où elle est autorisée/approuvée/enregistrée ?"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:297
+#: src/components/TrixoQuestionnaireForm/index.tsx:296
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money\n"
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
@@ -870,7 +870,7 @@ msgstr ""
 "en matière de LBC, de CFT, de KYC/CDD et de sanctions conformément aux exigences des\n"
 "régimes réglementaires de la ou des juridictions où elle est autorisée/approuvée/enregistrée ?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:99
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:98
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
@@ -878,11 +878,11 @@ msgstr ""
 "Votre organisation dispose-t-elle d'un programme qui fixe des normes minimales en matière de LBC, de CFT, de KYC/CDD et de sanctions conformément aux exigences\n"
 "                    des régimes réglementaires de la ou des juridictions où elle est autorisée/approuvée/enregistrée ?"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:446
+#: src/components/TrixoQuestionnaireForm/index.tsx:445
 msgid "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
 msgstr "Votre organisation sécurise-t-elle et protège-t-elle les PII, y compris les PII reçues d'autres VASP en vertu de la réglementation sur les voyages?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:234
 msgid ""
 "Does your organization secure and protect Personally Identifiable\n"
 "                Information (PII), including Personally Identifiable\n"
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
 msgstr "Chaque VASP est tenu d'établir un endpoint TRISA pour la communication inter-VASP. Veuillez préciser les détails de votre endpoint pour la délivrance du certificat."
 
-#: src/components/TrisaImplementation/index.tsx:66
+#: src/components/TrisaImplementation/index.tsx:65
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
 msgstr "Chaque VASP est tenu d'établir un endpoint TRISA pour la communication inter-VASP. Veuillez spécifier les détails de votre endpoint pour l'émission de certificats. Veuillez spécifier le point final TestNet et le point final MainNet. Le point final TestNet et le point final MainNet doivent être différents."
 
@@ -930,7 +930,7 @@ msgid "Edit collaborator Role"
 msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:129
-#: src/components/Contacts/ContactForm/index.tsx:67
+#: src/components/Contacts/ContactForm/index.tsx:66
 #: src/components/Form/LoginForm.tsx:52
 #: src/components/Form/SignupForm.tsx:53
 #: src/components/Section/PasswordResetForm.tsx:26
@@ -967,8 +967,8 @@ msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:181
 #: src/components/CertificateInventory/index.tsx:116
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:57
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:77
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:56
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:76
 msgid "Endpoint"
 msgstr "Point de terminaison"
 
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
 msgstr "Entrez le nom commun VASP ou l'ID VASP. Vous n'êtes pas membre de TRISA ?"
 
-#: src/components/NameIdentifiers/index.tsx:31
+#: src/components/NameIdentifiers/index.tsx:30
 msgid "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
 msgstr "Entrez le nom et le type de nom sous lequel la personne morale est connue. Au moins un nom légal est requis. Les organisations sont vivement encouragées à saisir des identifiants de nom supplémentaires, tels que le nom commercial/le Doing Business As (DBA), les noms locaux et les noms phonétiques, le cas échéant."
 
@@ -1048,7 +1048,7 @@ msgstr "Révision finale et soumission du formulaire"
 msgid "First (Given) Name"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:67
+#: src/components/OrganizationProfile/TrisaDetail.tsx:57
 msgid "First Listed"
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
 msgstr "Pour les demandes de certificats MainNet, un membre de l'équipe de vérification de TRISA examinera votre soumission et effectuera un appel téléphonique de diligence finale pour la vérification physique. Une fois la vérification physique terminée, TRISA émettra les certificats MainNet. Les demandes de certificats TestNet ne nécessitent pas de vérification physique."
 
-#: src/components/NameIdentification/index.tsx:32
+#: src/components/NationalIdentification/index.tsx:31
 msgid "For identifiers other than LEI specify the registration authority from the following list. See"
 msgstr "Pour les identifiants autres que LEI, indiquez l'autorité d'enregistrement dans la liste suivante. Voir"
 
@@ -1072,7 +1072,7 @@ msgstr "Numéro d'identité d'investissement étranger"
 msgid "Forgot password?"
 msgstr "Mot de passe oublié ?"
 
-#: src/components/Contacts/ContactForm/index.tsx:58
+#: src/components/Contacts/ContactForm/index.tsx:57
 msgid "Full Name"
 msgstr "Nom complet"
 
@@ -1080,7 +1080,7 @@ msgstr "Nom complet"
 msgid "Full name"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:40
+#: src/components/NationalIdentification/index.tsx:39
 msgid "GLEIF Registration Authorities"
 msgstr "Autorités d'enregistrement du GLEIF"
 
@@ -1129,7 +1129,7 @@ msgstr ""
 #~ msgid "I have a bad feeling about tomorrow."
 #~ msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:64
+#: src/components/OrganizationProfile/TrisaDetail.tsx:54
 msgid "ID"
 msgstr ""
 
@@ -1143,14 +1143,14 @@ msgstr "Structure de données IVMS 101"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:165
 #: src/components/MemberDetails/index.tsx:303
-#: src/components/NameIdentification/index.tsx:127
+#: src/components/NationalIdentification/index.tsx:126
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:112
 msgid "Identification Number"
 msgstr "Numéro d'identification"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:171
 #: src/components/MemberDetails/index.tsx:311
-#: src/components/NameIdentification/index.tsx:156
+#: src/components/NationalIdentification/index.tsx:155
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:120
 msgid "Identification Type"
 msgstr "Type d'identification"
@@ -1163,7 +1163,7 @@ msgstr "Numéro de carte d'identité"
 msgid "Identity Certificates"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:41
+#: src/components/Contacts/ContactForm/index.tsx:40
 msgid "If supplied, use full phone number with country code"
 msgstr "Si elle est fournie, utilisez le numéro de téléphone complet avec l'indicatif du pays."
 
@@ -1241,16 +1241,16 @@ msgstr "Interopérable"
 #~ msgid "Invalid date."
 #~ msgstr "Date non valide"
 
-#: src/components/Collaborators/index.tsx:165
+#: src/components/Collaborators/index.tsx:173
 msgid "Invited"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:67
-#: src/components/TrixoQuestionnaireForm/index.tsx:274
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:66
+#: src/components/TrixoQuestionnaireForm/index.tsx:273
 msgid "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
 msgstr "Votre organisation est-elle autorisée à envoyer et/ou recevoir des transferts d'actifs virtuels dans les juridictions dans lesquelles elle opère ?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:215
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:214
 msgid ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
@@ -1258,12 +1258,12 @@ msgstr ""
 "Votre organisation est-elle tenue par la loi de protéger\n"
 "                les PII ?"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:433
+#: src/components/TrixoQuestionnaireForm/index.tsx:432
 msgid "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
 msgstr "Votre organisation est-elle tenue par la loi de protéger les PII ?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:154
-#: src/components/TrixoQuestionnaireForm/index.tsx:363
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:153
+#: src/components/TrixoQuestionnaireForm/index.tsx:362
 msgid "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
 msgstr "Votre organisation est-elle tenue de se conformer à l'application des normes de la Travel Rule dans la ou les juridictions où elle est autorisée/approuvée/enregistrée ?"
 
@@ -1300,7 +1300,7 @@ msgstr "Rejoignez le réseau TRISA dès aujourd'hui."
 #~ msgid "Join us on Thursday Apr 28 for the TRISA Working Group."
 #~ msgstr ""
 
-#: src/components/Collaborators/index.tsx:168
+#: src/components/Collaborators/index.tsx:176
 #: src/modules/dashboard/member/components/MemberTable.tsx:22
 #: src/modules/dashboard/member/utils.ts:12
 msgid "Joined"
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "Last Login:"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:73
+#: src/components/OrganizationProfile/TrisaDetail.tsx:63
 #: src/modules/dashboard/member/components/MemberTable.tsx:25
 #: src/modules/dashboard/member/utils.ts:16
 msgid "Last Updated"
@@ -1377,7 +1377,7 @@ msgstr "Contact juridique/conformité (obligatoire)"
 msgid "Link Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:36
 msgid "Local Name Identifiers"
 msgstr "Identificateurs de noms locaux"
 
@@ -1425,7 +1425,7 @@ msgstr "Connexion"
 msgid "Login & Identity"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:196
+#: src/components/Section/SearchDirectory.tsx:187
 msgid "MAINNET DIRECTORY RECORD"
 msgstr "FICHE D'ANNUAIRE MAINNET"
 
@@ -1439,7 +1439,7 @@ msgid "MAINNET SUBMISSION"
 msgstr "SOUMISSION AU RÉSEAU PRINCIPAL"
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:53
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:72
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:51
 #: src/components/ReviewSubmit/index.tsx:224
 msgid "MainNet"
 msgstr ""
@@ -1507,16 +1507,16 @@ msgstr "Divers"
 #~ msgid "Missing required element"
 #~ msgstr "Élément requis manquant"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:369
+#: src/components/TrixoQuestionnaireForm/index.tsx:368
 msgid "Must comply with Travel Rule"
 msgstr "Doit se conformer à la réglementation sur les voyages"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:439
+#: src/components/TrixoQuestionnaireForm/index.tsx:438
 msgid "Must safeguard PII"
 msgstr "Doit protéger les PII"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "NO"
 msgstr "NON"
 
@@ -1526,7 +1526,7 @@ msgid "NO VERIFICATION"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:57
-#: src/components/NameIdentifier/index.tsx:118
+#: src/components/NameIdentifier/index.tsx:117
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:19
 msgid "Name"
 msgstr "Nom"
@@ -1545,7 +1545,7 @@ msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:43
 #: src/components/MemberDetails/index.tsx:172
-#: src/components/NameIdentifiers/index.tsx:29
+#: src/components/NameIdentifiers/index.tsx:28
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:68
 msgid "Name Identifiers"
 msgstr "Identificateurs de noms"
@@ -1554,8 +1554,8 @@ msgstr "Identificateurs de noms"
 #~ msgid "Name identifiers"
 #~ msgstr "Identifiants de noms"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:43
-#: src/components/TrixoQuestionnaireForm/index.tsx:245
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:42
+#: src/components/TrixoQuestionnaireForm/index.tsx:244
 msgid "Name of Primary Regulator"
 msgstr "Nom de l'organisme de réglementation principal"
 
@@ -1565,7 +1565,7 @@ msgstr "Nom, adresse, pays, identifiant national"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:156
 #: src/components/MemberDetails/index.tsx:298
-#: src/components/NameIdentification/index.tsx:115
+#: src/components/NationalIdentification/index.tsx:114
 msgid "National Identification"
 msgstr "Identification nationale"
 
@@ -1611,7 +1611,7 @@ msgstr "Suivant"
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:26
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:33
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:31
 #: src/constants/trixo.ts:7
 msgid "No"
@@ -1685,7 +1685,7 @@ msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:120
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:30
-#: src/components/Section/SearchDirectory.tsx:209
+#: src/components/Section/SearchDirectory.tsx:211
 #: src/components/Section/SearchDirectory.tsx:277
 msgid "Organization Name"
 msgstr "Nom de l'organisme"
@@ -1714,8 +1714,8 @@ msgstr ""
 msgid "Organizational Details"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:49
-#: src/components/TrixoQuestionnaireForm/index.tsx:251
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:48
+#: src/components/TrixoQuestionnaireForm/index.tsx:250
 msgid "Other Jurisdictions"
 msgstr "Autres juridictions"
 
@@ -1764,11 +1764,11 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:91
+#: src/components/Contacts/ContactForm/index.tsx:90
 msgid "Phone Number"
 msgstr "Numéro de téléphone"
 
-#: src/components/NameIdentifiers/index.tsx:44
+#: src/components/NameIdentifiers/index.tsx:43
 msgid "Phonetic Name Identifiers"
 msgstr "Identifiants phonétiques des noms"
 
@@ -1776,7 +1776,7 @@ msgstr "Identifiants phonétiques des noms"
 msgid "Please Provide the Name and Email Address"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:254
+#: src/components/TrixoQuestionnaireForm/index.tsx:253
 msgid "Please add any other regulatory jurisdictions your organization complies with."
 msgstr "Veuillez ajouter toute autre juridiction réglementaire à laquelle votre organisation se conforme."
 
@@ -1820,11 +1820,11 @@ msgstr "Veuillez examiner les informations fournies, les modifier si nécessaire
 msgid "Please select as many categories needed to represent the types of virtual asset services your organization provides."
 msgstr "Veuillez sélectionner autant de catégories que nécessaire pour représenter les types de services d'actifs virtuels fournis par votre organisation."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:420
+#: src/components/TrixoQuestionnaireForm/index.tsx:419
 msgid "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
 msgstr "Veuillez préciser le(s) règlement(s) applicable(s) pour la conformité aux normes des Règles de voyage, par exemple :\"Recommandation 16 du GAFI\""
 
-#: src/components/NameIdentification/index.tsx:118
+#: src/components/NationalIdentification/index.tsx:117
 msgid "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
 msgstr "Veuillez fournir un numéro d'identification national valide. TRISA recommande l'utilisation des numéros LEI. Pour plus d'informations, veuillez consulter"
 
@@ -1832,15 +1832,15 @@ msgstr "Veuillez fournir un numéro d'identification national valide. TRISA reco
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
 msgstr "Veuillez fournir les coordonnées des représentants de votre organisation. Tous les contacts recevront un jeton de vérification par e-mail et l'e-mail du contact doit être vérifié avant que l'inscription puisse se poursuivre."
 
-#: src/components/Contacts/index.tsx:62
+#: src/components/Contacts/index.tsx:61
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:23
+#: src/components/Contacts/ContactForm/index.tsx:22
 msgid "Please use the email address associated with your organization."
 msgstr "Veuillez utiliser l'adresse e-mail associée à votre organisation."
 
-#: src/components/Contacts/ContactForm/index.tsx:21
+#: src/components/Contacts/ContactForm/index.tsx:20
 msgid "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
@@ -1859,7 +1859,7 @@ msgstr ""
 msgid "Postal Code / Postcode / ZIP Code"
 msgstr "Code postal / Postcode / ZIP Code"
 
-#: src/components/Contacts/ContactForm/index.tsx:59
+#: src/components/Contacts/ContactForm/index.tsx:58
 msgid "Preferred name for email communication."
 msgstr "Nom préféré pour la communication par e-mail."
 
@@ -1867,12 +1867,12 @@ msgstr "Nom préféré pour la communication par e-mail."
 msgid "Previous"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:37
-#: src/components/TrixoQuestionnaireForm/index.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:36
+#: src/components/TrixoQuestionnaireForm/index.tsx:234
 msgid "Primary National Jurisdiction"
 msgstr "Compétence nationale primaire"
 
-#: src/components/Contacts/ContactsForm.tsx:154
+#: src/components/Contacts/ContactsForm.tsx:155
 msgid "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
 msgstr "Contact principal pour le traitement des questions techniques concernant le fonctionnement et le statut de votre service participant au réseau TRISA. Peut être un e-mail de groupe ou d'administration."
 
@@ -1929,12 +1929,12 @@ msgstr "Autorité de régulation"
 msgid "Region / Province / State (required)"
 msgstr "Région / Province / État (obligatoire)"
 
-#: src/components/Section/SearchDirectory.tsx:227
+#: src/components/Section/SearchDirectory.tsx:229
 #: src/components/Section/SearchDirectory.tsx:295
 msgid "Registered Directory"
 msgstr "Annuaire enregistré"
 
-#: src/components/NameIdentification/index.tsx:196
+#: src/components/NationalIdentification/index.tsx:195
 msgid "Registration Authority"
 msgstr "Autorité d'enregistrement"
 
@@ -1962,7 +1962,7 @@ msgstr "Nom du régulateur"
 msgid "Remove Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifier/index.tsx:137
+#: src/components/NameIdentifier/index.tsx:136
 #: src/components/OtherJuridictions/index.tsx:58
 #: src/components/Regulations/index.tsx:31
 msgid "Remove line"
@@ -2008,7 +2008,7 @@ msgstr "Consulter"
 msgid "Review section"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:159
+#: src/components/Collaborators/index.tsx:167
 #: src/components/UserProfile/UserDetails.tsx:22
 msgid "Role"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "SUBMITTED"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:452
+#: src/components/TrixoQuestionnaireForm/index.tsx:451
 msgid "Safeguards PII"
 msgstr "Sauvegarde des PII"
 
@@ -2057,7 +2057,7 @@ msgstr "Recherche dans le service d'annuaire"
 msgid "Section"
 msgstr "Section"
 
-#: src/components/BasicDetail/index.tsx:132
+#: src/components/BasicDetail/index.tsx:130
 #: src/components/CertificateReview/BasicDetailsReview.tsx:29
 #: src/components/CertificateSection/index.tsx:23
 #: src/components/CertificateSection/index.tsx:65
@@ -2072,17 +2072,17 @@ msgstr "Section 2 : Personne morale"
 
 #: src/components/CertificateReview/ContactsReview.tsx:19
 #: src/components/CertificateSection/index.tsx:36
-#: src/components/Contacts/index.tsx:56
+#: src/components/Contacts/index.tsx:55
 msgid "Section 3: Contacts"
 msgstr "Section 3: Contacts"
 
 #: src/components/CertificateReview/TrisaImplementationReview.tsx:19
 #: src/components/CertificateSection/index.tsx:41
-#: src/components/TrisaImplementation/index.tsx:60
+#: src/components/TrisaImplementation/index.tsx:59
 msgid "Section 4: TRISA Implementation"
 msgstr "Section 4 : Mise en œuvre de TRISA"
 
-#: src/components/CertificateReview/TrixoReview.tsx:34
+#: src/components/CertificateReview/TrixoReview.tsx:32
 #: src/components/CertificateSection/index.tsx:46
 #: src/components/TrixoQuestionnaire/index.tsx:55
 msgid "Section 5: TRIXO Questionnaire"
@@ -2113,7 +2113,7 @@ msgstr "Sélectionnez la catégorie VASP"
 msgid "Select a VASP from the Managed VASP List"
 msgstr ""
 
-#: src/components/CountryOfRegistration/index.tsx:28
+#: src/components/CountryOfRegistration/index.tsx:27
 msgid "Select a country"
 msgstr "Sélectionnez un pays"
 
@@ -2212,8 +2212,8 @@ msgstr ""
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:67
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:45
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:63
-#: src/components/Collaborators/index.tsx:162
-#: src/components/OrganizationProfile/TrisaDetail.tsx:76
+#: src/components/Collaborators/index.tsx:170
+#: src/components/OrganizationProfile/TrisaDetail.tsx:66
 #: src/modules/dashboard/member/components/MemberTable.tsx:31
 #: src/modules/dashboard/member/utils.ts:24
 msgid "Status"
@@ -2246,7 +2246,7 @@ msgid "Subject Details"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:39
-#: src/components/NeedsAttention/AttentionAlert.tsx:98
+#: src/components/NeedsAttention/AttentionAlert.tsx:97
 #: src/components/Section/PasswordResetForm.tsx:48
 #: src/hoc/withRHF.tsx:117
 msgid "Submit"
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "Synga Bridge"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:188
+#: src/components/Section/SearchDirectory.tsx:195
 msgid "TESTNET DIRECTORY RECORD"
 msgstr "FICHE D'ANNUAIRE DE TESTNET"
 
@@ -2292,13 +2292,13 @@ msgstr ""
 #~ msgid "TRISA Certificates"
 #~ msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:67
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:66
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:75
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:83
 msgid "TRISA Endpoint"
 msgstr "Point de terminaison TRISA"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:149
+#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:150
 msgid "TRISA Endpoint: MainNet"
 msgstr "Point de terminaison TRISA: MainNet"
 
@@ -2334,7 +2334,7 @@ msgstr "Mise en œuvre de TRISA"
 msgid "TRISA Member Directory"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:233
+#: src/components/Section/SearchDirectory.tsx:235
 #: src/components/Section/SearchDirectory.tsx:301
 msgid "TRISA Member ID"
 msgstr "ID du membre TRISA"
@@ -2351,13 +2351,13 @@ msgstr "ID du membre TRISA"
 msgid "TRISA Registration Request Submitted!"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:221
+#: src/components/Section/SearchDirectory.tsx:223
 #: src/components/Section/SearchDirectory.tsx:289
 msgid "TRISA Service Endpoint"
 msgstr "Point de terminaison du service TRISA"
 
-#: src/components/Section/SearchDirectory.tsx:250
-#: src/components/Section/SearchDirectory.tsx:319
+#: src/components/Section/SearchDirectory.tsx:253
+#: src/components/Section/SearchDirectory.tsx:318
 msgid "TRISA Verification"
 msgstr "Vérification TRISA"
 
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Tax Identification Number"
 msgstr "Numéro d'identification fiscale"
 
-#: src/components/Contacts/ContactsForm.tsx:153
+#: src/components/Contacts/ContactsForm.tsx:154
 msgid "Technical Contact (required)"
 msgstr "Contact technique (obligatoire)"
 
@@ -2500,7 +2500,7 @@ msgid "Technical information about your endpoint for certificate issuance. Each 
 msgstr "Informations techniques sur votre endpoint pour l'émission de certificats. Chaque VASP est tenu d'établir un endpoint TRISA pour la communication inter-VASP."
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:33
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:52
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:71
 #: src/components/ReviewSubmit/index.tsx:132
 msgid "TestNet"
 msgstr "TestNet"
@@ -2551,7 +2551,7 @@ msgstr "Merci. Nous avons envoyé les instructions pour réinitialiser votre mot
 msgid "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
 msgstr "Merci. Nous avons envoyé les instructions pour réinitialiser votre mot de passe à {0}. Le lien pour réinitialiser votre mot de passe expire dans 24 heures."
 
-#: src/components/Section/SearchDirectory.tsx:145
+#: src/components/Section/SearchDirectory.tsx:144
 msgid ""
 "The Common Name typically matches the Endpoint, without the port number\n"
 "                            at the end (e.g. trisa.myvasp.com) and is used to identify the subject\n"
@@ -2598,7 +2598,7 @@ msgstr "L'architecture de partage d'informations sur les règles de voyage (TRIS
 msgid "The VASP Name is required."
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:72
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:71
 msgid "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
 msgstr "L'adresse et le port du point de terminaison TRISA sur lequel les SVA partenaires peuvent se connecter via gRPC."
 
@@ -2610,7 +2610,7 @@ msgstr ""
 msgid "The collaborator has not been updated"
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:58
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:57
 msgid "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
 msgstr "Le nom commun pour le certificat mTLS. Dans la plupart des cas, cela devrait correspondre au point de terminaison TRISA sans le port."
 
@@ -2626,18 +2626,18 @@ msgstr ""
 msgid "The link to reset your password expires in 24 hours."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:408
+#: src/components/TrixoQuestionnaireForm/index.tsx:407
 msgid "The minimum threshold above which your organization is required to collect/send Travel Rule information."
 msgstr "Le seuil minimum à partir duquel votre organisation est tenue de collecter/envoyer des informations sur les règles de voyage."
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:48
 #: src/components/MemberDetails/index.tsx:177
-#: src/components/NameIdentifiers/index.tsx:38
-#: src/components/NameIdentifiers/index.tsx:45
+#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:44
 msgid "The name and type of name by which the legal person is known."
 msgstr "Le nom et le type de nom sous lequel la personne morale est connue."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:246
+#: src/components/TrixoQuestionnaireForm/index.tsx:245
 msgid "The name of primary regulator or supervisory authority for your national jurisdiction"
 msgstr "Le nom du régulateur primaire ou de l'autorité de surveillance de votre juridiction nationale"
 
@@ -2661,7 +2661,7 @@ msgstr ""
 msgid "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
 msgstr "Ce questionnaire est conçu pour aider les membres de TRISA à comprendre le régime réglementaire de votre organisation. Les informations fournies permettront de s'assurer que les échanges d'informations de conformité requis sont effectués correctement et en toute sécurité. Tous les membres vérifiés de l'ASRI auront accès à ces informations."
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:353
+#: src/components/TrixoQuestionnaireForm/index.tsx:352
 msgid "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
 msgstr "Seuil pour effectuer KYC avant de permettre au client d'envoyer/recevoir des transferts d'actifs virtuels"
 
@@ -2758,8 +2758,8 @@ msgstr ""
 msgid "VERIFIED"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:255
-#: src/components/Section/SearchDirectory.tsx:324
+#: src/components/Section/SearchDirectory.tsx:258
+#: src/components/Section/SearchDirectory.tsx:323
 msgid "VERIFIED ON"
 msgstr "VERIFIÉ LE"
 
@@ -2772,7 +2772,7 @@ msgstr ""
 msgid "Verified"
 msgstr "Vérifié"
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:70
+#: src/components/OrganizationProfile/TrisaDetail.tsx:60
 msgid "Verified On"
 msgstr "Vérifié le"
 
@@ -2828,12 +2828,12 @@ msgstr ""
 msgid "What is IVMS101?"
 msgstr "Qu'est-ce que l'IVMS101?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:193
-#: src/components/TrixoQuestionnaireForm/index.tsx:377
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:192
+#: src/components/TrixoQuestionnaireForm/index.tsx:376
 msgid "What is the minimum threshold for Travel Rule compliance?"
 msgstr "Quel est le seuil minimum de conformité à la Travel Rule ?"
 
-#: src/components/Section/SearchDirectory.tsx:157
+#: src/components/Section/SearchDirectory.tsx:156
 msgid "What’s a Common name or VASP ID?"
 msgstr "Quel est le nom commun ou l'ID VASP ?"
 
@@ -2867,12 +2867,12 @@ msgstr ""
 msgid "X.509 Identity Certificates"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "YES"
 msgstr "OUI"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:34
 #: src/constants/trixo.ts:5
 msgid "Yes"
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Your TRISA Implementation"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:46
+#: src/components/OrganizationProfile/TrisaDetail.tsx:44
 msgid "Your TRISA {type} Details"
 msgstr ""
 
@@ -3068,7 +3068,7 @@ msgid ""
 "                    testing purposes."
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:137
+#: src/components/Collaborators/index.tsx:145
 msgid "you do not have permission to invite a collaborator"
 msgstr ""
 

--- a/web/gds-user-ui/src/locales/ja/messages.po
+++ b/web/gds-user-ui/src/locales/ja/messages.po
@@ -150,7 +150,7 @@ msgstr "4 TRISAの実施"
 msgid "5 TRIXO Questionnaire"
 msgstr "5 TRIXOアンケート"
 
-#: src/components/Contacts/ContactForm/index.tsx:30
+#: src/components/Contacts/ContactForm/index.tsx:29
 msgid "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgid "Action"
 msgstr "行動"
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:70
-#: src/components/Collaborators/index.tsx:171
+#: src/components/Collaborators/index.tsx:179
 #: src/modules/dashboard/member/components/MemberTable.tsx:34
 msgid "Actions"
 msgstr ""
@@ -209,11 +209,11 @@ msgstr ""
 msgid "Add Address"
 msgstr "アドレスを追加します"
 
-#: src/components/NameIdentifiers/index.tsx:51
+#: src/components/NameIdentifiers/index.tsx:50
 msgid "Add Another Legal Name"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:140
+#: src/components/Collaborators/index.tsx:148
 msgid "Add Contact"
 msgstr ""
 
@@ -229,11 +229,11 @@ msgstr "管轄の追加"
 msgid "Add Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:54
+#: src/components/NameIdentifiers/index.tsx:53
 msgid "Add Local Name"
 msgstr "ローカル名の追加"
 
-#: src/components/NameIdentifiers/index.tsx:57
+#: src/components/NameIdentifiers/index.tsx:56
 msgid "Add Phonetic Names"
 msgstr "音声名を追加する"
 
@@ -265,13 +265,13 @@ msgstr "住所1行目 例：建物名/番号、通り名（必須)\""
 msgid "Address line 2 e.g. apartment or suite number"
 msgstr "住所2行目 例：アパート番号またはスイート番号"
 
-#: src/components/Addresses/index.tsx:11
+#: src/components/Addresses/index.tsx:10
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:118
 #: src/components/MemberDetails/index.tsx:244
 msgid "Addresses"
 msgstr "住所"
 
-#: src/components/Contacts/ContactsForm.tsx:158
+#: src/components/Contacts/ContactsForm.tsx:161
 msgid "Administrative Contact (optional)"
 msgstr "管理連絡先（任意)"
 
@@ -287,7 +287,7 @@ msgstr ""
 msgid "Administrative Contact Phone"
 msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:159
+#: src/components/Contacts/ContactsForm.tsx:162
 msgid "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
 msgstr "高度な要求や問い合わせに対応するための、組織の管理職または役員の連絡先。(強く推奨))"
 
@@ -325,7 +325,7 @@ msgstr ""
 msgid "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:130
+#: src/components/NationalIdentification/index.tsx:129
 msgid "An identifier issued by an appropriate issuing authority"
 msgstr "適切な発行機関によって発行された識別子。"
 
@@ -333,8 +333,8 @@ msgstr "適切な発行機関によって発行された識別子。"
 msgid "App version {appVersion}"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:174
-#: src/components/TrixoQuestionnaireForm/index.tsx:417
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:173
+#: src/components/TrixoQuestionnaireForm/index.tsx:416
 msgid "Applicable Regulations"
 msgstr "適用される法規制"
 
@@ -346,13 +346,13 @@ msgstr "TRISA認定仮想資産サービスプロバイダーへの申請。"
 msgid "At least 9 characters in length"
 msgstr ""
 
-#: src/components/Addresses/index.tsx:14
+#: src/components/Addresses/index.tsx:13
 msgid "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
 msgstr "少なくとも1つの地理的な住所が必要です。組織の主要な地理的住所を入力する。組織は、複数の管轄区域で事業を展開している場合、追加の住所を入力することができます。"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:143
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:142
 #: src/components/MemberDetails/index.tsx:589
-#: src/components/TrixoQuestionnaireForm/index.tsx:322
+#: src/components/TrixoQuestionnaireForm/index.tsx:321
 msgid "At what threshold and currency does your organization conduct KYC checks?"
 msgstr ""
 
@@ -391,11 +391,11 @@ msgstr "トラベルルールへの対応"
 #~ msgid "Beware the Ides of March"
 #~ msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:163
+#: src/components/Contacts/ContactsForm.tsx:168
 msgid "Billing Contact (optional)"
 msgstr "請求先（オプション）"
 
-#: src/components/Contacts/ContactsForm.tsx:164
+#: src/components/Contacts/ContactsForm.tsx:169
 msgid "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
 msgstr "TRISAネットワークの運用に関連するアカウントや請求書の要求や問い合わせに対応するための、お客様の組織の請求窓口です"
 
@@ -433,7 +433,7 @@ msgstr "事業所またはコンプライアンス室"
 msgid "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:282
+#: src/components/TrixoQuestionnaireForm/index.tsx:281
 msgid "CDD & Travel Rule Policies"
 msgstr "CDDとトラベルルールのポリシー"
 
@@ -449,7 +449,7 @@ msgstr "CDDおよびデータ保護ポリシー"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:80
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:79
 msgid "Certificate Common Name"
 msgstr "証明書のコモンネーム"
 
@@ -544,7 +544,7 @@ msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:158
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:198
-#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:74
+#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:75
 msgid "Close"
 msgstr ""
 
@@ -573,9 +573,9 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:286
 #: src/components/CertificateInventory/index.tsx:206
 #: src/components/CertificateInventory/index.tsx:269
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:63
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:83
-#: src/components/Section/SearchDirectory.tsx:215
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:62
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:82
+#: src/components/Section/SearchDirectory.tsx:217
 #: src/components/Section/SearchDirectory.tsx:283
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:79
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:89
@@ -586,7 +586,7 @@ msgstr "一般名"
 #~ msgid "Common name or VASP ID"
 #~ msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:42
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:41
 msgid "Common name should match the TRISA endpoint without the port."
 msgstr ""
 
@@ -666,7 +666,7 @@ msgstr ""
 msgid "Comply with the Travel Rule"
 msgstr "トラベルルールを遵守する"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:313
+#: src/components/TrixoQuestionnaireForm/index.tsx:312
 msgid "Conducts KYC before virtual asset transfers"
 msgstr "仮想資産譲渡前にKYCを実施"
 
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Confirm New Password"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:156
+#: src/components/Collaborators/index.tsx:164
 msgid "Contact Details"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgid "Contact information for representatives of your organization. Contacts in
 msgstr "お客様の組織の代表者の連絡先。連絡先には、技術担当者、法務/コンプライアンス担当者、事務担当者、請求担当者が含まれます"
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:21
-#: src/components/OrganizationProfile/OrganizationalDetail.tsx:157
+#: src/components/OrganizationProfile/OrganizationalDetail.tsx:158
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:165
 msgid "Contacts"
 msgstr "コンタクト"
@@ -737,8 +737,8 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:292
 #: src/components/CertificateInventory/index.tsx:212
 #: src/components/CertificateInventory/index.tsx:275
-#: src/components/Section/SearchDirectory.tsx:239
-#: src/components/Section/SearchDirectory.tsx:308
+#: src/components/Section/SearchDirectory.tsx:242
+#: src/components/Section/SearchDirectory.tsx:307
 msgid "Country"
 msgstr "国"
 
@@ -747,16 +747,16 @@ msgid "Country (required)"
 msgstr "国名（必須）"
 
 #: src/components/MemberDetails/index.tsx:321
-#: src/components/NameIdentification/index.tsx:174
+#: src/components/NationalIdentification/index.tsx:173
 msgid "Country of Issue"
 msgstr "発行国について"
 
-#: src/components/NameIdentification/index.tsx:178
+#: src/components/NationalIdentification/index.tsx:177
 msgid "Country of Issue is reserved for National Identifiers of Natural Persons"
 msgstr "発行国は自然人の国民IDのために予約されています"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:138
-#: src/components/CountryOfRegistration/index.tsx:19
+#: src/components/CountryOfRegistration/index.tsx:18
 #: src/components/MemberDetails/index.tsx:271
 #: src/components/MemberDetails/index.tsx:331
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:137
@@ -819,11 +819,11 @@ msgstr "作成・管理"
 msgid "Current Name"
 msgstr ""
 
-#: src/components/Sidebar/MobileNav.tsx:83
+#: src/components/Sidebar/MobileNav.tsx:81
 msgid "Current Organization name"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:89
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:88
 msgid "Customer Due Diligence (CDD) & Travel Rule Policies"
 msgstr ""
 
@@ -835,8 +835,8 @@ msgstr "お客様番号"
 msgid "Dashboard"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:207
-#: src/components/TrixoQuestionnaireForm/index.tsx:429
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:206
+#: src/components/TrixoQuestionnaireForm/index.tsx:428
 msgid "Data Protection Policies"
 msgstr "データ保護ポリシー"
 
@@ -904,11 +904,11 @@ msgstr "ディレクトリ参照"
 msgid "Documentation"
 msgstr "ドキュメンテーション"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:307
+#: src/components/TrixoQuestionnaireForm/index.tsx:306
 msgid "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr "あなたの組織は、顧客に仮想資産の送受信を許可する前に、KYC/CDDを実施していますか?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:123
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:122
 msgid "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr ""
 
@@ -925,24 +925,24 @@ msgid ""
 "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:297
+#: src/components/TrixoQuestionnaireForm/index.tsx:296
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money\n"
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:99
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:98
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:446
+#: src/components/TrixoQuestionnaireForm/index.tsx:445
 msgid "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
 msgstr "あなたの組織は、トラベルルールに基づき他のVASPから受け取ったPIIを含め、PIIを安全に保護していますか?"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:234
 msgid ""
 "Does your organization secure and protect Personally Identifiable\n"
 "                Information (PII), including Personally Identifiable\n"
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
 msgstr "各VASPは、VASP間通信のためにTRISAエンドポイントを設定する必要があります。証明書発行のためのエンドポイントの詳細をご指定ください"
 
-#: src/components/TrisaImplementation/index.tsx:66
+#: src/components/TrisaImplementation/index.tsx:65
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
 msgstr "各VASPは、VASP間通信のためにTRISAエンドポイントを設定する必要があります。証明書発行のためのエンドポイントの詳細をご指定ください。TestNetエンドポイントとMainNetエンドポイントをご指定ください。TestNetエンドポイントとMainNetエンドポイントは異なる必要があります"
 
@@ -987,7 +987,7 @@ msgid "Edit collaborator Role"
 msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:129
-#: src/components/Contacts/ContactForm/index.tsx:67
+#: src/components/Contacts/ContactForm/index.tsx:66
 #: src/components/Form/LoginForm.tsx:52
 #: src/components/Form/SignupForm.tsx:53
 #: src/components/Section/PasswordResetForm.tsx:26
@@ -1024,8 +1024,8 @@ msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:181
 #: src/components/CertificateInventory/index.tsx:116
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:57
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:77
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:56
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:76
 msgid "Endpoint"
 msgstr "エンドポイント"
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
 msgstr "VASPコモンネームまたはVASP IDを入力してください。TRISA会員でないのか"
 
-#: src/components/NameIdentifiers/index.tsx:31
+#: src/components/NameIdentifiers/index.tsx:30
 msgid "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
 msgstr ""
 
@@ -1113,7 +1113,7 @@ msgstr "最終確認とフォームの提出"
 msgid "First (Given) Name"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:67
+#: src/components/OrganizationProfile/TrisaDetail.tsx:57
 msgid "First Listed"
 msgstr ""
 
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
 msgstr "メインネット証明書の申請については、TRISAの検証チームのメンバーが申請を確認し、物理的検証のための最終デューデリジェンス電話を実施します。物理的検証が完了すると、TRISA は MainNet 証明書を発行します。TestNet証明書の申請には、物理的検証は必要ありません。"
 
-#: src/components/NameIdentification/index.tsx:32
+#: src/components/NationalIdentification/index.tsx:31
 msgid "For identifiers other than LEI specify the registration authority from the following list. See"
 msgstr "LEI 以外の識別子については、以下のリストの中から登録機関を指定する。参照"
 
@@ -1137,7 +1137,7 @@ msgstr "外国人投資家識別番号。"
 msgid "Forgot password?"
 msgstr "パスワードを忘れましたか?\""
 
-#: src/components/Contacts/ContactForm/index.tsx:58
+#: src/components/Contacts/ContactForm/index.tsx:57
 msgid "Full Name"
 msgstr "氏名"
 
@@ -1145,7 +1145,7 @@ msgstr "氏名"
 msgid "Full name"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:40
+#: src/components/NationalIdentification/index.tsx:39
 msgid "GLEIF Registration Authorities"
 msgstr "GLEIF登録機関"
 
@@ -1194,7 +1194,7 @@ msgstr ""
 #~ msgid "I have a bad feeling about tomorrow."
 #~ msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:64
+#: src/components/OrganizationProfile/TrisaDetail.tsx:54
 msgid "ID"
 msgstr ""
 
@@ -1208,14 +1208,14 @@ msgstr "IVMS101のデータ構造"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:165
 #: src/components/MemberDetails/index.tsx:303
-#: src/components/NameIdentification/index.tsx:127
+#: src/components/NationalIdentification/index.tsx:126
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:112
 msgid "Identification Number"
 msgstr "識別番号"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:171
 #: src/components/MemberDetails/index.tsx:311
-#: src/components/NameIdentification/index.tsx:156
+#: src/components/NationalIdentification/index.tsx:155
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:120
 msgid "Identification Type"
 msgstr "識別の種類"
@@ -1228,7 +1228,7 @@ msgstr "身分証明書番号"
 msgid "Identity Certificates"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:41
+#: src/components/Contacts/ContactForm/index.tsx:40
 msgid "If supplied, use full phone number with country code"
 msgstr "提供された場合、国番号を含む完全な電話番号を使用する"
 
@@ -1314,12 +1314,12 @@ msgstr "インターオペラブル"
 #~ msgid "Invalid date."
 #~ msgstr ""
 
-#: src/components/Collaborators/index.tsx:165
+#: src/components/Collaborators/index.tsx:173
 msgid "Invited"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:67
-#: src/components/TrixoQuestionnaireForm/index.tsx:274
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:66
+#: src/components/TrixoQuestionnaireForm/index.tsx:273
 msgid "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
 msgstr "あなたの組織は、運営する法域において仮想資産の送受信を行うことが許されていますか？"
 
@@ -1328,18 +1328,18 @@ msgstr "あなたの組織は、運営する法域において仮想資産の送
 #~ msgid "Is your organization required by law to safeguard PII?"
 #~ msgstr "個人情報の保護が法律で義務付けられていますか？"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:215
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:214
 msgid ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:433
+#: src/components/TrixoQuestionnaireForm/index.tsx:432
 msgid "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:154
-#: src/components/TrixoQuestionnaireForm/index.tsx:363
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:153
+#: src/components/TrixoQuestionnaireForm/index.tsx:362
 msgid "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
 msgstr "あなたの組織は、ライセンス/承認/登録されている管轄区域において、旅行規則の基準の適用に準拠する必要がありますか?"
 
@@ -1376,7 +1376,7 @@ msgstr "TRISAネットワークに今すぐ参加する"
 #~ msgid "Join us on Thursday Apr 28 for the TRISA Working Group."
 #~ msgstr ""
 
-#: src/components/Collaborators/index.tsx:168
+#: src/components/Collaborators/index.tsx:176
 #: src/modules/dashboard/member/components/MemberTable.tsx:22
 #: src/modules/dashboard/member/utils.ts:12
 msgid "Joined"
@@ -1394,7 +1394,7 @@ msgstr ""
 msgid "Last Login:"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:73
+#: src/components/OrganizationProfile/TrisaDetail.tsx:63
 #: src/modules/dashboard/member/components/MemberTable.tsx:25
 #: src/modules/dashboard/member/utils.ts:16
 msgid "Last Updated"
@@ -1453,7 +1453,7 @@ msgstr "法務・コンプライアンス担当者（必須）"
 msgid "Link Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:36
 msgid "Local Name Identifiers"
 msgstr "ローカル名識別子"
 
@@ -1501,7 +1501,7 @@ msgstr "ログイン"
 msgid "Login & Identity"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:196
+#: src/components/Section/SearchDirectory.tsx:187
 msgid "MAINNET DIRECTORY RECORD"
 msgstr "メインネットディレクトリレコード"
 
@@ -1515,7 +1515,7 @@ msgid "MAINNET SUBMISSION"
 msgstr "メインネット発信"
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:53
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:72
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:51
 #: src/components/ReviewSubmit/index.tsx:224
 msgid "MainNet"
 msgstr "メインネット"
@@ -1583,16 +1583,16 @@ msgstr "その他"
 #~ msgid "Missing required element"
 #~ msgstr "必要な要素がない"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:369
+#: src/components/TrixoQuestionnaireForm/index.tsx:368
 msgid "Must comply with Travel Rule"
 msgstr "トラベルルールを遵守すること"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:439
+#: src/components/TrixoQuestionnaireForm/index.tsx:438
 msgid "Must safeguard PII"
 msgstr "個人情報を保護する必要があります"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "NO"
 msgstr ""
 
@@ -1602,7 +1602,7 @@ msgid "NO VERIFICATION"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:57
-#: src/components/NameIdentifier/index.tsx:118
+#: src/components/NameIdentifier/index.tsx:117
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:19
 msgid "Name"
 msgstr "名前"
@@ -1621,7 +1621,7 @@ msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:43
 #: src/components/MemberDetails/index.tsx:172
-#: src/components/NameIdentifiers/index.tsx:29
+#: src/components/NameIdentifiers/index.tsx:28
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:68
 msgid "Name Identifiers"
 msgstr "名前識別情報"
@@ -1630,8 +1630,8 @@ msgstr "名前識別情報"
 #~ msgid "Name identifiers"
 #~ msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:43
-#: src/components/TrixoQuestionnaireForm/index.tsx:245
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:42
+#: src/components/TrixoQuestionnaireForm/index.tsx:244
 msgid "Name of Primary Regulator"
 msgstr ""
 
@@ -1645,7 +1645,7 @@ msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:156
 #: src/components/MemberDetails/index.tsx:298
-#: src/components/NameIdentification/index.tsx:115
+#: src/components/NationalIdentification/index.tsx:114
 msgid "National Identification"
 msgstr "ナショナルアイデンティフィケーション"
 
@@ -1691,7 +1691,7 @@ msgstr "次"
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:26
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:33
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:31
 #: src/constants/trixo.ts:7
 msgid "No"
@@ -1769,7 +1769,7 @@ msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:120
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:30
-#: src/components/Section/SearchDirectory.tsx:209
+#: src/components/Section/SearchDirectory.tsx:211
 #: src/components/Section/SearchDirectory.tsx:277
 msgid "Organization Name"
 msgstr "団体名"
@@ -1798,8 +1798,8 @@ msgstr ""
 msgid "Organizational Details"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:49
-#: src/components/TrixoQuestionnaireForm/index.tsx:251
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:48
+#: src/components/TrixoQuestionnaireForm/index.tsx:250
 msgid "Other Jurisdictions"
 msgstr "他の管轄地域"
 
@@ -1848,11 +1848,11 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:91
+#: src/components/Contacts/ContactForm/index.tsx:90
 msgid "Phone Number"
 msgstr "電話番号"
 
-#: src/components/NameIdentifiers/index.tsx:44
+#: src/components/NameIdentifiers/index.tsx:43
 msgid "Phonetic Name Identifiers"
 msgstr "フォネティックネーム識別子"
 
@@ -1860,7 +1860,7 @@ msgstr "フォネティックネーム識別子"
 msgid "Please Provide the Name and Email Address"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:254
+#: src/components/TrixoQuestionnaireForm/index.tsx:253
 msgid "Please add any other regulatory jurisdictions your organization complies with."
 msgstr "その他、貴社が準拠している規制当局があれば、追加してください"
 
@@ -1913,11 +1913,11 @@ msgstr "入力された情報を確認し、必要に応じて編集し、送信
 msgid "Please select as many categories needed to represent the types of virtual asset services your organization provides."
 msgstr "貴社が提供する仮想資産サービスの種類を表すために必要な数のカテゴリーを選択してください。"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:420
+#: src/components/TrixoQuestionnaireForm/index.tsx:419
 msgid "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
 msgstr "トラベルルール規格に準拠するため、適用される規則を特定してください。e.g.\"FATF Recommendation 16\""
 
-#: src/components/NameIdentification/index.tsx:118
+#: src/components/NationalIdentification/index.tsx:117
 msgid "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
 msgstr "有効な国民識別番号を入力してください。TRISAはLEI番号の使用を推奨しています。詳細については、以下をご覧ください。"
 
@@ -1930,15 +1930,15 @@ msgstr "有効な国民識別番号を入力してください。TRISAはLEI番�
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
 msgstr ""
 
-#: src/components/Contacts/index.tsx:62
+#: src/components/Contacts/index.tsx:61
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:23
+#: src/components/Contacts/ContactForm/index.tsx:22
 msgid "Please use the email address associated with your organization."
 msgstr "ご所属の組織に関連するメールアドレスをご使用ください"
 
-#: src/components/Contacts/ContactForm/index.tsx:21
+#: src/components/Contacts/ContactForm/index.tsx:20
 msgid "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
@@ -1957,7 +1957,7 @@ msgstr ""
 msgid "Postal Code / Postcode / ZIP Code"
 msgstr "郵便番号 / 郵便番号 / ZIPコード"
 
-#: src/components/Contacts/ContactForm/index.tsx:59
+#: src/components/Contacts/ContactForm/index.tsx:58
 msgid "Preferred name for email communication."
 msgstr "電子メールでのコミュニケーションに適した名前。"
 
@@ -1965,12 +1965,12 @@ msgstr "電子メールでのコミュニケーションに適した名前。"
 msgid "Previous"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:37
-#: src/components/TrixoQuestionnaireForm/index.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:36
+#: src/components/TrixoQuestionnaireForm/index.tsx:234
 msgid "Primary National Jurisdiction"
 msgstr "国内主要管轄地域"
 
-#: src/components/Contacts/ContactsForm.tsx:154
+#: src/components/Contacts/ContactsForm.tsx:155
 msgid "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
 msgstr "TRISAネットワークに参加しているお客様のサービスの運用や状態に関する技術的な問い合わせに対応するための主要な連絡先です。グループメールや管理者メールでも可"
 
@@ -2027,12 +2027,12 @@ msgstr "レグオーソリティ"
 msgid "Region / Province / State (required)"
 msgstr "地域／都道府県／州（必須)"
 
-#: src/components/Section/SearchDirectory.tsx:227
+#: src/components/Section/SearchDirectory.tsx:229
 #: src/components/Section/SearchDirectory.tsx:295
 msgid "Registered Directory"
 msgstr "登録済みディレクトリ"
 
-#: src/components/NameIdentification/index.tsx:196
+#: src/components/NationalIdentification/index.tsx:195
 msgid "Registration Authority"
 msgstr "登録機関"
 
@@ -2060,7 +2060,7 @@ msgstr "レギュレータ名"
 msgid "Remove Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifier/index.tsx:137
+#: src/components/NameIdentifier/index.tsx:136
 #: src/components/OtherJuridictions/index.tsx:58
 #: src/components/Regulations/index.tsx:31
 msgid "Remove line"
@@ -2106,7 +2106,7 @@ msgstr "レビュー"
 msgid "Review section"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:159
+#: src/components/Collaborators/index.tsx:167
 #: src/components/UserProfile/UserDetails.tsx:22
 msgid "Role"
 msgstr ""
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "SUBMITTED"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:452
+#: src/components/TrixoQuestionnaireForm/index.tsx:451
 msgid "Safeguards PII"
 msgstr "個人情報の保護について"
 
@@ -2155,7 +2155,7 @@ msgstr "ディレクトリサービスを検索する"
 msgid "Section"
 msgstr "セクション"
 
-#: src/components/BasicDetail/index.tsx:132
+#: src/components/BasicDetail/index.tsx:130
 #: src/components/CertificateReview/BasicDetailsReview.tsx:29
 #: src/components/CertificateSection/index.tsx:23
 #: src/components/CertificateSection/index.tsx:65
@@ -2170,17 +2170,17 @@ msgstr "第2章：リーガル・パーソン"
 
 #: src/components/CertificateReview/ContactsReview.tsx:19
 #: src/components/CertificateSection/index.tsx:36
-#: src/components/Contacts/index.tsx:56
+#: src/components/Contacts/index.tsx:55
 msgid "Section 3: Contacts"
 msgstr "セクション 3: 連絡先"
 
 #: src/components/CertificateReview/TrisaImplementationReview.tsx:19
 #: src/components/CertificateSection/index.tsx:41
-#: src/components/TrisaImplementation/index.tsx:60
+#: src/components/TrisaImplementation/index.tsx:59
 msgid "Section 4: TRISA Implementation"
 msgstr "第4節 TRISAの実施"
 
-#: src/components/CertificateReview/TrixoReview.tsx:34
+#: src/components/CertificateReview/TrixoReview.tsx:32
 #: src/components/CertificateSection/index.tsx:46
 #: src/components/TrixoQuestionnaire/index.tsx:55
 msgid "Section 5: TRIXO Questionnaire"
@@ -2211,7 +2211,7 @@ msgstr " VASPのカテゴリーを選択する"
 msgid "Select a VASP from the Managed VASP List"
 msgstr ""
 
-#: src/components/CountryOfRegistration/index.tsx:28
+#: src/components/CountryOfRegistration/index.tsx:27
 msgid "Select a country"
 msgstr "国を選択してください"
 
@@ -2314,8 +2314,8 @@ msgstr ""
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:67
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:45
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:63
-#: src/components/Collaborators/index.tsx:162
-#: src/components/OrganizationProfile/TrisaDetail.tsx:76
+#: src/components/Collaborators/index.tsx:170
+#: src/components/OrganizationProfile/TrisaDetail.tsx:66
 #: src/modules/dashboard/member/components/MemberTable.tsx:31
 #: src/modules/dashboard/member/utils.ts:24
 msgid "Status"
@@ -2348,7 +2348,7 @@ msgid "Subject Details"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:39
-#: src/components/NeedsAttention/AttentionAlert.tsx:98
+#: src/components/NeedsAttention/AttentionAlert.tsx:97
 #: src/components/Section/PasswordResetForm.tsx:48
 #: src/hoc/withRHF.tsx:117
 msgid "Submit"
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Synga Bridge"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:188
+#: src/components/Section/SearchDirectory.tsx:195
 msgid "TESTNET DIRECTORY RECORD"
 msgstr "テストネットディレクトリレコード"
 
@@ -2394,7 +2394,7 @@ msgstr ""
 #~ msgid "TRISA Certificates"
 #~ msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:67
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:66
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:75
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:83
 msgid "TRISA Endpoint"
@@ -2404,7 +2404,7 @@ msgstr " TRISAエンドポイント"
 #~ msgid "TRISA Endpoint is a server address (e.g. trisa.myvasp.com:443) at which the VASP can be reached via secure channels. The Common Name typically matches the Endpoint, without the port number at the end (e.g. trisa.myvasp.com) and is used to identify the subject in the X.509 certificate."
 #~ msgstr " TRISA Endpointは、VASPが安全なチャネルを介して到達できるサーバ・アドレス（例：trisa.myvasp.com:443）である。コモンネームは通常、エンドポイントに一致し、末尾のポート番号を除いたもの（例：trisa.myvasp.com）で、X.509証明書でサブジェクトを識別するために使用されます。"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:149
+#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:150
 msgid "TRISA Endpoint: MainNet"
 msgstr " TRISA Endpoint:メインネット"
 
@@ -2436,7 +2436,7 @@ msgstr ""
 msgid "TRISA Member Directory"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:233
+#: src/components/Section/SearchDirectory.tsx:235
 #: src/components/Section/SearchDirectory.tsx:301
 msgid "TRISA Member ID"
 msgstr " TRISAメンバーID"
@@ -2453,13 +2453,13 @@ msgstr ""
 msgid "TRISA Registration Request Submitted!"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:221
+#: src/components/Section/SearchDirectory.tsx:223
 #: src/components/Section/SearchDirectory.tsx:289
 msgid "TRISA Service Endpoint"
 msgstr " TRISA サービスエンドポイント"
 
-#: src/components/Section/SearchDirectory.tsx:250
-#: src/components/Section/SearchDirectory.tsx:319
+#: src/components/Section/SearchDirectory.tsx:253
+#: src/components/Section/SearchDirectory.tsx:318
 msgid "TRISA Verification"
 msgstr " TRISAの検証"
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Tax Identification Number"
 msgstr "課税証明書番号"
 
-#: src/components/Contacts/ContactsForm.tsx:153
+#: src/components/Contacts/ContactsForm.tsx:154
 msgid "Technical Contact (required)"
 msgstr "技術連絡先（必須）"
 
@@ -2602,7 +2602,7 @@ msgid "Technical information about your endpoint for certificate issuance. Each 
 msgstr "証明書発行のためのエンドポイントに関する技術的な情報。各VASPは、VASP間通信のためにTRISAエンドポイントを設置することが必要です"
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:33
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:52
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:71
 #: src/components/ReviewSubmit/index.tsx:132
 msgid "TestNet"
 msgstr "テストネット"
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
 msgstr "ありがとうございます。パスワードをリセットするための手順を {0} に送信しました。パスワードリセットのリンクは24時間以内に有効期限が切れます。"
 
-#: src/components/Section/SearchDirectory.tsx:145
+#: src/components/Section/SearchDirectory.tsx:144
 msgid ""
 "The Common Name typically matches the Endpoint, without the port number\n"
 "                            at the end (e.g. trisa.myvasp.com) and is used to identify the subject\n"
@@ -2700,7 +2700,7 @@ msgstr "旅行規則情報共有アーキテクチャ（TRISA)"
 msgid "The VASP Name is required."
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:72
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:71
 msgid "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
 msgstr "パートナーVASPがgRPCを介して接続するためのTRISAエンドポイントのアドレスとポート"
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "The collaborator has not been updated"
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:58
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:57
 msgid "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
 msgstr " mTLS証明書のコモンネーム。これはほとんどの場合、ポートを含まないTRISAエンドポイントと一致するはずであります"
 
@@ -2728,18 +2728,18 @@ msgstr ""
 msgid "The link to reset your password expires in 24 hours."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:408
+#: src/components/TrixoQuestionnaireForm/index.tsx:407
 msgid "The minimum threshold above which your organization is required to collect/send Travel Rule information."
 msgstr "組織がTravel Rule情報を収集/送信するために必要な最低基準値"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:48
 #: src/components/MemberDetails/index.tsx:177
-#: src/components/NameIdentifiers/index.tsx:38
-#: src/components/NameIdentifiers/index.tsx:45
+#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:44
 msgid "The name and type of name by which the legal person is known."
 msgstr "法人の名称および名称の種類"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:246
+#: src/components/TrixoQuestionnaireForm/index.tsx:245
 msgid "The name of primary regulator or supervisory authority for your national jurisdiction"
 msgstr "あなたの国の管轄区域の主要な規制当局または監督当局の名前。"
 
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
 msgstr "このアンケートは、TRISA会員が貴組織の規制体制を理解するために作成されたものです。提供された情報は、要求されるコンプライアンス情報交換が正しく安全に行われるようにするために役立ちます。認証されたすべてのTRISA会員は、この情報にアクセスすることができます。"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:353
+#: src/components/TrixoQuestionnaireForm/index.tsx:352
 msgid "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
 msgstr "顧客に仮想資産の送受信を許可する前にKYCを実施するための基準値"
 
@@ -2864,8 +2864,8 @@ msgstr ""
 msgid "VERIFIED"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:255
-#: src/components/Section/SearchDirectory.tsx:324
+#: src/components/Section/SearchDirectory.tsx:258
+#: src/components/Section/SearchDirectory.tsx:323
 msgid "VERIFIED ON"
 msgstr "ベリファイドオン"
 
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:70
+#: src/components/OrganizationProfile/TrisaDetail.tsx:60
 msgid "Verified On"
 msgstr "ベリファイドオン"
 
@@ -2934,12 +2934,12 @@ msgstr ""
 msgid "What is IVMS101?"
 msgstr " IVMS101とは何ですか？"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:193
-#: src/components/TrixoQuestionnaireForm/index.tsx:377
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:192
+#: src/components/TrixoQuestionnaireForm/index.tsx:376
 msgid "What is the minimum threshold for Travel Rule compliance?"
 msgstr " Travel Ruleに準拠するための最低基準値は？"
 
-#: src/components/Section/SearchDirectory.tsx:157
+#: src/components/Section/SearchDirectory.tsx:156
 msgid "What’s a Common name or VASP ID?"
 msgstr "コモンネームやVASP IDって何。"
 
@@ -2973,12 +2973,12 @@ msgstr ""
 msgid "X.509 Identity Certificates"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "YES"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:34
 #: src/constants/trixo.ts:5
 msgid "Yes"
@@ -3034,7 +3034,7 @@ msgstr ""
 msgid "Your TRISA Implementation"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:46
+#: src/components/OrganizationProfile/TrisaDetail.tsx:44
 msgid "Your TRISA {type} Details"
 msgstr ""
 
@@ -3194,7 +3194,7 @@ msgid ""
 "                    testing purposes."
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:137
+#: src/components/Collaborators/index.tsx:145
 msgid "you do not have permission to invite a collaborator"
 msgstr ""
 

--- a/web/gds-user-ui/src/locales/pt/messages.po
+++ b/web/gds-user-ui/src/locales/pt/messages.po
@@ -1,38 +1,24 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-22 14:33+0000\n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language: en-dh\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2024-01-17 17:14-0500\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: \n"
-"MIME-Version: 1.0\n"
 "X-Generator: @lingui/cli\n"
-
-#: src/components/ReviewSubmit/index.tsx:103
-#~ msgid " Failure to click either confirmation will result in an incomplete registration"
-#~ msgstr "---"
+"Language: pt\n"
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:67
 msgid ""
 " When you are verified you will be issued PKCS12 encrypted identity certificates\n"
 "                  for use in mTLS authentication between TRISA members. The password to decrypt\n"
 "                  those certificates is shown below:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:17
 msgid ""
 " create your TRISA account with your VASP email address. Add collaborators in your\n"
 "            organization."
-msgstr "---"
-
-#: src/components/ReviewSubmit/index.tsx:224
-#~ msgid " for MainNet registration so your MainNet certificate will be issued upon review by the validation team"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/InvalidFormPrompt.tsx:47
 msgid "\"Save & Next\" or \"Save & Previous\" button."
@@ -42,31 +28,23 @@ msgstr ""
 msgid "(1) <0>X.509 Identity Certificates:</0> X.509 Identity certificates are about <1>trust</1>. They prove the identity of the organization and are used to maintain a secure connection between TRISA members. X.509 Identity certificates must have an Endpoint and Common Name and may have Subject Alternative Names associated with them. TRISA’s X.509 Identity certificates are valid for one calendar year. TRISA’s X.509 Identity certificates expire after one year so member organizations must request a new X.509 Identity certificate upon expiration."
 msgstr ""
 
-#: src/components/CertificateManagement/index.tsx:60
-#~ msgid "(1)X.509 Identity Certificates"
-#~ msgstr "---"
-
 #: src/components/CertificateManagement/index.tsx:80
 msgid "(2) <0>Sealing Certificates:</0> Sealing certificates are for specific use cases such as <1>long-term data storage</1>. They are used to encrypt individual Secure Envelopes or batches of Secure Envelopes at the transactional level. Organizations may have multiple signing keys and multiple signing-key certificates for different clients, time periods, or use cases. In a compliance information transfer, the transactional sealing certificates are referred to as Envelope Seals. While an organization may use their X.509 Identity certificate as a sealing certificate, TRISA strongly recommends that transactional sealing certificates are different from X.509 Identity certificates for security purposes."
 msgstr ""
 
-#: src/components/CertificateManagement/index.tsx:72
-#~ msgid "(2)Sealing Certificates"
-#~ msgstr "---"
-
 #: src/components/CertificateSection/index.tsx:96
 #: src/components/SectionStatus/SavedSectionStatus.tsx:20
 msgid "(Saved)"
-msgstr "---"
+msgstr ""
 
 #: src/components/TravelRuleProviders/index.tsx:27
 #: src/components/TravelRuleProviders/index.tsx:33
 msgid "(not interoperable)"
-msgstr "---"
+msgstr ""
 
 #: src/components/SectionStatus/NotSavedSectionSection.tsx:20
 msgid "(not saved)"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/register.validation.ts:21
 msgid ""
@@ -77,53 +55,45 @@ msgid ""
 "* upper case letters (A-Z) \n"
 "* numbers (i.e. 0-9) \n"
 "* special characters (e.g. !@#$%^&*)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:97
 msgid "1 Basic Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:108
 msgid "2 Legal Person"
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:46
-#~ msgid "2022-03-14"
-#~ msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:40
-#~ msgid "2022-04-01"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:123
 msgid "3 Contacts"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:129
 #: src/components/TravelRuleProviders/index.tsx:9
 msgid "3rd Party Travel Rule Providers"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:133
 msgid "4 TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:142
 msgid "5 TRIXO Questionnaire"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:29
 msgid "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:20
 msgid "A component of"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:142
 #: src/components/ReviewSubmit/index.tsx:234
 msgid "A physical verification check in the form of a phone call"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:67
 msgid "APPEALED"
@@ -133,7 +103,7 @@ msgstr ""
 #: src/components/Header/LandingHeader.tsx:116
 #: src/components/Section/AboutUs.tsx:30
 msgid "About TRISA"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:63
 msgid "Account ID"
@@ -142,7 +112,7 @@ msgstr ""
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:48
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:66
 msgid "Action"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:70
 #: src/components/Collaborators/index.tsx:179
@@ -161,7 +131,7 @@ msgstr ""
 
 #: src/components/Addresses/AddressList.tsx:30
 msgid "Add Address"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:50
 msgid "Add Another Legal Name"
@@ -169,15 +139,11 @@ msgstr ""
 
 #: src/components/Collaborators/index.tsx:148
 msgid "Add Contact"
-msgstr "---"
+msgstr ""
 
 #: src/components/OtherJuridictions/index.tsx:67
 msgid "Add Jurisdiction"
-msgstr "---"
-
-#: src/components/NameIdentifiers/index.tsx:51
-#~ msgid "Add Legal Name"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/AddLinkedAccountModal.tsx:32
 msgid "Add Linked Account"
@@ -185,49 +151,45 @@ msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:53
 msgid "Add Local Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:56
 msgid "Add Phonetic Names"
-msgstr "---"
+msgstr ""
 
 #: src/components/Regulations/index.tsx:37
 msgid "Add Regulation"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:86
 msgid "Add new managed VASP"
 msgstr ""
 
-#: src/components/CollaboratorsSection/index.tsx:156
-#~ msgid "Added"
-#~ msgstr "---"
-
 #: src/components/Addresses/Address.tsx:17
 msgid "Address"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:117
 msgid "Address Type (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:40
 msgid "Address line 1 e.g. building name/number, street name (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:48
 msgid "Address line 2 e.g. apartment or suite number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Addresses/index.tsx:10
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:118
 #: src/components/MemberDetails/index.tsx:244
 msgid "Addresses"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:161
 msgid "Administrative Contact (optional)"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:67
 msgid "Administrative Contact Email"
@@ -243,37 +205,37 @@ msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:162
 msgid "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:13
 msgid "Alien Registration Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:55
 msgid "All TRISA members must complete TRISA’s VASP verification and due diligence process to become a Verified VASP."
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/SignupForm.tsx:85
 #: src/components/Section/IntegrateAndComply.tsx:198
 #: src/components/Section/VaspVerification.tsx:217
 msgid "Already have an account?"
-msgstr "---"
+msgstr ""
 
 #: src/components/NetworkAnnouncements/index.tsx:32
 msgid "An error has occurred to load announcements"
-msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/index.tsx:35
 msgid "An error has occurred to load attention data"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:19
 msgid "An error has occurred to load legal person data"
-msgstr "---"
+msgstr ""
 
 #: src/components/Metrics/index.tsx:18
 msgid "An error has occurred to load {type} metric"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:86
 msgid "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
@@ -281,56 +243,42 @@ msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:129
 msgid "An identifier issued by an appropriate issuing authority"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/Version.tsx:36
 msgid "App version {appVersion}"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:173
 #: src/components/TrixoQuestionnaireForm/index.tsx:416
 msgid "Applicable Regulations"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:32
 msgid "Apply to Become a TRISA-certified Virtual Asset Service Provider."
-msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:66
 msgid "At least 9 characters in length"
-msgstr "---"
+msgstr ""
 
 #: src/components/Addresses/index.tsx:13
 msgid "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:146
-#~ msgid "At what threshold and currency does your organization conduct KYC (Know your Counterparty)?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:142
 #: src/components/MemberDetails/index.tsx:589
 #: src/components/TrixoQuestionnaireForm/index.tsx:321
 msgid "At what threshold and currency does your organization conduct KYC checks?"
-msgstr "---"
-
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:140
-#: src/components/MemberDetails/index.tsx:580
-#: src/components/TrixoQuestionnaireForm/index.tsx:146
-#~ msgid "At what threshold and currency does your organization conduct KYC?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Footer/Version.tsx:42
 msgid "BFF & GDS version {bffAndGdsVersion}"
-msgstr "---"
+msgstr ""
 
 #: src/components/NotFound/index.tsx:25
 msgid "Back Home"
-msgstr "---"
-
-#: src/components/ReviewSubmit/index.tsx:298
-#~ msgid "Back to Review Page"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:323
 msgid "Back to Review section"
@@ -339,31 +287,27 @@ msgstr ""
 #: src/components/MemberDetails/index.tsx:90
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:159
 msgid "Basic Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:31
 msgid "Become Travel Rule compliant."
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:44
-#~ msgid "Beware the Ides of March"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:168
 msgid "Billing Contact (optional)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:169
 msgid "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
-msgstr "---"
+msgstr ""
 
 #: src/constants/address.ts:6
 msgid "Business"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:104
 msgid "Business Address"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:165
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:52
@@ -371,11 +315,11 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:27
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:24
 msgid "Business Category"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:9
 msgid "Business Details"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:110
 msgid "Business Entity"
@@ -385,19 +329,19 @@ msgstr ""
 #: src/components/Section/VaspVerification.tsx:120
 #: src/components/Section/VaspVerification.tsx:130
 msgid "Business or Compliance Office"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:9
 msgid "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:281
 msgid "CDD & Travel Rule Policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:34
 msgid "CDD and data protection policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:88
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:78
@@ -405,15 +349,15 @@ msgstr "---"
 #: src/components/UserProfile/AddLinkedAccountModal.tsx:48
 #: src/components/UserProfile/RemoveLinkedAccountModal.tsx:64
 msgid "Cancel"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:79
 msgid "Certificate Common Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:62
 msgid "Certificate Details"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:40
 msgid "Certificate Inventory"
@@ -422,25 +366,20 @@ msgstr ""
 #: src/components/CertificateManagement/index.tsx:31
 #: src/utils/menu.tsx:29
 msgid "Certificate Management"
-msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:191
 msgid "Certificate Progress"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/registration.tsx:26
 #: src/utils/menu.tsx:34
 msgid "Certificate Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/index.tsx:10
 msgid "Certificate Registration Process"
-msgstr "---"
-
-#: src/components/CertificateManagement/SealingCertificateTableRows.tsx:12
-#: src/components/CertificateManagement/X509TableRows.tsx:14
-#~ msgid "Change Permissions"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:165
 msgid "Change Role"
@@ -450,25 +389,21 @@ msgstr ""
 msgid "Check to delete user account."
 msgstr ""
 
-#: src/components/Section/IntegrateAndComply.tsx:134
-#~ msgid "CipherTrace Providers"
-#~ msgstr "---"
-
 #: src/components/Section/IntegrateAndComply.tsx:133
 msgid "CipherTrace Traveler"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:56
 msgid "City / Town / Municipality"
-msgstr "---"
+msgstr ""
 
 #: src/components/StepsButtons/index.tsx:63
 msgid "Clear & Reset Form"
-msgstr "---"
+msgstr ""
 
 #: src/components/Modal/ConfirmationResetFormModal.tsx:86
 msgid "Clear & Reset Registration Form"
-msgstr "---"
+msgstr ""
 
 #: src/components/Modal/ConfirmationResetFormModal.tsx:88
 #: src/components/StepsButtons/index.tsx:61
@@ -486,19 +421,15 @@ msgstr ""
 #: src/components/ReviewSubmit/index.tsx:130
 #: src/components/ReviewSubmit/index.tsx:222
 msgid "Click below to submit your"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:14
 msgid "Click “No” if you have not copied the PKCS12 password yet and would like to view and copy the password."
-msgstr "---"
-
-#: src/components/Modal/ConfirmationResetFormModal.tsx:62
-#~ msgid "Click “Reset” to clear and reset the registration form. All data will be deleted and you will be re-directed to the beginning of the form and you will be required to restart the registration process"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:19
 msgid "Click “Yes” if you have copied the PKCS12 password and have securely saved it."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:158
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:198
@@ -538,33 +469,16 @@ msgstr ""
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:79
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:89
 msgid "Common Name"
-msgstr "---"
-
-#: src/components/Section/SearchDirectory.tsx:91
-#~ msgid "Common name or VASP ID"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:41
 msgid "Common name should match the TRISA endpoint without the port."
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:40
-#~ msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:29
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:55
-#~ msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it and should have at least 2 characters after the periods"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:22
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:44
 msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it and should have at least 2 characters after the periods."
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:20
-#~ msgid "Common name should not contain special characters, no spaces and must have a dot(.) in it, should have at least 2 characters after the periods"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/AttentionAlert.tsx:74
 msgid "Complete"
@@ -572,21 +486,21 @@ msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:34
 msgid "Complete Certficate Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:45
 msgid "Complete TRISA’s VASP Verfication Process"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:34
 msgid ""
 "Complete the multi-part TRISA verification form and due diligence process. Once\n"
 "            approved, gain access to the Testnet."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:19
 msgid "Complete the multi-part TRISA verification form and due diligence process. Once approved, gain access to the Testnet and MainNet."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:55
 msgid "Compliance / Legal Contact Email"
@@ -602,23 +516,23 @@ msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:151
 msgid "Compliance Officer"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:149
 msgid "Compliance officer or legal contact for requests about the compliance requirements and legal status of your organization. A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:22
 msgid "Compliance, Technical, Admininstrative, Billing"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:50
 msgid "Comply with the Travel Rule"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:312
 msgid "Conducts KYC before virtual asset transfers"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/RemoveLinkedAccountModal.tsx:61
 msgid "Confirm"
@@ -638,25 +552,25 @@ msgstr ""
 
 #: src/components/Section/UserEmailConfirmation.tsx:27
 msgid "Contact Verified"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:124
 msgid "Contact information for representatives of your organization. Contacts include Technical, Legal/Compliance, Administrative, and Billing persons."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:21
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:158
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:165
 msgid "Contacts"
-msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:71
 msgid "Contain at least 3 of the following 4 types of characters"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:34
 msgid "Continue"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:88
 #: src/components/Section/Login.tsx:75
@@ -666,7 +580,7 @@ msgstr ""
 #: src/components/Section/CreateAccount.tsx:62
 #: src/components/Section/Login.tsx:49
 msgid "Continue with Google"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:114
 #: src/components/Section/Login.tsx:101
@@ -676,12 +590,12 @@ msgstr ""
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:85
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:101
 msgid "Copied"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:87
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:105
 msgid "Copy"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:229
 #: src/components/CertificateDetails/CertificateDetails.tsx:292
@@ -690,20 +604,20 @@ msgstr "---"
 #: src/components/Section/SearchDirectory.tsx:242
 #: src/components/Section/SearchDirectory.tsx:307
 msgid "Country"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:97
 msgid "Country (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/MemberDetails/index.tsx:321
 #: src/components/NationalIdentification/index.tsx:173
 msgid "Country of Issue"
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:177
 msgid "Country of Issue is reserved for National Identifiers of Natural Persons"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:138
 #: src/components/CountryOfRegistration/index.tsx:18
@@ -713,23 +627,15 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:35
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:48
 msgid "Country of Registration"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:10
-#~ msgid "Country of registration is required"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:12
-#~ msgid "Country of registration is required."
-#~ msgstr ""
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:52
 msgid "Country:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:13
 msgid "Create Account"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/SignupForm.tsx:82
 msgid "Create Your Account"
@@ -739,11 +645,7 @@ msgstr ""
 #: src/components/Section/IntegrateAndComply.tsx:195
 #: src/components/Section/VaspVerification.tsx:213
 msgid "Create account"
-msgstr "---"
-
-#: src/components/Form/SignupForm.tsx:78
-#~ msgid "Create an Account"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:30
 msgid "Create your TRISA account"
@@ -751,19 +653,15 @@ msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:12
 msgid "Create your TRISA account with your VASP email address. Add collaborators in your organization."
-msgstr "---"
-
-#: src/components/Section/CreateAccount.tsx:41
-#~ msgid "Create your TRISA account."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:62
 msgid "Create your account today."
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:29
 msgid "Created and maintained by"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/ChangeNameForm.tsx:84
 msgid "Current Name"
@@ -775,49 +673,40 @@ msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:88
 msgid "Customer Due Diligence (CDD) & Travel Rule Policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/CustomerNumber/index.tsx:17
 msgid "Customer Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Navbar/Landing/MobileNav.tsx:69
 msgid "Dashboard"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:206
 #: src/components/TrixoQuestionnaireForm/index.tsx:428
 msgid "Data Protection Policies"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:144
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:59
 #: src/components/MemberDetails/index.tsx:117
 msgid "Date of Incorporation / Establishment"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:42
 msgid "Date of incorporation / establishment must be earlier than current date."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:33
 #: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:39
 msgid "Date of incorporation / establishment must be later than"
 msgstr ""
 
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:29
-#~ msgid "Date of incorporation / establishment must be later than {0}."
-#~ msgstr "---"
-
-#: src/components/CertificateManagement/SealingCertificateTableRows.tsx:15
-#: src/components/CertificateManagement/X509TableRows.tsx:17
-#~ msgid "Deactivate"
-#~ msgstr "---"
-
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:155
 #: src/components/ui/DeleteButton.tsx:15
 msgid "Delete"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:116
 msgid "Delete Collaborator"
@@ -825,7 +714,7 @@ msgstr ""
 
 #: src/components/Addresses/Address.tsx:26
 msgid "Delete the address line"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:121
 msgid "Delete the following collaborator from the VASP account. The collaborator will no longer have access to the account."
@@ -833,17 +722,17 @@ msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:60
 msgid "Description"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:41
 #: src/components/Tables/MembersRow.tsx:50
 msgid "Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:97
 #: src/components/Section/SearchDirectory.tsx:91
 msgid "Directory Lookup"
-msgstr "---"
+msgstr ""
 
 #: src/components/Header/LandingHeader.tsx:82
 #: src/components/Header/LandingHeader.tsx:119
@@ -852,34 +741,15 @@ msgstr "---"
 #: src/components/OpenSourceResources/index.tsx:20
 #: src/components/Section/IntegrateAndComply.tsx:155
 msgid "Documentation"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:306
 msgid "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
-msgstr "---"
-
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:124
-#~ msgid ""
-#~ "Does your organization conduct Know your Counterparty/Customer Due\n"
-#~ "                Diligence (KYC/CDD) before permitting its customers to send/receive virtual asset transfers?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:122
 msgid "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:123
-#~ msgid "Does your organization have a programme that sets minimum AML, CFT, KYC/CDD and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-#~ msgstr "---"
-
-#: src/components/MemberDetails/index.tsx:543
-#~ msgid ""
-#~ "Does your organization have a programme that sets minimum Anti-Money\n"
-#~ "                      Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
-#~ "                      Counterparty/Customer Due Diligence (KYC/CDD) (Know your Counterparty/Customer\n"
-#~ "                      Due Diligence) and Sanctions standards per the requirements of the\n"
-#~ "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/MemberDetails/index.tsx:543
 msgid ""
@@ -887,41 +757,41 @@ msgid ""
 "                      Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "                      Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the\n"
 "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:296
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money\n"
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:98
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:445
 msgid "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:234
 msgid ""
 "Does your organization secure and protect Personally Identifiable\n"
 "                Information (PII), including Personally Identifiable\n"
 "                Information (PII) received from other VASPs under the Travel Rule?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:189
 #: src/components/CertificateInventory/index.tsx:124
 #: src/components/TrisaVerifiedLogo/index.tsx:49
 msgid "Download"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:12
 msgid "Driver's License Number"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:52
 msgid "EMAIL VERIFIED"
@@ -933,18 +803,18 @@ msgstr ""
 
 #: src/components/CertificateSection/index.tsx:42
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/index.tsx:65
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:96
 #: src/components/CertificateInventory/index.tsx:51
 #: src/components/CertificateReview/CertificateReviewHeader.tsx:26
 #: src/components/Tables/CertificateRegistrationRow.tsx:102
 msgid "Edit"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:142
 msgid "Edit collaborator Role"
@@ -957,15 +827,7 @@ msgstr ""
 #: src/components/Section/PasswordResetForm.tsx:26
 #: src/components/UserProfile/index.tsx:57
 msgid "Email Address"
-msgstr "---"
-
-#: src/contexts/LanguageContext.tsx:21
-#: src/modules/auth/register/register.validation.ts:15
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:12
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:21
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:28
-#~ msgid "Email is not valid"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorFormValidation.ts:13
 #: src/contexts/LanguageContext.tsx:21
@@ -975,11 +837,6 @@ msgstr "---"
 #: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:26
 msgid "Email is not valid."
 msgstr ""
-
-#: src/modules/auth/register/register.validation.ts:16
-#: src/modules/dashboard/certificate/lib/contactsValidationSchema.ts:22
-#~ msgid "Email is required"
-#~ msgstr "---"
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorFormValidation.ts:14
 #: src/modules/auth/register/register.validation.ts:16
@@ -991,7 +848,7 @@ msgstr ""
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:56
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:76
 msgid "Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/ChangePasswordModal.tsx:44
 msgid "Enter Current Password"
@@ -1003,25 +860,25 @@ msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:80
 msgid "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:30
 msgid "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordReset.tsx:77
 msgid "Enter your email address"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/index.tsx:70
 msgid "Error Submitting Certificate"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:35
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:64
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:42
 msgid "Expiration Date"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:149
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:98
@@ -1035,7 +892,7 @@ msgstr ""
 
 #: src/components/DetailsCard/index.tsx:84
 msgid "Expiry Date:"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberHeader.tsx:25
 msgid "Export"
@@ -1043,7 +900,7 @@ msgstr ""
 
 #: src/components/CertificateReview/ReviewsSummary.tsx:107
 msgid "Export Data"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/overview/index.tsx:37
 msgid "Failed to load Network announcement , please reload"
@@ -1055,15 +912,15 @@ msgstr ""
 
 #: src/components/FileUpload/index.tsx:68
 msgid "Files is required"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:162
 msgid "Final Confirmation"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:40
 msgid "Final review and form submission"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/ChangeNameForm.tsx:95
 msgid "First (Given) Name"
@@ -1071,31 +928,31 @@ msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:57
 msgid "First Listed"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordReset.tsx:72
 msgid "Follow the instructions below to reset your TRISA password"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:165
 msgid "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:31
 msgid "For identifiers other than LEI specify the registration authority from the following list. See"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:8
 msgid "Foreign Investment Identity Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/LoginForm.tsx:96
 msgid "Forgot password?"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:57
 msgid "Full Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:87
 msgid "Full name"
@@ -1103,27 +960,19 @@ msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:39
 msgid "GLEIF Registration Authorities"
-msgstr "---"
+msgstr ""
 
 #: src/constants/address.ts:7
 msgid "Geographic"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:288
-#~ msgid "Getting Started Help Guide"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Footer/Version.tsx:39
 msgid "Git Revision"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:98
 msgid "GitHub repository"
-msgstr "---"
-
-#: src/components/Sidebar/SidebarContent.tsx:48
-#~ msgid "Global Directory Service"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:107
 msgid "Government Entity"
@@ -1131,62 +980,58 @@ msgstr ""
 
 #: src/components/Sidebar/MobileNav.tsx:95
 msgid "Guest"
-msgstr "---"
+msgstr ""
 
 #: src/components/Navbar/Landing/MobileNav.tsx:70
 #: src/components/Navbar/Landing/Nav.tsx:20
 msgid "Home"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:117
 msgid "How to set up your own node?"
-msgstr "---"
+msgstr ""
 
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:54
 msgid "I acknowledge that requesting a new X.509 Identity Certificate will invalidate and revoke my organization’s current X.509 Identity Certificate."
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:45
-#~ msgid "I have a bad feeling about tomorrow."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:54
 msgid "ID"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:106
 msgid "ID:"
-msgstr "---"
+msgstr ""
 
 #: src/components/LegalPerson/index.tsx:71
 msgid "IVMS 101 data structure"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:165
 #: src/components/MemberDetails/index.tsx:303
 #: src/components/NationalIdentification/index.tsx:126
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:112
 msgid "Identification Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:171
 #: src/components/MemberDetails/index.tsx:311
 #: src/components/NationalIdentification/index.tsx:155
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:120
 msgid "Identification Type"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:11
 msgid "Identity Card Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Metrics/index.tsx:23
 msgid "Identity Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:40
 msgid "If supplied, use full phone number with country code"
-msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/InvalidFormPrompt.tsx:41
 msgid "If you continue, your changes will be lost. To save your changes, click Cancel and then click on the"
@@ -1198,12 +1043,12 @@ msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:28
 msgid "If you lose the PKCS12 password, you will have to the start the registration process from the beginning."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:155
 #: src/components/ReviewSubmit/index.tsx:246
 msgid "If you would like to edit your registration form before submitting, please return to the"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:258
 msgid "If you would like to register for MainNet, please provide a <0>MainNet Endpoint and Common Name</0>."
@@ -1211,7 +1056,7 @@ msgstr ""
 
 #: src/components/ReviewSubmit/MainNetWarningBox.tsx:9
 msgid "If you would like to register for MainNet, please provide a MainNet Endpoint and Common Name."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:168
 msgid "If you would like to register for TestNet, please provide a <0>TestNet Endpoint and Common Name</0>."
@@ -1219,56 +1064,44 @@ msgstr ""
 
 #: src/components/ReviewSubmit/TestNetWarningBox.tsx:10
 msgid "If you would like to register for TestNet, please provide a TestNet Endpoint and Common Name."
-msgstr "---"
+msgstr ""
 
 #: src/components/FileUpload/index.tsx:96
 msgid "Import File"
-msgstr "---"
+msgstr ""
 
 #: src/components/Tables/CertificateRegistrationRow.tsx:92
 msgid "Incomplete"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:98
 msgid "Incorporation Date"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:98
 msgid "Information about the VASP such as website, incorporation date, business and VASP category."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:109
 msgid "Information that identifies your organization as a Legal Person. This section represents the IVMS 101 data structure for legal persons and is strongly suggested for use as KYC information exchanged in TRISA transfers."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:143
 msgid "Information to ensure that required compliance information exchanges are conducted correctly and safely. This includes information about jurisdiction and national regulator, Customer Due Diligence(CDD) and Travel Rule policies, and data protection policies."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:50
 #: src/components/Section/MembershipGuide.tsx:25
 msgid "Integrate and Comply"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:43
 msgid "Integrate with TRISA."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:48
 msgid "Interoperable"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:18
-#~ msgid "Invalid date"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:19
-#~ msgid "Invalid date / year must be 4 digit"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:35
-#~ msgid "Invalid date."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/index.tsx:173
 msgid "Invited"
@@ -1277,41 +1110,32 @@ msgstr ""
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:66
 #: src/components/TrixoQuestionnaireForm/index.tsx:273
 msgid "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:258
-#~ msgid "Is your organization required by law to safeguard PII (Personally Identifiable Information)?"
-#~ msgstr "---"
-
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:231
-#: src/components/TrixoQuestionnaireForm/index.tsx:257
-#~ msgid "Is your organization required by law to safeguard PII?"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:214
 msgid ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:432
 msgid "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:153
 #: src/components/TrixoQuestionnaireForm/index.tsx:362
 msgid "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:32
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:61
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:39
 msgid "Issue Date"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:76
 msgid "Issue Date:"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:169
 #: src/components/CertificateInventory/index.tsx:104
@@ -1320,21 +1144,17 @@ msgstr ""
 
 #: src/components/Maintenance/index.tsx:26
 msgid "Join"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:114
 msgid "Join Today"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/Login.tsx:117
 #: src/components/Section/PasswordResetFail.tsx:36
 #: src/components/Section/SearchDirectory.tsx:84
 msgid "Join the TRISA network today."
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:33
-#~ msgid "Join us on Thursday Apr 28 for the TRISA Working Group."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/index.tsx:176
 #: src/modules/dashboard/member/components/MemberTable.tsx:22
@@ -1352,18 +1172,18 @@ msgstr ""
 
 #: src/components/UserDetails/index.tsx:39
 msgid "Last Login:"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:63
 #: src/modules/dashboard/member/components/MemberTable.tsx:25
 #: src/modules/dashboard/member/utils.ts:16
 msgid "Last Updated"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:180
 #: src/components/Section/VaspVerification.tsx:182
 msgid "Learn How TRISA Works"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:19
 #: src/components/Section/GettingStarted.tsx:42
@@ -1371,34 +1191,34 @@ msgstr "---"
 #: src/components/Section/MembershipGuide.tsx:20
 #: src/components/Section/MembershipGuide.tsx:27
 msgid "Learn More"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:57
 msgid "Learn about the three-step process to become a member and verified VASP."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:76
 msgid "Learn how TRISA works."
-msgstr "---"
+msgstr ""
 
 #: src/constants/name-identifiers.ts:4
 msgid "Legal"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:4
 msgid "Legal Entity Identifier (LEI)"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:15
 #: src/components/MemberDetails/index.tsx:152
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:162
 #: src/components/RegistrationForm/StepLabel.tsx:29
 msgid "Legal Person"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:53
 msgid "Legal name is required"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:19
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:36
@@ -1407,7 +1227,7 @@ msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:148
 msgid "Legal/ Compliance Contact (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/AddLinkedAccountModal.tsx:45
 msgid "Link Account"
@@ -1415,7 +1235,7 @@ msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:36
 msgid "Local Name Identifiers"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:235
 #: src/components/CertificateDetails/CertificateDetails.tsx:298
@@ -1427,35 +1247,31 @@ msgstr ""
 #: src/components/Form/LoginForm.tsx:87
 #: src/components/Section/UserEmailConfirmation.tsx:41
 msgid "Log In"
-msgstr "---"
+msgstr ""
 
 #: src/components/Navbar/Landing/MobileNav.tsx:73
 #: src/components/Navbar/Landing/Nav.tsx:23
 msgid "Log in"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/success.tsx:36
 msgid "Log in to TRISA’s Global Directory Service"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/SignupForm.tsx:91
 #: src/components/Section/IntegrateAndComply.tsx:202
 #: src/components/Section/VaspVerification.tsx:221
 msgid "Log in."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/Login.tsx:24
 msgid "Log into your TRISA account"
 msgstr ""
 
-#: src/components/Section/Login.tsx:25
-#~ msgid "Log into your TRISA account."
-#~ msgstr "---"
-
 #: src/components/Header/LandingHeader.tsx:88
 #: src/components/Header/LandingHeader.tsx:125
 msgid "Login"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:52
 msgid "Login & Identity"
@@ -1463,7 +1279,7 @@ msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:187
 msgid "MAINNET DIRECTORY RECORD"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:93
 #: src/components/CertificateInventory/index.tsx:48
@@ -1472,17 +1288,17 @@ msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:219
 msgid "MAINNET SUBMISSION"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:53
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:51
 #: src/components/ReviewSubmit/index.tsx:224
 msgid "MainNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:64
 msgid "MainNet Certificate Common Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:102
 #: src/components/CertificateInventory/index.tsx:57
@@ -1492,7 +1308,7 @@ msgstr ""
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:37
 #: src/components/CertificateManagement/index.tsx:109
 msgid "MainNet Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:45
 msgid "MainNet Identity Certificates"
@@ -1500,23 +1316,23 @@ msgstr ""
 
 #: src/components/MetricsTabs/index.tsx:28
 msgid "MainNet Network Metrics"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:58
 msgid "MainNet TRISA Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/FileUpload/index.tsx:73
 msgid "Max file size 10mb"
-msgstr "---"
+msgstr ""
 
 #: src/components/OpenSourceResources/index.tsx:32
 msgid "Meet Alice VASP, Bob VASP and Evil VASP"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:167
 msgid "Meet Alice VASP, Bob VASP, and “Evil” VASP"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:54
 msgid "Member Directory"
@@ -1533,32 +1349,24 @@ msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:130
 msgid "Message from server:"
-msgstr "---"
+msgstr ""
 
 #: src/constants/name-identifiers.ts:7
 msgid "Misc"
-msgstr "---"
-
-#: src/components/TestnetProgress/CertificateStepLabel.tsx:123
-#~ msgid "Missing required element"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:368
 msgid "Must comply with Travel Rule"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:438
 msgid "Must safeguard PII"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:264
-#~ msgid "Must safeguard PII (Personally Identifiable Information)"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "NO"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:46
 #: src/modules/dashboard/member/utils.ts:72
@@ -1569,13 +1377,7 @@ msgstr ""
 #: src/components/NameIdentifier/index.tsx:117
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:19
 msgid "Name"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:25
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:42
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:59
-#~ msgid "Name Identifier Type is required"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:26
 #: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:43
@@ -1588,35 +1390,31 @@ msgstr ""
 #: src/components/NameIdentifiers/index.tsx:28
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:68
 msgid "Name Identifiers"
-msgstr "---"
-
-#: src/components/NameIdentifiers/index.tsx:29
-#~ msgid "Name identifiers"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:42
 #: src/components/TrixoQuestionnaireForm/index.tsx:244
 msgid "Name of Primary Regulator"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:16
 msgid "Name, Addresss, Country, National Identifier"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:156
 #: src/components/MemberDetails/index.tsx:298
 #: src/components/NationalIdentification/index.tsx:114
 msgid "National Identification"
-msgstr "---"
+msgstr ""
 
 #: src/components/OtherJuridictions/index.tsx:39
 msgid "National Jurisdiction"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:176
 #: src/components/Section/VaspVerification.tsx:176
 msgid "Need to Learn More?"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberTable.tsx:28
 #: src/modules/dashboard/member/utils.ts:20
@@ -1625,12 +1423,12 @@ msgstr ""
 
 #: src/components/NetworkAnnouncements/caroussels.tsx:116
 msgid "Network Announcement"
-msgstr "---"
+msgstr ""
 
 #: src/components/NetworkStatus/index.tsx:15
 #: src/components/StatusCard/index.tsx:26
 msgid "Network Status"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/UnverifiedMember.tsx:15
 msgid "Network directory member list not available because you are not a verified contact for this network. Please complete the registration process."
@@ -1638,16 +1436,16 @@ msgstr ""
 
 #: src/components/Metrics/index.tsx:24
 msgid "New Members"
-msgstr "---"
+msgstr ""
 
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:41
 msgid "New X.509 Identity Certificate Request"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:85
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:74
 msgid "Next"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:26
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:33
@@ -1655,7 +1453,7 @@ msgstr "---"
 #: src/components/ReviewSubmit/ModalAlert.tsx:31
 #: src/constants/trixo.ts:7
 msgid "No"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:117
 msgid "No Certificate available"
@@ -1664,10 +1462,6 @@ msgstr ""
 #: src/components/NoData/NoData.tsx:14
 msgid "No Data"
 msgstr ""
-
-#: src/modules/dashboard/certificate/registration.tsx:298
-#~ msgid "No information is sent until you complete Section 6 - Review & Submit"
-#~ msgstr "---"
 
 #: src/modules/dashboard/certificate/registration.tsx:52
 msgid "No information is sent until you submit for a TestNet and/or MainNet Certificate after the Review section."
@@ -1679,38 +1473,38 @@ msgstr ""
 
 #: src/components/CertificateSection/index.tsx:87
 msgid "Not Saved"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:16
 msgid "Not Verified"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/Login.tsx:111
 #: src/components/Section/PasswordResetFail.tsx:34
 msgid "Not a TRISA Member?"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/AlertContent.tsx:26
 #: src/components/ReviewSubmit/index.tsx:100
 msgid "Note:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:39
 msgid "Open Source"
-msgstr "---"
+msgstr ""
 
 #: src/components/OpenSourceResources/index.tsx:9
 #: src/components/Section/IntegrateAndComply.tsx:146
 msgid "Open Source Resources"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:88
 msgid "Option 1. Set Up Your Own TRISA Node"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:107
 msgid "Option 2. Use a 3rd-party Solution"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:241
 #: src/components/CertificateDetails/CertificateDetails.tsx:304
@@ -1719,20 +1513,16 @@ msgstr "---"
 msgid "Organization"
 msgstr ""
 
-#: src/components/CollaboratorsSection/index.tsx:142
-#~ msgid "Organization Collaborators"
-#~ msgstr "---"
-
 #: src/components/BasicDetailsForm/index.tsx:120
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:30
 #: src/components/Section/SearchDirectory.tsx:211
 #: src/components/Section/SearchDirectory.tsx:277
 msgid "Organization Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:76
 msgid "Organization Type"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:247
 #: src/components/CertificateDetails/CertificateDetails.tsx:310
@@ -1741,27 +1531,23 @@ msgstr "---"
 msgid "Organization Unit"
 msgstr ""
 
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:40
-#~ msgid "Organization name is required"
-#~ msgstr "---"
-
 #: src/components/DetailsCard/index.tsx:68
 msgid "Organization:"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:30
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:63
 msgid "Organizational Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:48
 #: src/components/TrixoQuestionnaireForm/index.tsx:250
 msgid "Other Jurisdictions"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:23
 msgid "Overview"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:55
 msgid "PENDING REVIEW"
@@ -1769,36 +1555,32 @@ msgstr ""
 
 #: src/components/NotFound/index.tsx:15
 msgid "Page Not Found"
-msgstr "---"
+msgstr ""
 
 #: src/constants/trixo.ts:6
 msgid "Partially"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:53
 msgid "Participate in verified VASP-to-VASP Travel Rule exchanges."
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:10
 msgid "Passport Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Form/LoginForm.tsx:64
 #: src/components/Form/SignupForm.tsx:62
 msgid "Password"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:30
 msgid "Peer-to-Peer"
-msgstr "---"
-
-#: src/components/CollaboratorsSection/index.tsx:153
-#~ msgid "Permission"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserDetails/index.tsx:36
 msgid "Permission:"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/UserDetails.tsx:31
 msgid "Permissions"
@@ -1806,11 +1588,11 @@ msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:90
 msgid "Phone Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/NameIdentifiers/index.tsx:43
 msgid "Phonetic Name Identifiers"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:81
 msgid "Please Provide the Name and Email Address"
@@ -1818,29 +1600,24 @@ msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:253
 msgid "Please add any other regulatory jurisdictions your organization complies with."
-msgstr "---"
+msgstr ""
 
 #: src/components/MissingRequire/index.tsx:14
 msgid "Please complete all details"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:98
 msgid "Please copy and paste this password and store somewhere safe!"
-msgstr "---"
+msgstr ""
 
 #: src/components/LegalPerson/index.tsx:65
 msgid "Please enter the information that identifies your organization as a Legal Person. This form represents the"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:28
 #: src/components/CertificateSection/index.tsx:52
 msgid "Please enter the information that identifies your organization as a Legal Person. This form represents the {0} data structure for legal persons and is strongly suggested for use as KYC (Know your Counterparty) or CDD (Customer Due Diligence) information exchanged in TRISA transfers."
-msgstr "---"
-
-#: src/components/CertificateSection/index.tsx:28
-#: src/components/CertificateSection/index.tsx:52
-#~ msgid "Please enter the information that identifies your organization as a Legal Person. This form represents the {0} data structure for legal persons and is strongly suggested for use as KYC or CDD information exchanged in TRISA transfers."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:25
 msgid "Please input the name of the new managed Virtual Asset Service Provider (VASP). When the entity is created, you will have the ability to add collaborators, start and complete the certificate registration process, and manage the VASP account. Please acknowledge below and provide the name of the entity."
@@ -1851,31 +1628,31 @@ msgstr ""
 #: src/components/ReviewSubmit/index.tsx:180
 #: src/components/ReviewSubmit/index.tsx:270
 msgid "Please note that TestNet and MainNet are separate networks that require different X.509 Identity Certificates."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:47
 msgid "Please review the information provided, edit as needed, and submit to complete the registration form. After the information is reviewed, emails will be sent to the provided contacts for verification. Once verified, your TestNet certificate will be issued."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ReviewsSummary.tsx:113
 msgid "Please review the information provided, edit as needed, and submit to complete the registration form. After the information is reviewed, you will be contacted to verify details. Once verified, your TestNet certificate will be issued."
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:189
 msgid "Please select as many categories needed to represent the types of virtual asset services your organization provides."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:419
 msgid "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:117
 msgid "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:37
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/index.tsx:61
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
@@ -1883,15 +1660,11 @@ msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:22
 msgid "Please use the email address associated with your organization."
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:20
 msgid "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
-
-#: src/components/Contacts/ContactForm/index.tsx:64
-#~ msgid "Please use the email address associated with your organization.Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored"
-#~ msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:253
 #: src/components/CertificateDetails/CertificateDetails.tsx:316
@@ -1902,24 +1675,24 @@ msgstr ""
 
 #: src/components/AddressForm/index.tsx:75
 msgid "Postal Code / Postcode / ZIP Code"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactForm/index.tsx:58
 msgid "Preferred name for email communication."
-msgstr "---"
+msgstr ""
 
 #: src/components/StepsButtons/index.tsx:52
 msgid "Previous"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:36
 #: src/components/TrixoQuestionnaireForm/index.tsx:234
 msgid "Primary National Jurisdiction"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:155
 msgid "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:104
 msgid "Private Organization"
@@ -1935,7 +1708,7 @@ msgstr ""
 
 #: src/components/UserDetails/index.tsx:30
 msgid "Profile Created:"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:69
 msgid "Provider"
@@ -1963,45 +1736,37 @@ msgstr ""
 #: src/components/OpenSourceResources/index.tsx:27
 #: src/components/Section/IntegrateAndComply.tsx:162
 msgid "Reference implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:190
 #: src/components/MemberDetails/index.tsx:337
 msgid "Reg Authority"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddressForm/index.tsx:66
 msgid "Region / Province / State (required)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:229
 #: src/components/Section/SearchDirectory.tsx:295
 msgid "Registered Directory"
-msgstr "---"
+msgstr ""
 
 #: src/components/NationalIdentification/index.tsx:195
 msgid "Registration Authority"
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:6
 msgid "Registration Authority Identifier"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:87
-#~ msgid "Registration Authority cannot be left empty"
-#~ msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/legalPersonValidationSchema.ts:96
-#~ msgid "Registration Authority cannot be left empty."
-#~ msgstr ""
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:90
 msgid "Registration Submission"
-msgstr "---"
+msgstr ""
 
 #: src/components/OtherJuridictions/index.tsx:47
 msgid "Regulator Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/RemoveLinkedAccountModal.tsx:37
 msgid "Remove Linked Account"
@@ -2011,42 +1776,33 @@ msgstr ""
 #: src/components/OtherJuridictions/index.tsx:58
 #: src/components/Regulations/index.tsx:31
 msgid "Remove line"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:51
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:26
 msgid "Request New Identity Certificate"
-msgstr "---"
+msgstr ""
 
 #: src/components/ConfirmIdentityCertificateRequest/index.tsx:47
 msgid "Requesting a new X.509 Identity Certificate will invalidate and revoke your current X.509 Identity Certificate."
-msgstr "---"
+msgstr ""
 
 #: src/components/Modal/ConfirmationResetFormModal.tsx:128
 msgid "Reset"
-msgstr "---"
+msgstr ""
 
 #: src/constants/address.ts:5
 msgid "Residential"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/success.tsx:60
 msgid "Return to vaspdirectory.net"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ReviewsSummary.tsx:95
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:174
 msgid "Review"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:337
-#~ msgid "Review & Submit"
-#~ msgstr "---"
-
-#: src/components/ReviewSubmit/index.tsx:151
-#: src/components/ReviewSubmit/index.tsx:235
-#~ msgid "Review page"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:160
 #: src/components/ReviewSubmit/index.tsx:251
@@ -2056,11 +1812,7 @@ msgstr ""
 #: src/components/Collaborators/index.tsx:167
 #: src/components/UserProfile/UserDetails.tsx:22
 msgid "Role"
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:38
-#~ msgid "Routine Maintenance Scheduled"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/UserProfilePassword.tsx:52
 msgid "SECURITY"
@@ -2072,11 +1824,7 @@ msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:451
 msgid "Safeguards PII"
-msgstr "---"
-
-#: src/components/TrixoQuestionnaireForm/index.tsx:277
-#~ msgid "Safeguards Personally Identifiable Information (PII)"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:190
 msgid "Save"
@@ -2084,15 +1832,15 @@ msgstr ""
 
 #: src/components/StepsButtons/index.tsx:56
 msgid "Save & Next"
-msgstr "---"
+msgstr ""
 
 #: src/components/StepsButtons/index.tsx:52
 msgid "Save & Previous"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:59
 msgid "Sealing Certificate Inventory"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:15
 msgid "Sealing Certificates"
@@ -2100,55 +1848,55 @@ msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:77
 msgid "Search the Directory Service"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:54
 msgid "Section"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetail/index.tsx:130
 #: src/components/CertificateReview/BasicDetailsReview.tsx:29
 #: src/components/CertificateSection/index.tsx:23
 #: src/components/CertificateSection/index.tsx:65
 msgid "Section 1: Basic Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReview.tsx:19
 #: src/components/CertificateSection/index.tsx:27
 #: src/components/LegalPerson/index.tsx:59
 msgid "Section 2: Legal Person"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ContactsReview.tsx:19
 #: src/components/CertificateSection/index.tsx:36
 #: src/components/Contacts/index.tsx:55
 msgid "Section 3: Contacts"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReview.tsx:19
 #: src/components/CertificateSection/index.tsx:41
 #: src/components/TrisaImplementation/index.tsx:59
 msgid "Section 4: TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReview.tsx:32
 #: src/components/CertificateSection/index.tsx:46
 #: src/components/TrixoQuestionnaire/index.tsx:55
 msgid "Section 5: TRIXO Questionnaire"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:51
 #: src/components/CertificateSection/index.tsx:60
 msgid "Section 6: Review & Submit"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:89
 msgid "Sections & Details"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:21
 msgid "Secure"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberNetworkSelect.tsx:15
 msgid "Select Network"
@@ -2156,7 +1904,7 @@ msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:181
 msgid "Select VASP category"
-msgstr "---"
+msgstr ""
 
 #: src/components/ChooseAnOrganization/index.tsx:61
 msgid "Select a VASP from the Managed VASP List"
@@ -2164,11 +1912,11 @@ msgstr ""
 
 #: src/components/CountryOfRegistration/index.tsx:27
 msgid "Select a country"
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:166
 msgid "Select business category"
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:147
 msgid "Select the collaborator’s role and save."
@@ -2191,52 +1939,52 @@ msgstr ""
 msgid ""
 "Set up your TRISA node or integrate with a 3rd-party Travel Rule solution. Complete\n"
 "            testing and move to production."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:26
 msgid "Set up your TRISA node or integrate with a 3rd-party Travel Rule solution. Complete testing and move to production."
-msgstr "---"
+msgstr ""
 
 #: src/constants/name-identifiers.ts:5
 msgid "Short"
-msgstr "---"
+msgstr ""
 
 #: src/components/Sidebar/MobileNav.tsx:121
 msgid "Sign out"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:29
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:36
 msgid "Signature ID"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:89
 msgid ""
 "Since TRISA is an open source, peer-to-peer Travel Rule solution, VASPs can set\n"
 "                    up and maintain their own TRISA server to exhange encrypted Travel Rule\n"
 "                    compliance data. TRISA maintains an"
-msgstr "---"
+msgstr ""
 
 #: src/components/YourImplementation/index.tsx:11
 msgid "Since TRISA is an open source, peer-to-peer Travel Rule solution, VASPs can set up and maintain their own TRISA server to exhange encrypted Travel Rule compliance data. At the same time, TRISA is designed to be interoperable. There are several Travel Rule solutions providers available on the market. If you are a customer, work with your Travel Ruie provider to integrate TRISA into your Travel Rule compliance workflow."
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:9
 msgid "Social Security Number"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/login/user.slice.ts:124
 #: src/modules/auth/login/user.slice.ts:124
 msgid "Something went wrong. Please try again later."
-msgstr "---"
+msgstr ""
 
 #: src/components/NotFound/index.tsx:19
 msgid "Sorry, the page you are looking for doesn't exist or has been moved"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordResetFail.tsx:21
 msgid "Sorry. We could not find a user account with the email address"
-msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/AttentionAlert.tsx:50
 msgid "Start"
@@ -2245,15 +1993,15 @@ msgstr ""
 #: src/components/TechnicalResources/index.tsx:19
 #: src/modules/dashboard/overview/index.tsx:32
 msgid "Start Certificate Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:83
 msgid "Start Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/ui/Button.tsx:8
 msgid "Start trial"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:131
 #: src/components/CertificateInventory/index.tsx:86
@@ -2266,16 +2014,16 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberTable.tsx:31
 #: src/modules/dashboard/member/utils.ts:24
 msgid "Status"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserDetails/index.tsx:33
 msgid "Status:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:11
 #: src/components/Section/GettingStarted.tsx:47
 msgid "Step 1"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:271
 #: src/components/CertificateDetails/CertificateDetails.tsx:334
@@ -2299,23 +2047,23 @@ msgstr ""
 #: src/components/Section/PasswordResetForm.tsx:48
 #: src/hoc/withRHF.tsx:117
 msgid "Submit"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:302
 msgid "Submit MainNet Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:212
 msgid "Submit TestNet Registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:105
 msgid "Submitted"
-msgstr "---"
+msgstr ""
 
 #: src/components/Sidebar/SidebarContent.tsx:111
 msgid "Support"
-msgstr "---"
+msgstr ""
 
 #: src/components/Sidebar/MobileNav.tsx:116
 msgid "Switch Accounts"
@@ -2323,61 +2071,53 @@ msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:138
 msgid "Synga Bridge"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:195
 msgid "TESTNET DIRECTORY RECORD"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:127
 msgid "TESTNET SUBMISSION"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:53
 msgid "TRISA Certificate Types"
 msgstr ""
 
-#: src/components/CertificateManagement/index.tsx:52
-#~ msgid "TRISA Certificates"
-#~ msgstr "---"
-
-#: src/components/OrganizationProfile/TrisaDetail.tsx:20
-#~ msgid "TRISA Details"
-#~ msgstr "---"
-
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:66
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:75
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:83
 msgid "TRISA Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm.tsx:150
 msgid "TRISA Endpoint: MainNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm.tsx:144
 msgid "TRISA Endpoint: TestNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/OpenSourceResources/index.tsx:15
 msgid "TRISA GitHub repo"
-msgstr "---"
+msgstr ""
 
 #: src/components/Head/LandingHead.tsx:24
 msgid "TRISA Global Directory Service"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:92
 msgid "TRISA Identity Signature:"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:27
 msgid "TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:20
 msgid "TRISA Implementations"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/index.tsx:14
 msgid "TRISA Member Directory"
@@ -2386,46 +2126,37 @@ msgstr ""
 #: src/components/Section/SearchDirectory.tsx:235
 #: src/components/Section/SearchDirectory.tsx:301
 msgid "TRISA Member ID"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:36
 msgid "TRISA Member ID:"
-msgstr "---"
-
-#: src/components/OrganizationProfile/OrganizationalDetail.tsx:55
-#~ msgid "TRISA Organization Profile"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:52
 msgid "TRISA Registration Request Submitted!"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:223
 #: src/components/Section/SearchDirectory.tsx:289
 msgid "TRISA Service Endpoint"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:253
 #: src/components/Section/SearchDirectory.tsx:318
 msgid "TRISA Verification"
-msgstr "---"
+msgstr ""
 
 #: src/components/DetailsCard/index.tsx:44
 msgid "TRISA Verification:"
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaVerifiedLogo/index.tsx:11
 msgid "TRISA Verified Logo"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:28
 msgid "TRISA endpoint for communication"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:22
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:48
-#~ msgid "TRISA endpoint is not valid"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:18
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:40
@@ -2434,15 +2165,15 @@ msgstr ""
 
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:168
 msgid "TRISA implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:32
 msgid "TRISA is a decentralized network where VASPs communicate directly with each other."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:67
 msgid "TRISA is a global, open source, peer-to-peer and secure Travel Rule architecture and network designed to be accessible and interoperable. Become a TRISA-certified VASP today."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:145
 msgid "TRISA is a network of trusted members. I acknowledge that the contact is authorized to access the organization’s TRISA account information."
@@ -2454,59 +2185,59 @@ msgstr ""
 
 #: src/components/Section/JoinUs.tsx:50
 msgid "TRISA is designed to be interoperable with other Travel Rule solutions."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:108
 msgid ""
 "TRISA is designed to be interoperable. There are several Travel Rule solutions\n"
 "                    providers available on the market. If you are a customer, work with them to\n"
 "                    integrate TRISA into your Travel Rule compliance workflow."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:41
 msgid "TRISA is open source and available to implement by any VASP."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/index.tsx:59
 msgid "TRISA issues two types of certificates:"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:66
 msgid "TRISA members must complete a comprehensive multi-part verification form and due diligence process. Once verified, TRISA will issue TestNet and MainNet certificates for secure Travel Rule compliance."
-msgstr "---"
+msgstr ""
 
 #: src/components/CustomerNumber/index.tsx:23
 msgid "TRISA specific identity number (UUID), only supplied if you're updating an existing registration request"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:23
 msgid "TRISA uses public-key cryptography for encrypting data in flight and at rest."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrisaVerifiedLogo/index.tsx:17
 msgid "TRISA verified members may download and display a “TRISA Verified VASP” logo on their website. The logo is unique to your VASP and non-reproducible. Members may download their logo after verification is complete and their certificate has been issued. The logo is in .svg fotmat"
-msgstr "---"
+msgstr ""
 
 #: src/components/Maintenance/index.tsx:32
 msgid "TRISA's Slack channel"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:150
 msgid "TRISA’s Github repo"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/AboutUs.tsx:57
 msgid "TRISA’s Global Directory Service (GDS) is a network of vetted VASPs that can securely exchange Travel Rule compliance data with each other."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:75
 msgid "TRISA’s verification form includes five sections and may require information from several parties in your organization."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:33
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:171
 msgid "TRIXO Questionnaire"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:118
 msgid ""
@@ -2514,15 +2245,15 @@ msgid ""
 "                    resources to integrate TRISA with your system. Have members of your technical\n"
 "                    team integrate your systems with TRISA. Or work with a solutions provider that\n"
 "                    can help your VASP set up your TRISA server and maintain it."
-msgstr "---"
+msgstr ""
 
 #: src/constants/national-identification.ts:5
 msgid "Tax Identification Number"
-msgstr "---"
+msgstr ""
 
 #: src/components/Contacts/ContactsForm.tsx:154
 msgid "Technical Contact (required)"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:43
 msgid "Technical Contact Email"
@@ -2538,30 +2269,30 @@ msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:140
 msgid "Technical Officer"
-msgstr "---"
+msgstr ""
 
 #: src/utils/menu.tsx:60
 msgid "Technical Resources"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:134
 msgid "Technical information about your endpoint for certificate issuance. Each VASP is required to establish a TRISA endpoint for inter-VASP communication."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:33
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:71
 #: src/components/ReviewSubmit/index.tsx:132
 msgid "TestNet"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:44
 msgid "TestNet Certificate Common Name"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:40
 #: src/components/CertificateManagement/index.tsx:112
 msgid "TestNet Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:47
 msgid "TestNet Identity Certificates"
@@ -2569,15 +2300,11 @@ msgstr ""
 
 #: src/components/MetricsTabs/index.tsx:38
 msgid "TestNet Network Metrics"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:38
 msgid "TestNet TRISA Endpoint"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:39
-#~ msgid "TestNet and MainNet endpoints should not be the same"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/lib/trisaImplementationValidationSchema.ts:31
 msgid "TestNet and MainNet endpoints should not be the same."
@@ -2586,26 +2313,26 @@ msgstr ""
 #: src/components/Section/UserEmailVerification.tsx:17
 #: src/modules/auth/register/success.tsx:17
 msgid "Thank you for creating your TRISA account."
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/register/success.tsx:23
 msgid "Thank you for creating your TRISA account. You must verify your email address. An email with verification instructions has been sent to your email address. Please complete the email verification process in 24 hours. The email verification link will expire in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordResetConfirmation.tsx:15
 msgid "Thank you. We have sent instructions to reset your password to"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/PasswordReset.tsx:44
 msgid "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:144
 msgid ""
 "The Common Name typically matches the Endpoint, without the port number\n"
 "                            at the end (e.g. trisa.myvasp.com) and is used to identify the subject\n"
 "                            in the X.509 certificate."
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:25
 msgid "The Domain Name is invalid."
@@ -2614,10 +2341,6 @@ msgstr ""
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:26
 msgid "The Domain Name is required."
 msgstr ""
-
-#: src/components/NetworkAnnouncements/index.tsx:39
-#~ msgid "The GDS will be undergoing routine maintenance on Apr 7."
-#~ msgstr "---"
 
 #: src/components/CertificateManagement/CertificateValidityAlert.tsx:51
 msgid "The Organization has a current and valid <0>Mainnet</0> Identity Certificate."
@@ -2633,7 +2356,7 @@ msgstr ""
 
 #: src/components/Maintenance/index.tsx:16
 msgid "The TRISA Global Directory Service (GDS) is temporarily undergoing maintenance. Please try again later."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/components/DirectoryNotification.tsx:11
 msgid "The TRISA Member Directory is for informational purposes and is meant to foster collaboration between members. It is available to verified TRISA contacts only. If you cannot view the list, please complete the registration process. You can view the member list after verification is complete."
@@ -2641,7 +2364,7 @@ msgstr ""
 
 #: src/components/Section/AboutUs.tsx:37
 msgid "The Travel Rule Information Sharing Architecture (TRISA)"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspModal/AddNewVaspModal.tsx:23
 msgid "The VASP Name is required."
@@ -2649,7 +2372,7 @@ msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:71
 msgid "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:89
 msgid "The collaborator has not been deleted"
@@ -2661,7 +2384,7 @@ msgstr ""
 
 #: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:57
 msgid "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:84
 msgid "The contact will receive an email to create a TRISA Global Directory Service (GDS) account or join this organization if the contact already has a TRISA GDS account. The invitation to join is valid for 7 calendar days. The contact will be added as a member for the VASP. The contact will have the ability to contribute to certificate requests, check on the status of certificate requests, and complete other actions related to the organization’s TRISA membership."
@@ -2673,22 +2396,22 @@ msgstr ""
 
 #: src/components/Section/PasswordResetConfirmation.tsx:22
 msgid "The link to reset your password expires in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:407
 msgid "The minimum threshold above which your organization is required to collect/send Travel Rule information."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:48
 #: src/components/MemberDetails/index.tsx:177
 #: src/components/NameIdentifiers/index.tsx:37
 #: src/components/NameIdentifiers/index.tsx:44
 msgid "The name and type of name by which the legal person is known."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:245
 msgid "The name of primary regulator or supervisory authority for your national jurisdiction"
-msgstr "---"
+msgstr ""
 
 #: src/components/ErrorComponent/RequiredElementMissing.tsx:32
 msgid "There is an error or missing data in this section. Please edit the section."
@@ -2696,11 +2419,7 @@ msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:93
 msgid "This is the only time the PKCS12 password is shown during the registration process."
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:281
-#~ msgid "This multi-section form is an important step in the registration and certificate issuance process. The information you provide will be used to verify the legal entity that you represent and, where appropriate, will be available to verified TRISA members to facilitate compliance decisions. If you need guidance, see the"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/registration.tsx:34
 msgid "This multi-section form is an important step in the registration and certificate issuance process. The information you provide will be used to verify the legal entity that you represent and, where appropriate, will be available to verified TRISA members to facilitate compliance decisions. If you need guidance, see the <0>Getting Started</0> Help Guide."
@@ -2708,15 +2427,11 @@ msgstr ""
 
 #: src/components/TrixoQuestionnaire/index.tsx:61
 msgid "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
-msgstr "---"
+msgstr ""
 
 #: src/components/TrixoQuestionnaireForm/index.tsx:352
 msgid "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/registration.tsx:292
-#~ msgid "To assist in completing the registration form, the form is divided into multiple sections"
-#~ msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/certificate/registration.tsx:46
 msgid "To assist in completing the registration form, the form is divided into multiple sections. Navigate through the form by clicking on each section of the progress bar or the buttons at the bottom of each section."
@@ -2724,19 +2439,15 @@ msgstr ""
 
 #: src/constants/name-identifiers.ts:6
 msgid "Trading"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/UserDetails.tsx:12
 msgid "USER DETAILS"
 msgstr ""
 
-#: src/hooks/useCertificateStepper.tsx:108
-#~ msgid "Under TRISA Implementation, please provide an Endpoint or Common Name for TestNet and/or MainNet"
-#~ msgstr "---"
-
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:140
 msgid "Understood"
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:115
 msgid "Unknown Entity"
@@ -2749,29 +2460,21 @@ msgstr ""
 #: src/constants/address.ts:4
 #: src/constants/national-identification.ts:7
 msgid "Unspecified"
-msgstr "---"
-
-#: src/components/NetworkAnnouncements/index.tsx:32
-#~ msgid "Upcoming TRISA Working Group Call"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:66
 msgid "Upon verification, integrate with TRISA to begin exchanging Travel Rule compliance data."
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:217
 #: src/components/CertificateInventory/index.tsx:200
 #: src/components/UserDetails/index.tsx:24
 msgid "User Details"
-msgstr "---"
-
-#: src/components/CollaboratorsSection/index.tsx:147
-#~ msgid "User ID"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/UserDetails/index.tsx:27
 msgid "User ID:"
-msgstr "---"
+msgstr ""
 
 #: src/components/UserProfile/index.tsx:48
 msgid "User Profile"
@@ -2788,7 +2491,7 @@ msgstr ""
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:31
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:32
 msgid "VASP Category"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:59
 msgid "VASP Domain"
@@ -2801,7 +2504,7 @@ msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:74
 msgid "VASPs have two options to integrate with TRISA."
-msgstr "---"
+msgstr ""
 
 #: src/modules/dashboard/member/utils.ts:61
 msgid "VERIFIED"
@@ -2810,25 +2513,25 @@ msgstr ""
 #: src/components/Section/SearchDirectory.tsx:258
 #: src/components/Section/SearchDirectory.tsx:323
 msgid "VERIFIED ON"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:116
 msgid "Verification Status:"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:22
 #: src/components/TrisaVerifiedLogo/index.tsx:36
 msgid "Verified"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:60
 msgid "Verified On"
-msgstr "---"
+msgstr ""
 
 #: src/components/Metrics/index.tsx:22
 #: src/components/StatCard/index.tsx:35
 msgid "Verified VASPs"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:130
 msgid "View Member List"
@@ -2842,11 +2545,11 @@ msgstr ""
 
 #: src/modules/auth/register/success.tsx:48
 msgid "Visit Getting Started with TRISA"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/CreateAccount.tsx:33
 msgid "We recommend that a senior compliance officer initially creates the account for the VASP. Additional accounts can be created later."
-msgstr "---"
+msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:131
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:37
@@ -2854,41 +2557,37 @@ msgstr "---"
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:23
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:18
 msgid "Website"
-msgstr "---"
-
-#: src/modules/dashboard/certificate/lib/basicDetailsValidationSchema.ts:17
-#~ msgid "Website is a required field"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:10
 msgid "Website, incorporation Date, VASP Category"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:52
 msgid "Welcome to TRISA’s network of Certified VASPs."
-msgstr "---"
+msgstr ""
 
 #: src/components/Maintenance/index.tsx:13
 msgid "We’ll be back soon."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/IntegrateAndComply.tsx:185
 #: src/components/Section/VaspVerification.tsx:187
 msgid "What is IVMS101?"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:192
 #: src/components/TrixoQuestionnaireForm/index.tsx:376
 msgid "What is the minimum threshold for Travel Rule compliance?"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/SearchDirectory.tsx:156
 msgid "What’s a Common name or VASP ID?"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:92
 msgid "Who to Ask"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/VaspVerification.tsx:104
 #: src/components/Section/VaspVerification.tsx:119
@@ -2896,11 +2595,11 @@ msgstr "---"
 #: src/components/Section/VaspVerification.tsx:139
 #: src/components/Section/VaspVerification.tsx:150
 msgid "Who to ask"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/JoinUs.tsx:64
 msgid "Why Join TRISA"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:82
 #: src/components/CertificateInventory/index.tsx:37
@@ -2910,22 +2609,22 @@ msgstr ""
 #: src/components/CertificateManagement/X509IdentityCertificateInventory.tsx:29
 #: src/components/CertificateManagement/index.tsx:103
 msgid "X.509 Identity Certificate Inventory"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:23
 msgid "X.509 Identity Certificates"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "YES"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:34
 #: src/constants/trixo.ts:5
 msgid "Yes"
-msgstr "---"
+msgstr ""
 
 #: src/components/RegistrationForm/InvalidFormPrompt.tsx:34
 msgid "You have unsaved changes. Are you sure you want to continue without saving?"
@@ -2939,57 +2638,47 @@ msgstr ""
 msgid "You must click on each confirmation link to complete the registration process."
 msgstr ""
 
-#: src/hooks/useCertificateStepper.tsx:109
-#~ msgid ""
-#~ "You must provide an Endpoint and Common Name for at least one network to proceed to the final step and submit the registration form.\n"
-#~ "Please note that TestNet and MainNet are separate networks that require different X.509 Identity Certificates."
-#~ msgstr "---"
-
 #: src/components/OrganizationProfile/TrisaImplementation.tsx:23
 msgid "You must request a new X.509 Identity Certificate to change your Endpoint and Common Name."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:96
 msgid "You must submit your registration for TestNet and MainNet separately."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/UserEmailVerification.tsx:22
 msgid "You must verify your email address. An email with verification instructions has been sent to your email address. Please complete the email verification process in 24 hours. The email verification link will expire in 24 hours."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:102
 msgid "You will receive"
 msgstr ""
 
-#: src/components/ReviewSubmit/index.tsx:98
-#~ msgid "You will receive two separate emails with confirmation links for each registration. You must click on each confirmation link to complete the registration process."
-#~ msgstr "---"
-
 #: src/components/YourImplementation/index.tsx:8
 msgid "Your TRISA Implementation"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/TrisaDetail.tsx:44
 msgid "Your TRISA {type} Details"
-msgstr "---"
+msgstr ""
 
 #: src/modules/auth/login/user.slice.ts:128
 #: src/modules/auth/login/user.slice.ts:128
 msgid "Your account has not been verified. Please check your email to verify your account."
-msgstr "---"
+msgstr ""
 
 #: src/components/Header/LandingHeader.tsx:94
 #: src/components/Header/LandingHeader.tsx:131
 msgid "Your dashboard"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateSection/index.tsx:61
 msgid "Your registration form has been successfully submitted. You will receive a confirmation email from admin@trisa.io. In the email, you will receive instructions on next steps. Return to your dashboard to monitor the status of your registration and certificate."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/ConfirmationModal.tsx:59
 msgid "Your registration request has been successfully received by the Directory Service. Verification emails have been sent to all contacts listed. Once your contact information has been verified, the registration form will be sent to the TRISA review board to verify your membership in the TRISA network."
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:47
 msgid "Your {0} TRISA Organization Profile:"
@@ -2998,31 +2687,27 @@ msgstr ""
 #: src/components/Navbar/Landing/MobileNav.tsx:71
 #: src/components/Navbar/Landing/Nav.tsx:21
 msgid "about us"
-msgstr "---"
-
-#: src/components/TrisaImplementationForm/index.tsx:43
-#~ msgid "common name should match the TRISA endpoint without the port"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:18
 msgid "complete VASP verification"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/AboutUs.tsx:50
 msgid "compliance. TRISA helps Virtual Asset Service Providers (VASPs) comply with the Travel Rule for cross-border cryptocurrency transactions. TRISA is designed to be interoperable."
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/GettingStarted.tsx:25
 msgid "create account"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/MembershipGuide.tsx:11
 msgid "create your account"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:24
 msgid "for Cryptocurrency Travel Rule compliance."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:240
 msgid "for MainNet registration so your MainNet certificate will be issued after the verification phone call has been completed by the validation team."
@@ -3030,47 +2715,39 @@ msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:148
 msgid "for TestNet registration so your TestNet certificate will be issued upon review by the validation team"
-msgstr "---"
+msgstr ""
 
 #: src/components/LegalPerson/index.tsx:73
 msgid "for legal persons and is strongly suggested for use as KYC or CDD (Know your Counterparty) information exchanged in TRISA transfers."
-msgstr "---"
-
-#: src/components/LegalPerson/index.tsx:36
-#~ msgid "for legal persons and is strongly suggested for use as KYC or CDD information exchanged in TRISA transfers."
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:34
 msgid "in partnership with"
-msgstr "---"
+msgstr ""
 
 #: src/components/Section/AboutUs.tsx:41
 msgid "is a global, open source, secure, and peer-to-peer protocol for"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:146
 msgid "is not required"
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:238
 msgid "is required"
-msgstr "---"
-
-#: src/components/NameIdentifiers/index.tsx:30
-#~ msgid "legal"
-#~ msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:90
 msgid "lower case letters (a-z)"
-msgstr "---"
+msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:121
 msgid "numbers (i.e. 0-9)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:39
 msgid "on behalf of"
-msgstr "---"
+msgstr ""
 
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:23
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:24
@@ -3080,7 +2757,7 @@ msgstr ""
 #: src/components/ReviewSubmit/index.tsx:134
 #: src/components/ReviewSubmit/index.tsx:226
 msgid "registration. Upon submission, you will receive an email with a confirmation link. You must click the confirmation link to complete the registration process. Failure to click the confirmation link will result in an incomplete registration"
-msgstr "---"
+msgstr ""
 
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:45
 #: src/components/AddNewVaspForm/AddNewVaspForm.tsx:61
@@ -3091,15 +2768,15 @@ msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:135
 msgid "special characters (e.g. !@#$%^&*)"
-msgstr "---"
+msgstr ""
 
 #: src/components/Footer/LandingFooter.tsx:22
 msgid "the TRISA architecture"
-msgstr "---"
+msgstr ""
 
 #: src/components/Maintenance/index.tsx:34
 msgid "to receive maintenance and outage notifications. If you have an immediate concern, please email support@rotational.io."
-msgstr "---"
+msgstr ""
 
 #: src/components/ReviewSubmit/index.tsx:106
 msgid "two separate emails with confirmation links for each registration."
@@ -3107,7 +2784,7 @@ msgstr ""
 
 #: src/components/PasswordStrength/index.tsx:107
 msgid "upper case letters (A-Z)"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:105
 #: src/components/CertificateManagement/SealingCertificateTableRows.tsx:16
@@ -3123,7 +2800,7 @@ msgstr ""
 msgid ""
 "with detailed documentation, a reference implemenation, and “robot” VASPs for\n"
 "                    testing purposes."
-msgstr "---"
+msgstr ""
 
 #: src/components/Collaborators/index.tsx:145
 msgid "you do not have permission to invite a collaborator"
@@ -3135,12 +2812,12 @@ msgstr ""
 #: src/components/UserProfile/UserDetails.tsx:25
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:56
 msgid "{0}"
-msgstr "---"
+msgstr ""
 
 #: src/components/CertificateReview/ContactsReviewDataTable.tsx:28
 msgid "{0} Contact"
-msgstr "---"
+msgstr ""
 
 #: src/components/NeedsAttention/AttentionAlert.tsx:85
 msgid "{message}"
-msgstr "---"
+msgstr ""

--- a/web/gds-user-ui/src/locales/zh/messages.po
+++ b/web/gds-user-ui/src/locales/zh/messages.po
@@ -146,7 +146,7 @@ msgstr "4 TRISA 实施 "
 msgid "5 TRIXO Questionnaire"
 msgstr "5 TRIXO 问卷 "
 
-#: src/components/Contacts/ContactForm/index.tsx:30
+#: src/components/Contacts/ContactForm/index.tsx:29
 msgid "A business phone number is required to complete physical verification for MainNet registration. Please provide a phone number where the Legal/ Compliance contact can be contacted"
 msgstr ""
 
@@ -187,7 +187,7 @@ msgid "Action"
 msgstr "开始"
 
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:70
-#: src/components/Collaborators/index.tsx:171
+#: src/components/Collaborators/index.tsx:179
 #: src/modules/dashboard/member/components/MemberTable.tsx:34
 msgid "Actions"
 msgstr ""
@@ -205,11 +205,11 @@ msgstr ""
 msgid "Add Address"
 msgstr "添加地址"
 
-#: src/components/NameIdentifiers/index.tsx:51
+#: src/components/NameIdentifiers/index.tsx:50
 msgid "Add Another Legal Name"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:140
+#: src/components/Collaborators/index.tsx:148
 msgid "Add Contact"
 msgstr ""
 
@@ -225,11 +225,11 @@ msgstr "添加权限"
 msgid "Add Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:54
+#: src/components/NameIdentifiers/index.tsx:53
 msgid "Add Local Name"
 msgstr "添加本地名称"
 
-#: src/components/NameIdentifiers/index.tsx:57
+#: src/components/NameIdentifiers/index.tsx:56
 msgid "Add Phonetic Names"
 msgstr "添加语音名称"
 
@@ -261,13 +261,13 @@ msgstr "地址第1行，如建筑物名称/编号、街道名称（必填）"
 msgid "Address line 2 e.g. apartment or suite number"
 msgstr "地址第2行，如公寓或套房号码"
 
-#: src/components/Addresses/index.tsx:11
+#: src/components/Addresses/index.tsx:10
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:118
 #: src/components/MemberDetails/index.tsx:244
 msgid "Addresses"
 msgstr "地址"
 
-#: src/components/Contacts/ContactsForm.tsx:158
+#: src/components/Contacts/ContactsForm.tsx:161
 msgid "Administrative Contact (optional)"
 msgstr "管理联系人（选填）"
 
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Administrative Contact Phone"
 msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:159
+#: src/components/Contacts/ContactsForm.tsx:162
 msgid "Administrative or executive contact for your organization to field high-level requests or queries. (Strongly recommended)"
 msgstr "贵组织的管理或执行联系人，以处理高级请求或查询。（强烈建议）"
 
@@ -321,7 +321,7 @@ msgstr ""
 msgid "An error occurred while deleting the collaborator, please try again or contact support at support@trisa.io"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:130
+#: src/components/NationalIdentification/index.tsx:129
 msgid "An identifier issued by an appropriate issuing authority"
 msgstr "一个合适的颁发机构颁发的一种标识符"
 
@@ -329,8 +329,8 @@ msgstr "一个合适的颁发机构颁发的一种标识符"
 msgid "App version {appVersion}"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:174
-#: src/components/TrixoQuestionnaireForm/index.tsx:417
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:173
+#: src/components/TrixoQuestionnaireForm/index.tsx:416
 msgid "Applicable Regulations"
 msgstr "适用条例"
 
@@ -342,13 +342,13 @@ msgstr "申请成为TRISA认证的虚拟资产服务提供商"
 msgid "At least 9 characters in length"
 msgstr ""
 
-#: src/components/Addresses/index.tsx:14
+#: src/components/Addresses/index.tsx:13
 msgid "At least one geographic address is required. Enter the primary geographic address of the organization. Organizations may enter additional addresses if operating in multiple jurisdictions."
 msgstr "我们需要至少一个地理地址。请输入组织的主要地理地址。如果在多个司法管辖区经营，组织可以再输入其他地址。"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:143
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:142
 #: src/components/MemberDetails/index.tsx:589
-#: src/components/TrixoQuestionnaireForm/index.tsx:322
+#: src/components/TrixoQuestionnaireForm/index.tsx:321
 msgid "At what threshold and currency does your organization conduct KYC checks?"
 msgstr ""
 
@@ -387,11 +387,11 @@ msgstr "遵守旅行规则。"
 #~ msgid "Beware the Ides of March"
 #~ msgstr ""
 
-#: src/components/Contacts/ContactsForm.tsx:163
+#: src/components/Contacts/ContactsForm.tsx:168
 msgid "Billing Contact (optional)"
 msgstr "账单联系人（可选）"
 
-#: src/components/Contacts/ContactsForm.tsx:164
+#: src/components/Contacts/ContactsForm.tsx:169
 msgid "Billing contact for your organization to handle account and invoice requests or queries relating to the operation of the TRISA network."
 msgstr "账单联系人，为贵组织处理与TRISA网络操作相关的账户和发票请求或查询。"
 
@@ -429,7 +429,7 @@ msgstr "业务或合规办公室"
 msgid "By answering yes, I understand that this is the only time the PKCS12 Password is displayed and I have copied and securely saved the password."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:282
+#: src/components/TrixoQuestionnaireForm/index.tsx:281
 msgid "CDD & Travel Rule Policies"
 msgstr "客户尽责调查和旅游规则政策"
 
@@ -445,7 +445,7 @@ msgstr "客户尽责调查和数据保护政策"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:80
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:79
 msgid "Certificate Common Name"
 msgstr "证书公用名"
 
@@ -540,7 +540,7 @@ msgstr ""
 
 #: src/components/Collaborators/DeleteCollaborator/DeleteCollaboratorModal.tsx:158
 #: src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx:198
-#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:74
+#: src/modules/dashboard/member/components/MemberModal/MemberModal.tsx:75
 msgid "Close"
 msgstr ""
 
@@ -569,9 +569,9 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:286
 #: src/components/CertificateInventory/index.tsx:206
 #: src/components/CertificateInventory/index.tsx:269
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:63
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:83
-#: src/components/Section/SearchDirectory.tsx:215
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:62
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:82
+#: src/components/Section/SearchDirectory.tsx:217
 #: src/components/Section/SearchDirectory.tsx:283
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:79
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:89
@@ -582,7 +582,7 @@ msgstr "公用名"
 #~ msgid "Common name or VASP ID"
 #~ msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:42
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:41
 msgid "Common name should match the TRISA endpoint without the port."
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr ""
 msgid "Comply with the Travel Rule"
 msgstr "遵守旅行规则"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:313
+#: src/components/TrixoQuestionnaireForm/index.tsx:312
 msgid "Conducts KYC before virtual asset transfers"
 msgstr "在虚拟资产转移之前执行KYC"
 
@@ -674,7 +674,7 @@ msgstr ""
 msgid "Confirm New Password"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:156
+#: src/components/Collaborators/index.tsx:164
 msgid "Contact Details"
 msgstr ""
 
@@ -691,7 +691,7 @@ msgid "Contact information for representatives of your organization. Contacts in
 msgstr "代表贵组织的联系信息。联系人包括技术、法律/合规、行政和计费人员。"
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:21
-#: src/components/OrganizationProfile/OrganizationalDetail.tsx:157
+#: src/components/OrganizationProfile/OrganizationalDetail.tsx:158
 #: src/components/RegistrationForm/CertificateStepLabel.tsx:165
 msgid "Contacts"
 msgstr "联系人"
@@ -733,8 +733,8 @@ msgstr ""
 #: src/components/CertificateDetails/CertificateDetails.tsx:292
 #: src/components/CertificateInventory/index.tsx:212
 #: src/components/CertificateInventory/index.tsx:275
-#: src/components/Section/SearchDirectory.tsx:239
-#: src/components/Section/SearchDirectory.tsx:308
+#: src/components/Section/SearchDirectory.tsx:242
+#: src/components/Section/SearchDirectory.tsx:307
 msgid "Country"
 msgstr "国家"
 
@@ -743,16 +743,16 @@ msgid "Country (required)"
 msgstr "国家（必填）"
 
 #: src/components/MemberDetails/index.tsx:321
-#: src/components/NameIdentification/index.tsx:174
+#: src/components/NationalIdentification/index.tsx:173
 msgid "Country of Issue"
 msgstr "国家的问题"
 
-#: src/components/NameIdentification/index.tsx:178
+#: src/components/NationalIdentification/index.tsx:177
 msgid "Country of Issue is reserved for National Identifiers of Natural Persons"
 msgstr "发行国为自然人的国家标识符作保留"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:138
-#: src/components/CountryOfRegistration/index.tsx:19
+#: src/components/CountryOfRegistration/index.tsx:18
 #: src/components/MemberDetails/index.tsx:271
 #: src/components/MemberDetails/index.tsx:331
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:137
@@ -815,11 +815,11 @@ msgstr "创建和维护人"
 msgid "Current Name"
 msgstr ""
 
-#: src/components/Sidebar/MobileNav.tsx:83
+#: src/components/Sidebar/MobileNav.tsx:81
 msgid "Current Organization name"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:89
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:88
 msgid "Customer Due Diligence (CDD) & Travel Rule Policies"
 msgstr ""
 
@@ -831,8 +831,8 @@ msgstr "客户编号"
 msgid "Dashboard"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:207
-#: src/components/TrixoQuestionnaireForm/index.tsx:429
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:206
+#: src/components/TrixoQuestionnaireForm/index.tsx:428
 msgid "Data Protection Policies"
 msgstr "数据保护政策"
 
@@ -900,11 +900,11 @@ msgstr "目录查找"
 msgid "Documentation"
 msgstr "文档"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:307
+#: src/components/TrixoQuestionnaireForm/index.tsx:306
 msgid "Does your organization conduct KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr "在允许客户发送/接收虚拟资产转移之前，贵组织是否进行了KYC/CDD？"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:123
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:122
 msgid "Does your organization conduct Know your KYC/CDD before permitting its customers to send/receive virtual asset transfers?"
 msgstr ""
 
@@ -921,24 +921,24 @@ msgid ""
 "                      jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:297
+#: src/components/TrixoQuestionnaireForm/index.tsx:296
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money\n"
 "Laundering (AML), Countering the Financing of Terrorism (CFT), Know your\n"
 "Counterparty/Customer Due Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:99
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:98
 msgid ""
 "Does your organization have a programme that sets minimum Anti-Money Laundering (AML), Countering the Financing of Terrorism (CFT), Know your Counterparty/Customer Due\n"
 "                    Diligence (KYC/CDD) and Sanctions standards per the requirements of the jurisdiction(s) regulatory regimes where it is licensed/approved/registered?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:446
+#: src/components/TrixoQuestionnaireForm/index.tsx:445
 msgid "Does your organization secure and protect PII, including PII received from other VASPs under the Travel Rule?"
 msgstr "贵组织是否安全并保护PII，包括根据旅行规则从其他VASP收到的PII？"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:234
 msgid ""
 "Does your organization secure and protect Personally Identifiable\n"
 "                Information (PII), including Personally Identifiable\n"
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance."
 msgstr "每个VASP都需要为VASP之间的通信建立TRISA端点。请详细说明颁发证书的端点。"
 
-#: src/components/TrisaImplementation/index.tsx:66
+#: src/components/TrisaImplementation/index.tsx:65
 msgid "Each VASP is required to establish a TRISA endpoint for inter-VASP communication. Please specify the details of your endpoint for certificate issuance. Please specify the TestNet endpoint and the MainNet endpoint. The TestNet endpoint and the MainNet endpoint must be different."
 msgstr "每个VASP都需要为VASP之间的通信建立TRISA端点。请详细说明颁发证书的端点。请指定测试网端点和主网端点。测试网端点和主网端点必须是不同的。"
 
@@ -983,7 +983,7 @@ msgid "Edit collaborator Role"
 msgstr ""
 
 #: src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx:129
-#: src/components/Contacts/ContactForm/index.tsx:67
+#: src/components/Contacts/ContactForm/index.tsx:66
 #: src/components/Form/LoginForm.tsx:52
 #: src/components/Form/SignupForm.tsx:53
 #: src/components/Section/PasswordResetForm.tsx:26
@@ -1020,8 +1020,8 @@ msgstr ""
 
 #: src/components/CertificateDetails/CertificateDetails.tsx:181
 #: src/components/CertificateInventory/index.tsx:116
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:57
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:77
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:56
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:76
 msgid "Endpoint"
 msgstr "端点"
 
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "Enter the VASP Common Name or VASP ID. Not a TRISA Member?"
 msgstr "输入VASP公用名或VASP ID。不是TRISA会员？"
 
-#: src/components/NameIdentifiers/index.tsx:31
+#: src/components/NameIdentifiers/index.tsx:30
 msgid "Enter the name and type of name by which the legal person is known. At least one legal name is required. Organizations are strongly encouraged to enter additional name identifiers such as Trading Name/ Doing Business As (DBA), Local names, and phonetic names where appropriate."
 msgstr ""
 
@@ -1109,7 +1109,7 @@ msgstr "最终审核和提交表单"
 msgid "First (Given) Name"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:67
+#: src/components/OrganizationProfile/TrisaDetail.tsx:57
 msgid "First Listed"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "For MainNet certificate requests, a member of TRISA’s verification team will review your submission and conduct a final due diligence phone call for physical verification. When physical verification is complete, TRISA will issue MainNet certificates. Requests for TestNet certificates do not require physical verification."
 msgstr "对于主网证书的申请，TRISA验证团队的一名会员将审核您提交的文件，并进行最后的尽职调查电话核实。物理验证完后，TRISA将颁发主网证书。而测试网证书的请求不需要物理验证。"
 
-#: src/components/NameIdentification/index.tsx:32
+#: src/components/NationalIdentification/index.tsx:31
 msgid "For identifiers other than LEI specify the registration authority from the following list. See"
 msgstr "对于LEI以外的标识符，请从以下列表中指定注册机构。请参阅"
 
@@ -1133,7 +1133,7 @@ msgstr "外商投资身份证号码"
 msgid "Forgot password?"
 msgstr "忘记密码？"
 
-#: src/components/Contacts/ContactForm/index.tsx:58
+#: src/components/Contacts/ContactForm/index.tsx:57
 msgid "Full Name"
 msgstr "姓名"
 
@@ -1141,7 +1141,7 @@ msgstr "姓名"
 msgid "Full name"
 msgstr ""
 
-#: src/components/NameIdentification/index.tsx:40
+#: src/components/NationalIdentification/index.tsx:39
 msgid "GLEIF Registration Authorities"
 msgstr "GLEIF注册机构"
 
@@ -1190,7 +1190,7 @@ msgstr ""
 #~ msgid "I have a bad feeling about tomorrow."
 #~ msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:64
+#: src/components/OrganizationProfile/TrisaDetail.tsx:54
 msgid "ID"
 msgstr ""
 
@@ -1204,14 +1204,14 @@ msgstr "IVMS 101 数据结构"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:165
 #: src/components/MemberDetails/index.tsx:303
-#: src/components/NameIdentification/index.tsx:127
+#: src/components/NationalIdentification/index.tsx:126
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:112
 msgid "Identification Number"
 msgstr "识别号码"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:171
 #: src/components/MemberDetails/index.tsx:311
-#: src/components/NameIdentification/index.tsx:156
+#: src/components/NationalIdentification/index.tsx:155
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:120
 msgid "Identification Type"
 msgstr "识别类型"
@@ -1224,7 +1224,7 @@ msgstr "身份证号码"
 msgid "Identity Certificates"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:41
+#: src/components/Contacts/ContactForm/index.tsx:40
 msgid "If supplied, use full phone number with country code"
 msgstr "如果提供，请输入带有国家代码的完整电话号码"
 
@@ -1310,12 +1310,12 @@ msgstr "可互操作"
 #~ msgid "Invalid date."
 #~ msgstr ""
 
-#: src/components/Collaborators/index.tsx:165
+#: src/components/Collaborators/index.tsx:173
 msgid "Invited"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:67
-#: src/components/TrixoQuestionnaireForm/index.tsx:274
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:66
+#: src/components/TrixoQuestionnaireForm/index.tsx:273
 msgid "Is your organization permitted to send and/or receive transfers of virtual assets in the jurisdictions in which it operates?"
 msgstr "贵组织是否获准在其运营的司法管辖区内发送和/或接收虚拟资产转让？"
 
@@ -1324,18 +1324,18 @@ msgstr "贵组织是否获准在其运营的司法管辖区内发送和/或接�
 #~ msgid "Is your organization required by law to safeguard PII?"
 #~ msgstr "贵组织是否被法律要求保障PII？"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:215
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:214
 msgid ""
 "Is your organization required by law to safeguard Personally Identifiable\n"
 "                Information (PII)?"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:433
+#: src/components/TrixoQuestionnaireForm/index.tsx:432
 msgid "Is your organization required by law to safeguard Personally Identifiable Information (PII)?"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:154
-#: src/components/TrixoQuestionnaireForm/index.tsx:363
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:153
+#: src/components/TrixoQuestionnaireForm/index.tsx:362
 msgid "Is your organization required to comply with the application of the Travel Rule standards in the jurisdiction(s) where it is licensed/approved/registered?"
 msgstr "贵组织是否需要在其获得许可/批准/注册的管辖区遵守旅行规则标准？"
 
@@ -1372,7 +1372,7 @@ msgstr "立即加入TRISA网络。"
 #~ msgid "Join us on Thursday Apr 28 for the TRISA Working Group."
 #~ msgstr ""
 
-#: src/components/Collaborators/index.tsx:168
+#: src/components/Collaborators/index.tsx:176
 #: src/modules/dashboard/member/components/MemberTable.tsx:22
 #: src/modules/dashboard/member/utils.ts:12
 msgid "Joined"
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Last Login:"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:73
+#: src/components/OrganizationProfile/TrisaDetail.tsx:63
 #: src/modules/dashboard/member/components/MemberTable.tsx:25
 #: src/modules/dashboard/member/utils.ts:16
 msgid "Last Updated"
@@ -1449,7 +1449,7 @@ msgstr "法律/合规联系人（必填）"
 msgid "Link Account"
 msgstr ""
 
-#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:36
 msgid "Local Name Identifiers"
 msgstr "本地名称标识符"
 
@@ -1497,7 +1497,7 @@ msgstr "登入"
 msgid "Login & Identity"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:196
+#: src/components/Section/SearchDirectory.tsx:187
 msgid "MAINNET DIRECTORY RECORD"
 msgstr "主网目录记录"
 
@@ -1511,7 +1511,7 @@ msgid "MAINNET SUBMISSION"
 msgstr "主网提交"
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:53
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:72
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:51
 #: src/components/ReviewSubmit/index.tsx:224
 msgid "MainNet"
 msgstr "主网"
@@ -1579,16 +1579,16 @@ msgstr "其他"
 #~ msgid "Missing required element"
 #~ msgstr "缺少必要元素"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:369
+#: src/components/TrixoQuestionnaireForm/index.tsx:368
 msgid "Must comply with Travel Rule"
 msgstr "务必遵守旅行规则"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:439
+#: src/components/TrixoQuestionnaireForm/index.tsx:438
 msgid "Must safeguard PII"
 msgstr "务必保障PII"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "NO"
 msgstr ""
 
@@ -1598,7 +1598,7 @@ msgid "NO VERIFICATION"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:57
-#: src/components/NameIdentifier/index.tsx:118
+#: src/components/NameIdentifier/index.tsx:117
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:19
 msgid "Name"
 msgstr "名称"
@@ -1617,7 +1617,7 @@ msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:43
 #: src/components/MemberDetails/index.tsx:172
-#: src/components/NameIdentifiers/index.tsx:29
+#: src/components/NameIdentifiers/index.tsx:28
 #: src/components/OrganizationProfile/OrganizationalDetail.tsx:68
 msgid "Name Identifiers"
 msgstr "名称标识符"
@@ -1626,8 +1626,8 @@ msgstr "名称标识符"
 #~ msgid "Name identifiers"
 #~ msgstr "名称标识符"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:43
-#: src/components/TrixoQuestionnaireForm/index.tsx:245
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:42
+#: src/components/TrixoQuestionnaireForm/index.tsx:244
 msgid "Name of Primary Regulator"
 msgstr "主要监管机构名称"
 
@@ -1641,7 +1641,7 @@ msgstr ""
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:156
 #: src/components/MemberDetails/index.tsx:298
-#: src/components/NameIdentification/index.tsx:115
+#: src/components/NationalIdentification/index.tsx:114
 msgid "National Identification"
 msgstr "国民身份"
 
@@ -1687,7 +1687,7 @@ msgstr "下一页"
 
 #: src/components/CertificateManagement/CertificateDataTable.tsx:26
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:33
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:31
 #: src/constants/trixo.ts:7
 msgid "No"
@@ -1765,7 +1765,7 @@ msgstr ""
 
 #: src/components/BasicDetailsForm/index.tsx:120
 #: src/components/CertificateReview/BasicDetailsReviewDataTable.tsx:30
-#: src/components/Section/SearchDirectory.tsx:209
+#: src/components/Section/SearchDirectory.tsx:211
 #: src/components/Section/SearchDirectory.tsx:277
 msgid "Organization Name"
 msgstr "组织名称"
@@ -1794,8 +1794,8 @@ msgstr ""
 msgid "Organizational Details"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:49
-#: src/components/TrixoQuestionnaireForm/index.tsx:251
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:48
+#: src/components/TrixoQuestionnaireForm/index.tsx:250
 msgid "Other Jurisdictions"
 msgstr "其他司法管辖区"
 
@@ -1844,11 +1844,11 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:91
+#: src/components/Contacts/ContactForm/index.tsx:90
 msgid "Phone Number"
 msgstr "电话号码"
 
-#: src/components/NameIdentifiers/index.tsx:44
+#: src/components/NameIdentifiers/index.tsx:43
 msgid "Phonetic Name Identifiers"
 msgstr "语音名称标识符"
 
@@ -1856,7 +1856,7 @@ msgstr "语音名称标识符"
 msgid "Please Provide the Name and Email Address"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:254
+#: src/components/TrixoQuestionnaireForm/index.tsx:253
 msgid "Please add any other regulatory jurisdictions your organization complies with."
 msgstr "请添加贵组织遵守的任何其他监管辖区。"
 
@@ -1909,11 +1909,11 @@ msgstr "请检查所提供的信息，根据需要进行编辑，然后提交以
 msgid "Please select as many categories needed to represent the types of virtual asset services your organization provides."
 msgstr "请根据需要选择多个类别，以表示贵组织提供的虚拟资产服务类型。"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:420
+#: src/components/TrixoQuestionnaireForm/index.tsx:419
 msgid "Please specify the applicable regulation(s) for Travel Rule standards compliance, e.g.\"FATF Recommendation 16\""
 msgstr "请详细说明符合旅行规则标准的适用法规，例如“FATF第16项建议” "
 
-#: src/components/NameIdentification/index.tsx:118
+#: src/components/NationalIdentification/index.tsx:117
 msgid "Please supply a valid national identification number. TRISA recommends the use of LEI numbers. For more information, please visit"
 msgstr "请提供有效的国家识别号，TRISA建议使用LEI编号。欲了解更多，请访问"
 
@@ -1926,15 +1926,15 @@ msgstr "请提供有效的国家识别号，TRISA建议使用LEI编号。欲了�
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed."
 msgstr ""
 
-#: src/components/Contacts/index.tsx:62
+#: src/components/Contacts/index.tsx:61
 msgid "Please supply contact information for representatives of your organization. All contacts will receive an email verification token and the contact emails must be verified before the registration can proceed. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
-#: src/components/Contacts/ContactForm/index.tsx:23
+#: src/components/Contacts/ContactForm/index.tsx:22
 msgid "Please use the email address associated with your organization."
 msgstr "请使用与贵组织相关的电子邮件地址。"
 
-#: src/components/Contacts/ContactForm/index.tsx:21
+#: src/components/Contacts/ContactForm/index.tsx:20
 msgid "Please use the email address associated with your organization. Group or shared email addresses such as compliance@yourvasp.com are permitted if the email account is actively monitored."
 msgstr ""
 
@@ -1953,7 +1953,7 @@ msgstr ""
 msgid "Postal Code / Postcode / ZIP Code"
 msgstr "邮政编码/邮递区号"
 
-#: src/components/Contacts/ContactForm/index.tsx:59
+#: src/components/Contacts/ContactForm/index.tsx:58
 msgid "Preferred name for email communication."
 msgstr "电子邮件通信的首选名称。"
 
@@ -1961,12 +1961,12 @@ msgstr "电子邮件通信的首选名称。"
 msgid "Previous"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:37
-#: src/components/TrixoQuestionnaireForm/index.tsx:235
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:36
+#: src/components/TrixoQuestionnaireForm/index.tsx:234
 msgid "Primary National Jurisdiction"
 msgstr "主要国家管辖权"
 
-#: src/components/Contacts/ContactsForm.tsx:154
+#: src/components/Contacts/ContactsForm.tsx:155
 msgid "Primary contact for handling technical queries about the operation and status of your service participating in the TRISA network. Can be a group or admin email."
 msgstr "主要联系人，负责处理您参与TRISA网络服务的运行和状态的技术查询。可以是组或管理员电子邮件。"
 
@@ -2023,12 +2023,12 @@ msgstr "注册机构"
 msgid "Region / Province / State (required)"
 msgstr "地区/省/州（必填）"
 
-#: src/components/Section/SearchDirectory.tsx:227
+#: src/components/Section/SearchDirectory.tsx:229
 #: src/components/Section/SearchDirectory.tsx:295
 msgid "Registered Directory"
 msgstr "注册目录"
 
-#: src/components/NameIdentification/index.tsx:196
+#: src/components/NationalIdentification/index.tsx:195
 msgid "Registration Authority"
 msgstr "注册机构"
 
@@ -2056,7 +2056,7 @@ msgstr "监管机构名称"
 msgid "Remove Linked Account"
 msgstr ""
 
-#: src/components/NameIdentifier/index.tsx:137
+#: src/components/NameIdentifier/index.tsx:136
 #: src/components/OtherJuridictions/index.tsx:58
 #: src/components/Regulations/index.tsx:31
 msgid "Remove line"
@@ -2102,7 +2102,7 @@ msgstr "审查"
 msgid "Review section"
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:159
+#: src/components/Collaborators/index.tsx:167
 #: src/components/UserProfile/UserDetails.tsx:22
 msgid "Role"
 msgstr ""
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "SUBMITTED"
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:452
+#: src/components/TrixoQuestionnaireForm/index.tsx:451
 msgid "Safeguards PII"
 msgstr "保障PII"
 
@@ -2151,7 +2151,7 @@ msgstr "搜索目录服务"
 msgid "Section"
 msgstr "部分"
 
-#: src/components/BasicDetail/index.tsx:132
+#: src/components/BasicDetail/index.tsx:130
 #: src/components/CertificateReview/BasicDetailsReview.tsx:29
 #: src/components/CertificateSection/index.tsx:23
 #: src/components/CertificateSection/index.tsx:65
@@ -2166,17 +2166,17 @@ msgstr "第2部分：法人"
 
 #: src/components/CertificateReview/ContactsReview.tsx:19
 #: src/components/CertificateSection/index.tsx:36
-#: src/components/Contacts/index.tsx:56
+#: src/components/Contacts/index.tsx:55
 msgid "Section 3: Contacts"
 msgstr "第3部分：联系人"
 
 #: src/components/CertificateReview/TrisaImplementationReview.tsx:19
 #: src/components/CertificateSection/index.tsx:41
-#: src/components/TrisaImplementation/index.tsx:60
+#: src/components/TrisaImplementation/index.tsx:59
 msgid "Section 4: TRISA Implementation"
 msgstr "第4部分：TRISA实施"
 
-#: src/components/CertificateReview/TrixoReview.tsx:34
+#: src/components/CertificateReview/TrixoReview.tsx:32
 #: src/components/CertificateSection/index.tsx:46
 #: src/components/TrixoQuestionnaire/index.tsx:55
 msgid "Section 5: TRIXO Questionnaire"
@@ -2207,7 +2207,7 @@ msgstr "选择VASP类别"
 msgid "Select a VASP from the Managed VASP List"
 msgstr ""
 
-#: src/components/CountryOfRegistration/index.tsx:28
+#: src/components/CountryOfRegistration/index.tsx:27
 msgid "Select a country"
 msgstr "选择国家"
 
@@ -2310,8 +2310,8 @@ msgstr ""
 #: src/components/CertificateManagement/MainnetTestnetCertificates.tsx:67
 #: src/components/CertificateManagement/X509IdentityCertificateInventoryDataTable.tsx:45
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:63
-#: src/components/Collaborators/index.tsx:162
-#: src/components/OrganizationProfile/TrisaDetail.tsx:76
+#: src/components/Collaborators/index.tsx:170
+#: src/components/OrganizationProfile/TrisaDetail.tsx:66
 #: src/modules/dashboard/member/components/MemberTable.tsx:31
 #: src/modules/dashboard/member/utils.ts:24
 msgid "Status"
@@ -2344,7 +2344,7 @@ msgid "Subject Details"
 msgstr ""
 
 #: src/components/CertificateRegistration/CertificateRegistrationTable.tsx:39
-#: src/components/NeedsAttention/AttentionAlert.tsx:98
+#: src/components/NeedsAttention/AttentionAlert.tsx:97
 #: src/components/Section/PasswordResetForm.tsx:48
 #: src/hoc/withRHF.tsx:117
 msgid "Submit"
@@ -2374,7 +2374,7 @@ msgstr ""
 msgid "Synga Bridge"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:188
+#: src/components/Section/SearchDirectory.tsx:195
 msgid "TESTNET DIRECTORY RECORD"
 msgstr "测试网目录记录"
 
@@ -2390,7 +2390,7 @@ msgstr ""
 #~ msgid "TRISA Certificates"
 #~ msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:67
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:66
 #: src/modules/dashboard/member/components/MemberModal/Copy.tsx:75
 #: src/modules/dashboard/member/components/MemberModal/MemberModalContent.tsx:83
 msgid "TRISA Endpoint"
@@ -2400,7 +2400,7 @@ msgstr "TRISA 端点"
 #~ msgid "TRISA Endpoint is a server address (e.g. trisa.myvasp.com:443) at which the VASP can be reached via secure channels. The Common Name typically matches the Endpoint, without the port number at the end (e.g. trisa.myvasp.com) and is used to identify the subject in the X.509 certificate."
 #~ msgstr "TRISA端点是一个服务器地址（例如：trisa.myvasp.com:443），可以通过安全通道访问VASP。公用名通常与端点匹配，在末尾没有端口号（例如：trisa.myvasp.com），用于识别X.509证书中的主题。"
 
-#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:149
+#: src/components/TrisaImplementation/TrisaImplementationForm.tsx:150
 msgid "TRISA Endpoint: MainNet"
 msgstr "TRISA端点：主网"
 
@@ -2432,7 +2432,7 @@ msgstr ""
 msgid "TRISA Member Directory"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:233
+#: src/components/Section/SearchDirectory.tsx:235
 #: src/components/Section/SearchDirectory.tsx:301
 msgid "TRISA Member ID"
 msgstr "TRISA会员ID"
@@ -2449,13 +2449,13 @@ msgstr ""
 msgid "TRISA Registration Request Submitted!"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:221
+#: src/components/Section/SearchDirectory.tsx:223
 #: src/components/Section/SearchDirectory.tsx:289
 msgid "TRISA Service Endpoint"
 msgstr "TRISA服务端点"
 
-#: src/components/Section/SearchDirectory.tsx:250
-#: src/components/Section/SearchDirectory.tsx:319
+#: src/components/Section/SearchDirectory.tsx:253
+#: src/components/Section/SearchDirectory.tsx:318
 msgid "TRISA Verification"
 msgstr "TRISA 验证"
 
@@ -2569,7 +2569,7 @@ msgstr ""
 msgid "Tax Identification Number"
 msgstr "纳税人识别号"
 
-#: src/components/Contacts/ContactsForm.tsx:153
+#: src/components/Contacts/ContactsForm.tsx:154
 msgid "Technical Contact (required)"
 msgstr "技术联系人（必填）"
 
@@ -2598,7 +2598,7 @@ msgid "Technical information about your endpoint for certificate issuance. Each 
 msgstr "有关证书颁发端点的技术信息。每个VASP都需要建立一个TRISA端点，用于VASP之间的通信。"
 
 #: src/components/CertificateReview/TrisaImplementationReviewDataTable.tsx:33
-#: src/components/OrganizationProfile/TrisaImplementation.tsx:52
+#: src/components/OrganizationProfile/TrisaImplementation.tsx:71
 #: src/components/ReviewSubmit/index.tsx:132
 msgid "TestNet"
 msgstr "测试网"
@@ -2649,7 +2649,7 @@ msgstr ""
 msgid "Thank you. We have sent instructions to reset your password to {0}. The link to reset your password expires in 24 hours."
 msgstr "谢谢您，我们已发送指示，将您的密码重置为 {0}。重置密码的链接将在24小时后失效。"
 
-#: src/components/Section/SearchDirectory.tsx:145
+#: src/components/Section/SearchDirectory.tsx:144
 msgid ""
 "The Common Name typically matches the Endpoint, without the port number\n"
 "                            at the end (e.g. trisa.myvasp.com) and is used to identify the subject\n"
@@ -2696,7 +2696,7 @@ msgstr "旅行规则信息共享架构（TRISA）"
 msgid "The VASP Name is required."
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:72
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:71
 msgid "The address and port of the TRISA endpoint for partner VASPs to connect on via gRPC."
 msgstr "合作伙伴VASP通过gRPC连接TRISA端点的地址端口。"
 
@@ -2708,7 +2708,7 @@ msgstr ""
 msgid "The collaborator has not been updated"
 msgstr ""
 
-#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:58
+#: src/components/TrisaImplementation/TrisaImplementationForm/index.tsx:57
 msgid "The common name for the mTLS certificate. This should match the TRISA endpoint without the port in most cases."
 msgstr "mTLS证书的公用名。在大多数情况下，这应该与没有端口的TRISA端点相匹配。"
 
@@ -2724,18 +2724,18 @@ msgstr ""
 msgid "The link to reset your password expires in 24 hours."
 msgstr ""
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:408
+#: src/components/TrixoQuestionnaireForm/index.tsx:407
 msgid "The minimum threshold above which your organization is required to collect/send Travel Rule information."
 msgstr "贵组织需要收集/发送旅行规则信息的最低门槛。"
 
 #: src/components/CertificateReview/LegalPersonReviewDataTable.tsx:48
 #: src/components/MemberDetails/index.tsx:177
-#: src/components/NameIdentifiers/index.tsx:38
-#: src/components/NameIdentifiers/index.tsx:45
+#: src/components/NameIdentifiers/index.tsx:37
+#: src/components/NameIdentifiers/index.tsx:44
 msgid "The name and type of name by which the legal person is known."
 msgstr "法人的名称和名称类型。"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:246
+#: src/components/TrixoQuestionnaireForm/index.tsx:245
 msgid "The name of primary regulator or supervisory authority for your national jurisdiction"
 msgstr "您所在国家的主要监管机构或监管机构的名称"
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "This questionnaire is designed to help TRISA members understand the regulatory regime of your organization. The information provided will help ensure that required compliance information exchanges are conducted correctly and safely. All verified TRISA members will have access to this information."
 msgstr "本问卷旨在帮助TRISA会员了解贵组织的监管制度。所提供的信息将有助于确保正确和安全地进行所需的合规信息交换。所有经验证的TRISA会员都可以获得此信息。"
 
-#: src/components/TrixoQuestionnaireForm/index.tsx:353
+#: src/components/TrixoQuestionnaireForm/index.tsx:352
 msgid "Threshold to conduct KYC before permitting the customer to send/receive virtual asset transfers"
 msgstr "在允许客户发送/接收虚拟资产转让前进行KYC的门槛"
 
@@ -2860,8 +2860,8 @@ msgstr ""
 msgid "VERIFIED"
 msgstr ""
 
-#: src/components/Section/SearchDirectory.tsx:255
-#: src/components/Section/SearchDirectory.tsx:324
+#: src/components/Section/SearchDirectory.tsx:258
+#: src/components/Section/SearchDirectory.tsx:323
 msgid "VERIFIED ON"
 msgstr "验证日期"
 
@@ -2874,7 +2874,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:70
+#: src/components/OrganizationProfile/TrisaDetail.tsx:60
 msgid "Verified On"
 msgstr "验证日期"
 
@@ -2930,12 +2930,12 @@ msgstr ""
 msgid "What is IVMS101?"
 msgstr "IVMS101是什么？"
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:193
-#: src/components/TrixoQuestionnaireForm/index.tsx:377
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:192
+#: src/components/TrixoQuestionnaireForm/index.tsx:376
 msgid "What is the minimum threshold for Travel Rule compliance?"
 msgstr "\"遵守旅游规则的最低门槛是多少？"
 
-#: src/components/Section/SearchDirectory.tsx:157
+#: src/components/Section/SearchDirectory.tsx:156
 msgid "What’s a Common name or VASP ID?"
 msgstr "什么是公用名或VASP ID？"
 
@@ -2969,12 +2969,12 @@ msgstr ""
 msgid "X.509 Identity Certificates"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:228
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:250
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:227
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:249
 msgid "YES"
 msgstr ""
 
-#: src/components/CertificateReview/TrixoReviewDataTable.tsx:14
+#: src/components/CertificateReview/TrixoReviewDataTable.tsx:13
 #: src/components/ReviewSubmit/ModalAlert.tsx:34
 #: src/constants/trixo.ts:5
 msgid "Yes"
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "Your TRISA Implementation"
 msgstr ""
 
-#: src/components/OrganizationProfile/TrisaDetail.tsx:46
+#: src/components/OrganizationProfile/TrisaDetail.tsx:44
 msgid "Your TRISA {type} Details"
 msgstr ""
 
@@ -3190,7 +3190,7 @@ msgid ""
 "                    testing purposes."
 msgstr ""
 
-#: src/components/Collaborators/index.tsx:137
+#: src/components/Collaborators/index.tsx:145
 msgid "you do not have permission to invite a collaborator"
 msgstr ""
 


### PR DESCRIPTION
### Scope of changes

Add Spanish and Portuguese to locales in `lingui` config. Also, runs an extraction to create `.po` files where translations will be added for both languages.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (internationalization)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


