### PR TITLE
Fix reset error in TRIXO form

### DIFF
--- a/web/gds-user-ui/src/components/TrixoQuestionnaire/index.tsx
+++ b/web/gds-user-ui/src/components/TrixoQuestionnaire/index.tsx
@@ -17,14 +17,13 @@ const TrixoQuestionnaire: React.FC = () => {
   const stepStatus = getStepStatus(steps, currentStep);
   const [shouldResetForm, setShouldResetForm] = useState<boolean>(false);
   const { isStepDeleted, updateDeleteStepState } = useCertificateStepper();
-  const isTrixoStepDeleted = isStepDeleted(StepEnum.LEGAL);
+  const isTrixoStepDeleted = isStepDeleted(StepEnum.TRIXO);
   const { certificateStep, isFetchingCertificateStep, getCertificateStep } =
     useFetchCertificateStep({
       key: StepEnum.TRIXO
     });
   useEffect(() => {
     if (isTrixoStepDeleted) {
-      console.log('[] isLegalStepDeleted', isTrixoStepDeleted);
       const payload = {
         step: StepEnum.TRIXO,
         isDeleted: false


### PR DESCRIPTION
### Scope of changes

Fix error in `TRIXO` form so that the page will reload and remove data after users confirm that they'd like to reset the form.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/24336690?key=b694f17e7dc16e7c8e4e344e3d7ea8fe

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


