### PR TITLE
Replace custom toast component

### DIFF
--- a/web/gds-user-ui/src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx
+++ b/web/gds-user-ui/src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx
@@ -7,12 +7,12 @@ import { Button, Stack, Text, VStack, chakra, useToast } from '@chakra-ui/react'
 import { DevTool } from '@hookform/devtools';
 import { isProdEnv } from 'application/config';
 import InputFormControl from 'components/ui/InputFormControl';
-import CustomToast from 'components/ui/CustomToast';
 import CheckboxFormControl from 'components/ui/CheckboxFormControl';
 import { t, Trans } from '@lingui/macro';
 import { useFetchCollaborators } from 'components/Collaborators/useFetchCollaborator';
 import { useSelector } from 'react-redux';
 import { userSelector } from 'modules/auth/login/user.slice';
+import { upperCaseFirstLetter } from 'utils/utils';
 type Props = {
   onCloseModal: () => void;
 };
@@ -62,17 +62,19 @@ const AddCollaboratorForm: FC<Props> = (props) => {
     // set collaborators in global state
   };
 
-  if (hasCollaboratorFailed) {
-    return (
-      <Stack data-test="collaborator-failed">
-        <CustomToast
-          title="Fail to add a new collaborator"
-          description={errorMessage}
-          status="error"
-        />
-      </Stack>
-    );
-  }
+  useEffect(() => {
+    if(hasCollaboratorFailed) {
+      onCloseModal();
+      toast({
+        position: 'top-right',
+        title: t`Unable to add collaborator`,
+        description: t`${upperCaseFirstLetter(errorMessage?.data?.error)}`,
+        isClosable: true,
+        duration: 9000,
+        status: 'error'
+      });
+    }
+  }, [hasCollaboratorFailed, onCloseModal, toast, errorMessage])
 
   return (
     <chakra.form onSubmit={handleSubmit(onSubmit)}>

--- a/web/gds-user-ui/src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx
+++ b/web/gds-user-ui/src/components/Collaborators/AddCollaborator/AddCollaboratorForm.tsx
@@ -74,7 +74,7 @@ const AddCollaboratorForm: FC<Props> = (props) => {
         status: 'error'
       });
     }
-  }, [hasCollaboratorFailed, onCloseModal, toast, errorMessage])
+  }, [hasCollaboratorFailed, onCloseModal, toast, errorMessage]);
 
   return (
     <chakra.form onSubmit={handleSubmit(onSubmit)}>

--- a/web/gds-user-ui/src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx
+++ b/web/gds-user-ui/src/components/Collaborators/EditCollaborator/EditCollaboratorModal.tsx
@@ -24,6 +24,7 @@ import React, { useEffect, useState } from 'react';
 import { t } from '@lingui/macro';
 import { USER_PERMISSION } from 'types/enums';
 import { useSafeDisableIconButton } from 'components/Collaborators/useSafeDisableIconButton';
+import { upperCaseFirstLetter } from 'utils/utils';
 
 interface Props {
   collaboratorId: string;
@@ -112,7 +113,7 @@ function EditCollaboratorModal(props: Props) {
       //   t`An error occurred while updating the collaborator, please try again or contact support at support@trisa.io`;
       toast({
         title: t`Collaborator is not updated`,
-        description: errorMessage || t`The collaborator has not been updated`,
+        description: t`${upperCaseFirstLetter(errorMessage?.data?.error)}` || t`The collaborator has not been updated`,
         status: 'error',
         duration: 9000,
         isClosable: true,

--- a/web/gds-user-ui/src/components/Collaborators/EditCollaborator/useUpdateCollaborator.ts
+++ b/web/gds-user-ui/src/components/Collaborators/EditCollaborator/useUpdateCollaborator.ts
@@ -15,6 +15,6 @@ export function useUpdateCollaborator(): UpdateCollaboratorMutation {
         hasCollaboratorFailed: mutation.isError,
         wasCollaboratorUpdated: mutation.isSuccess,
         isUpdating: mutation.isLoading,
-        errorMessage: mutation.error?.response.data?.error || mutation.error,
+        errorMessage: mutation.error,
     };
 }

--- a/web/gds-user-ui/src/utils/axios.ts
+++ b/web/gds-user-ui/src/utils/axios.ts
@@ -120,7 +120,7 @@ axiosInstance.interceptors.response.use(
       }
     }
 
-    return Promise.reject(error);
+    return Promise.reject(error.response);
 
     // }
   }


### PR DESCRIPTION
### Scope of changes

Fix the following error, `Error: Objects are not valid as a React child` , by replacing a custom toast component with the Chakra UI toast component.

The changes also ensure the `Add Collaborator` modal completely closes after a user experiences an error and displays the error message provided from the BE. Error messaging was updated in the `Edit Collaborator` form as well to resolve an error caused by updating the `axiosInstance` to return error responses.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Note: The inspector was open while recording the video below to confirm that the error messages didn't appear in the console. This is why the modal may appear to not fit the screen.

https://www.awesomescreenshot.com/video/24167192?key=96d5767d73b78c0b8adda5a190d63267

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


