### PR TITLE
Add optional chaining to resolve null error

### DIFF
--- a/web/gds-user-ui/src/utils/auth0.helper.ts
+++ b/web/gds-user-ui/src/utils/auth0.helper.ts
@@ -63,7 +63,7 @@ export const auth0Hash = (hash?: any) => {
       if (err) {
         reject(err);
       } else {
-        const decodeToken: any = jwt_decode(authResult.accessToken);
+        const decodeToken: any = jwt_decode(authResult?.accessToken);
         authResult.idTokenPayload.permissions = decodeToken.permissions;
 
         resolve(authResult);

--- a/web/gds-user-ui/src/utils/axios.ts
+++ b/web/gds-user-ui/src/utils/axios.ts
@@ -70,7 +70,6 @@ axiosInstance.interceptors.response.use(
           axiosInstance.defaults.headers.common.Authorization = `Bearer ${token}`;
           axiosInstance.defaults.headers.common['X-CSRF-Token'] = csrfToken;
           originalRequest._retry += 1;
-          console.log('retrying request', originalRequest);
           return axiosInstance(originalRequest);
         }
       } else {


### PR DESCRIPTION
### Scope of changes

Fix to resolve `Cannot read properties of null` TypeError by adding optional chaining `(?)` to verify that the result isn't `null` or `undefined` before attempting to access the `accessToken` value.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


