### PR TITLE
Add util to remove duplicate orgs from appdata

### DIFF
--- a/cmd/bffutil/main.go
+++ b/cmd/bffutil/main.go
@@ -240,6 +240,19 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:   "appdata:dedupeorgs",
+			Usage:  "remove duplicate organizations from a user's app_metadata",
+			Action: dedupeAppdataOrgs,
+			Before: Before(loadConf, connectAuth0),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:    "dry-run",
+					Aliases: []string{"d"},
+					Usage:   "display user duplicate orgs without removing them",
+				},
+			},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -1085,6 +1098,50 @@ func sortAppdataOrgs(c *cli.Context) (err error) {
 	}
 
 	fmt.Printf("updated app metadata for %d users\n", updated)
+
+	return nil
+}
+
+func dedupeAppdataOrgs(c *cli.Context) (err error) {
+	// Get all users in the tenant
+	var users *management.UserList
+	if users, err = auth0.User.List(); err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	// Recreate org list for each user
+	for _, user := range users.Users {
+		appdata := &auth.AppMetadata{}
+		if err = appdata.Load(user.AppMetadata); err != nil {
+			return cli.Exit(err, 1)
+		}
+
+		// Get the user's current org list
+		orgs := appdata.GetOrganizations()
+		if len(orgs) == 0 {
+			continue
+		}
+
+		// Check for duplicate orgs and remove them.
+		seen := make(map[string]bool)
+		appdata.Organizations = []string{}
+		for _, org := range orgs {
+			if _, ok := seen[org]; !ok {
+				seen[org] = true
+				appdata.Organizations = append(appdata.Organizations, org)
+			} else {
+				fmt.Printf("found duplicate org %q from user %s (%s)\n", org, *user.Email, *user.ID)
+			}
+		}
+
+		fmt.Printf("current org list for user %s (%s): %v\n", *user.Email, *user.ID, appdata.Organizations)
+
+		if !c.Bool("dry-run") {
+			if err = SaveAppMetadata(*user.ID, *appdata); err != nil {
+				return cli.Exit(err, 1)
+			}
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Scope of changes

Adds `appdata:dedupeorgs` script to `bffutil` to aid in locating and remove duplicate organizations.

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


