### PR TITLE
Add optional chaining to prevent undefined error

### DIFF
--- a/web/gds-user-ui/src/components/NeedsAttention/index.tsx
+++ b/web/gds-user-ui/src/components/NeedsAttention/index.tsx
@@ -17,6 +17,7 @@ export type NeedsAttentionProps = {
 
 const NeedsAttention = ({ buttonText, onClick }: NeedsAttentionProps) => {
   const { attentionResponse } = useFetchAttention();
+  console.log(attentionResponse);
 
   if (
     attentionResponse &&
@@ -38,9 +39,9 @@ const NeedsAttention = ({ buttonText, onClick }: NeedsAttentionProps) => {
         {attentionResponse?.messages?.map((item: AttentionResponseType, key: any) => (
           <AttentionAlert
             key={key}
-            action={item.action}
-            severity={item.severity}
-            message={item.message}
+            action={item?.action}
+            severity={item?.severity}
+            message={item?.message}
             onClick={onClick}
             buttonText={buttonText}
           />

--- a/web/gds-user-ui/src/components/NeedsAttention/index.tsx
+++ b/web/gds-user-ui/src/components/NeedsAttention/index.tsx
@@ -17,7 +17,6 @@ export type NeedsAttentionProps = {
 
 const NeedsAttention = ({ buttonText, onClick }: NeedsAttentionProps) => {
   const { attentionResponse } = useFetchAttention();
-  console.log(attentionResponse);
 
   if (
     attentionResponse &&


### PR DESCRIPTION
### Scope of changes

This PR adds optional chaining to check if a property is undefined before attempting to access a value that will be passed to the `Alert` component as a prop.

The change should resolve the following error: `Cannot read properties of undefined (reading 'colorScheme')`.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]   Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.


