### PR TITLE
Fix bug displaying registration confirmation modal multiple times

### DIFF
--- a/web/gds-user-ui/src/components/CertificateReview/index.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/index.tsx
@@ -40,7 +40,7 @@ const CertificateReview = () => {
       if (network === STEPPER_NETWORK.TESTNET) {
         setIsTestNetSubmitting(true);
         const response = await submitTestnetRegistration();
-        if (response.status === 200) {
+        if (response?.status === 200) {
           await getRefreshToken(response?.data?.refresh_token);
           setIsTestNetSubmitting(false);
           setIsTestNetSent(true);

--- a/web/gds-user-ui/src/components/CertificateReview/index.tsx
+++ b/web/gds-user-ui/src/components/CertificateReview/index.tsx
@@ -23,7 +23,7 @@ const ReviewsSummary = lazy(() => import('./ReviewsSummary'));
 const CertificateReview = () => {
   const toast = useToast();
   const dispatch = useDispatch();
-  const { testnetSubmissionState, mainnetSubmissionState } = useCertificateStepper();
+  const { testnetSubmissionState, mainnetSubmissionState, jumpToLastStep } = useCertificateStepper();
 
   const hasReachSubmitStep: boolean = useSelector(
     (state: RootStateOrAny) => state.stepper.hasReachSubmitStep
@@ -89,6 +89,13 @@ const CertificateReview = () => {
     }
   }, [isTestNetSent, isMainNetSent, dispatch]);
 
+  const handleJumpToLastStep = (e: React.FormEvent) => {
+    e.preventDefault();
+    jumpToLastStep();
+    setIsTestNetSent(false);
+    setIsMainNetSent(false);
+  };
+
   if (!hasReachSubmitStep) {
     return <ReviewsSummary />;
   }
@@ -102,6 +109,7 @@ const CertificateReview = () => {
         result={result}
         isTestNetSubmitting={isTestNetSubmitting}
         isMainNetSubmitting={isMainNetSubmitting}
+        handleJumpToLastStep={handleJumpToLastStep}
       />
     </Suspense>
   );

--- a/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
+++ b/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
@@ -55,8 +55,13 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
   // const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
+  console.log('testnet submitted', isTestNetSubmitted);
+  console.log('mainnet submitted', isMainNetSubmitted);
+
+  // Replace with values from the redux store?
   const isTestnetNetworkFieldsIncomplete = false;
   const isMainnetNetworkIncomplete = false;
+  
   useEffect(() => {
     if (isTestNetSubmitted) {
       setTestnet(true);

--- a/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
+++ b/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import {
   Button,
   Heading,
@@ -16,7 +16,6 @@ import ConfirmationModal from 'components/ReviewSubmit/ConfirmationModal';
 import { t, Trans } from '@lingui/macro';
 import useCertificateStepper from 'hooks/useCertificateStepper';
 import { useSelector } from 'react-redux';
-// import { useNavigate } from 'react-router-dom';
 import { STEPPER_NETWORK } from 'utils/constants';
 import {
   getTestNetSubmittedStatus,
@@ -27,6 +26,8 @@ import WarningBox from 'components/WarningBox';
 import { setHasReachSubmitStep } from 'application/store/stepper.slice';
 import { useAppDispatch } from 'application/store';
 import { StepsIndexes } from 'constants/steps';
+import { useFetchCertificateStep } from 'hooks/useFetchCertificateStep';
+import { StepEnum } from 'types/enums';
 
 interface ReviewSubmitProps {
   onSubmitHandler: (e: React.FormEvent, network: string) => void;
@@ -47,29 +48,20 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
 }) => {
   const isTestNetSubmitted: boolean = useSelector(getTestNetSubmittedStatus);
   const isMainNetSubmitted: boolean = useSelector(getMainNetSubmittedStatus);
+ const { certificateStep } = useFetchCertificateStep({ key: StepEnum.ALL });
   const { isOpen, onOpen, onClose } = useDisclosure();
   const isSent = isTestNetSent || isMainNetSent;
-  const [testnet, setTestnet] = useState(false);
-  const [mainnet, setMainnet] = useState(false);
   const { jumpToLastStep, jumpToStep } = useCertificateStepper();
-  // const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
-  console.log('testnet submitted', isTestNetSubmitted);
-  console.log('mainnet submitted', isMainNetSubmitted);
+  const mainnetCommonName = certificateStep?.form?.mainnet?.common_name;
+  const mainnetEndpoint = certificateStep?.form?.mainnet?.endpoint;
+  const testnetCommonName = certificateStep?.form?.testnet?.common_name;
+  const testnetEndpoint = certificateStep?.form?.testnet?.endpoint;
 
-  // Replace with values from the redux store?
-  const isTestnetNetworkFieldsIncomplete = false;
-  const isMainnetNetworkIncomplete = false;
-  
-  useEffect(() => {
-    if (isTestNetSubmitted) {
-      setTestnet(true);
-    }
-    if (isMainNetSubmitted) {
-      setMainnet(true);
-    }
-  }, [isTestNetSubmitted, isMainNetSubmitted]);
+  const isMainnetNetworkIncomplete = !mainnetCommonName || !mainnetEndpoint;
+  const isTestnetNetworkIncomplete = !testnetCommonName || !testnetEndpoint;
+
   useEffect(() => {
     if (isSent) {
       onOpen();
@@ -168,7 +160,7 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
                   .
                 </Text>
 
-                {isTestnetNetworkFieldsIncomplete ? (
+                {isTestnetNetworkIncomplete ? (
                   <WarningBox>
                     <Text>
                       <Trans>
@@ -213,7 +205,7 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
                     bgColor: '#f55c35'
                   }}
                   isLoading={isTestNetSubmitting}
-                  isDisabled={testnet || isTestnetNetworkFieldsIncomplete}
+                  isDisabled={isTestNetSubmitted || isTestnetNetworkIncomplete}
                   data-testid="testnet-submit-btn"
                   onClick={(e) => {
                     onSubmitHandler(e, STEPPER_NETWORK.TESTNET);
@@ -304,7 +296,7 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
                     bgColor: '#189fda'
                   }}
                   isLoading={isMainNetSubmitting}
-                  isDisabled={mainnet || isMainnetNetworkIncomplete}
+                  isDisabled={isMainNetSubmitted || isMainnetNetworkIncomplete}
                   whiteSpace="normal"
                   boxShadow="lg"
                   data-testid="mainnet-submit-btn"

--- a/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
+++ b/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
@@ -15,12 +15,7 @@ import FormLayout from 'layouts/FormLayout';
 import ConfirmationModal from 'components/ReviewSubmit/ConfirmationModal';
 import { t, Trans } from '@lingui/macro';
 import useCertificateStepper from 'hooks/useCertificateStepper';
-import { useSelector } from 'react-redux';
 import { STEPPER_NETWORK } from 'utils/constants';
-import {
-  getTestNetSubmittedStatus,
-  getMainNetSubmittedStatus
-} from 'application/store/selectors/stepper';
 
 import WarningBox from 'components/WarningBox';
 import { setHasReachSubmitStep } from 'application/store/stepper.slice';
@@ -28,6 +23,7 @@ import { useAppDispatch } from 'application/store';
 import { StepsIndexes } from 'constants/steps';
 import { useFetchCertificateStep } from 'hooks/useFetchCertificateStep';
 import { StepEnum } from 'types/enums';
+import useSubmissionStatus from 'modules/dashboard/registration/hooks/useSubmissionStatus';
 
 interface ReviewSubmitProps {
   onSubmitHandler: (e: React.FormEvent, network: string) => void;
@@ -36,6 +32,7 @@ interface ReviewSubmitProps {
   result?: any;
   isTestNetSubmitting?: boolean;
   isMainNetSubmitting?: boolean;
+  handleJumpToLastStep?: (e: React.FormEvent) => void;
 }
 
 const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
@@ -44,16 +41,18 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
   isMainNetSent,
   result,
   isTestNetSubmitting,
-  isMainNetSubmitting
+  isMainNetSubmitting,
+  handleJumpToLastStep,
 }) => {
-  const isTestNetSubmitted: boolean = useSelector(getTestNetSubmittedStatus);
-  const isMainNetSubmitted: boolean = useSelector(getMainNetSubmittedStatus);
   const { certificateStep } = useFetchCertificateStep({ key: StepEnum.ALL });
   const { isOpen, onOpen, onClose } = useDisclosure();
   const isSent = isTestNetSent || isMainNetSent;
-  const { jumpToLastStep, jumpToStep } = useCertificateStepper();
+  const { jumpToStep } = useCertificateStepper();
+  const { status } = useSubmissionStatus();
   const dispatch = useAppDispatch();
   
+  // Display a warning box if the user has reached the submit step but not completed the
+  // TRISA implementation step for one of the networks.
   const mainnetCommonName = certificateStep?.form?.mainnet?.common_name;
   const mainnetEndpoint = certificateStep?.form?.mainnet?.endpoint;
   const testnetCommonName = certificateStep?.form?.testnet?.common_name;
@@ -62,16 +61,15 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
   const isMainnetNetworkIncomplete = !mainnetCommonName || !mainnetEndpoint;
   const isTestnetNetworkIncomplete = !testnetCommonName || !testnetEndpoint;
 
+  const isTestNetSubmitted = status?.data?.testnet_submitted;
+  const isMainNetSubmitted = status?.data?.mainnet_submitted;
+
   useEffect(() => {
     if (isSent) {
       onOpen();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSent]);
-
-  const handleJumpToLastStep = () => {
-    jumpToLastStep();
-  };
 
   const handleJumpToTrisaImplementationStep = () => {
     dispatch(setHasReachSubmitStep({ hasReachSubmitStep: false }));
@@ -203,7 +201,7 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
                     bgColor: '#f55c35'
                   }}
                   isLoading={isTestNetSubmitting}
-                  isDisabled={isTestNetSubmitted || isTestnetNetworkIncomplete}
+                  isDisabled={isTestnetNetworkIncomplete || isTestNetSubmitted }
                   data-testid="testnet-submit-btn"
                   onClick={(e) => {
                     onSubmitHandler(e, STEPPER_NETWORK.TESTNET);
@@ -294,7 +292,7 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
                     bgColor: '#189fda'
                   }}
                   isLoading={isMainNetSubmitting}
-                  isDisabled={isMainNetSubmitted || isMainnetNetworkIncomplete}
+                  isDisabled={isMainnetNetworkIncomplete || isMainNetSubmitted }
                   whiteSpace="normal"
                   boxShadow="lg"
                   data-testid="mainnet-submit-btn"

--- a/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
+++ b/web/gds-user-ui/src/components/ReviewSubmit/index.tsx
@@ -48,12 +48,12 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
 }) => {
   const isTestNetSubmitted: boolean = useSelector(getTestNetSubmittedStatus);
   const isMainNetSubmitted: boolean = useSelector(getMainNetSubmittedStatus);
- const { certificateStep } = useFetchCertificateStep({ key: StepEnum.ALL });
+  const { certificateStep } = useFetchCertificateStep({ key: StepEnum.ALL });
   const { isOpen, onOpen, onClose } = useDisclosure();
   const isSent = isTestNetSent || isMainNetSent;
   const { jumpToLastStep, jumpToStep } = useCertificateStepper();
   const dispatch = useAppDispatch();
-
+  
   const mainnetCommonName = certificateStep?.form?.mainnet?.common_name;
   const mainnetEndpoint = certificateStep?.form?.mainnet?.endpoint;
   const testnetCommonName = certificateStep?.form?.testnet?.common_name;
@@ -67,18 +67,16 @@ const ReviewSubmit: React.FC<ReviewSubmitProps> = ({
       onOpen();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isTestNetSent, isMainNetSent]);
+  }, [isSent]);
 
   const handleJumpToLastStep = () => {
     jumpToLastStep();
-    // navigate('/dashboard/certificate/registration');
   };
 
   const handleJumpToTrisaImplementationStep = () => {
     dispatch(setHasReachSubmitStep({ hasReachSubmitStep: false }));
     jumpToStep(StepsIndexes.TRISA_IMPLEMENTATION);
   };
-
   return (
     <>
       <Flex>

--- a/web/gds-user-ui/src/hooks/useCertificateStepper.tsx
+++ b/web/gds-user-ui/src/hooks/useCertificateStepper.tsx
@@ -108,6 +108,7 @@ const useCertificateStepper = () => {
     dispatch(setCertificateValue({ value }));
   };
 
+  // Does the submitted status get set to false when user goes back to a previous step?
   const setInitialState = (value: any) => {
     const state: TPayload = {
       currentStep: value?.state?.current,

--- a/web/gds-user-ui/src/hooks/useCertificateStepper.tsx
+++ b/web/gds-user-ui/src/hooks/useCertificateStepper.tsx
@@ -108,7 +108,6 @@ const useCertificateStepper = () => {
     dispatch(setCertificateValue({ value }));
   };
 
-  // Does the submitted status get set to false when user goes back to a previous step?
   const setInitialState = (value: any) => {
     const state: TPayload = {
       currentStep: value?.state?.current,

--- a/web/gds-user-ui/src/modules/dashboard/certificate/lib/trixoQuestionnaireValidationSchema.ts
+++ b/web/gds-user-ui/src/modules/dashboard/certificate/lib/trixoQuestionnaireValidationSchema.ts
@@ -57,7 +57,6 @@ export const isTrixoQuestionnaireValid = async (data: any) => {
     });
     return true;
   } catch (error) {
-    console.log('[isTrixoQuestionnaireValid] error', error);
     return false;
   }
 };

--- a/web/gds-user-ui/src/modules/dashboard/registration/hooks/useSubmissionStatus.ts
+++ b/web/gds-user-ui/src/modules/dashboard/registration/hooks/useSubmissionStatus.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { getSubmissionStatus } from "../service";
+import { upperCaseFirstLetter } from "utils/utils";
+
+const useSubmissionStatus = () => {
+  const [error, setError] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [status, setStatus] = useState<any>(null);
+
+    const fetchSubmissionStatus = async () => {
+      setIsLoading(true);
+      try {
+        const response = await getSubmissionStatus();
+        if (!response) setError('No data found');
+        setStatus(response);
+      } catch (e: any) {
+        if (!e?.data?.success) {
+          setError(upperCaseFirstLetter(e?.data?.error));
+        } else {
+          setError('Something went wrong.');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    useEffect(() => {
+      fetchSubmissionStatus();
+    }, []);
+
+    return { status, isLoading, error };
+  };
+
+export default useSubmissionStatus;


### PR DESCRIPTION
### Scope of changes

This fixes a bug that could cause the registration confirmation modal to appear multiple times. Another bug that allowed users to click the registration form's submit button if they'd previously submitted a registration has also been fixed. A warning box consistently appears on the registration page if a user has only completed all fields for one network.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Video:
https://www.awesomescreenshot.com/video/25218910?key=e0a0cf29a46669ede18adcf003a5a308

Images of warning box:
https://www.awesomescreenshot.com/image/46253857?key=08462d29f0ac4e956ff025991e6c8161
https://www.awesomescreenshot.com/image/46253859?key=30e2e70a915be77ad9710bc2970424ad

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


