### PR TITLE
Fix Ensign Config Preventing GDS from Running

### DIFF
--- a/pkg/bff/config/config.go
+++ b/pkg/bff/config/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/trisacrypto/directory/pkg/store/config"
 	"github.com/trisacrypto/directory/pkg/utils/activity"
-	"github.com/trisacrypto/directory/pkg/utils/ensign"
 	"github.com/trisacrypto/directory/pkg/utils/logger"
 	"github.com/trisacrypto/directory/pkg/utils/sentry"
 	"github.com/trisacrypto/trisa/pkg/trisa/mtls"
@@ -102,12 +101,6 @@ type CacheConfig struct {
 	Enabled    bool          `split_words:"true" default:"false"`
 	Size       uint          `split_words:"true" default:"16384"`
 	Expiration time.Duration `split_words:"true" default:"8h"`
-}
-
-type ActivityConfig struct {
-	Enabled bool   `split_words:"true" default:"false"`
-	Topic   string `split_words:"true"`
-	Ensign  ensign.Config
 }
 
 // New creates a new Config object from environment variables prefixed with GDS_BFF.

--- a/pkg/gds/config/config.go
+++ b/pkg/gds/config/config.go
@@ -162,6 +162,14 @@ func (c Config) Validate() (err error) {
 		return err
 	}
 
+	if err = c.Sentry.Validate(); err != nil {
+		return err
+	}
+
+	if err = c.Activity.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -171,7 +179,6 @@ func (c GDSConfig) Validate() error {
 			return errors.New("invalid configuration: bind addr is required for enabled GDS")
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/gds/config/config_test.go
+++ b/pkg/gds/config/config_test.go
@@ -193,7 +193,6 @@ func TestAuthorizedDomainsPreprocessing(t *testing.T) {
 }
 
 func TestRequiredConfig(t *testing.T) {
-	t.Skip("test assumes that confire is processing required tags recursively, is it?")
 	required := []string{
 		"GDS_DATABASE_URL",
 		"GDS_SECRET_KEY",

--- a/pkg/utils/activity/config.go
+++ b/pkg/utils/activity/config.go
@@ -1,30 +1,34 @@
 package activity
 
 import (
+	"errors"
 	"time"
 
 	"github.com/trisacrypto/directory/pkg/utils/ensign"
 )
 
 type Config struct {
-	Enabled           bool          `split_words:"true" default:"false"`
-	Topic             string        `split_words:"true"`
-	Network           Network       `split_words:"true"`
+	Enabled           bool          `default:"false"`
+	Topic             string        `required:"false"`
+	Network           Network       `required:"false"`
 	AggregationWindow time.Duration `split_words:"true" default:"5m"`
-	Testing           bool          `split_words:"true" default:"false"`
+	Testing           bool          `default:"false"`
 	Ensign            ensign.Config
 }
 
 func (c Config) Validate() (err error) {
 	if c.Enabled {
 		if c.Topic == "" {
-			return ErrMissingTopic
+			err = errors.Join(err, ErrMissingTopic)
 		}
 
-		if err = c.Ensign.Validate(); err != nil {
-			return err
+		if verr := c.Network.IsValid(); verr != nil {
+			err = errors.Join(err, verr)
+		}
+
+		if verr := c.Ensign.IsValid(); verr != nil {
+			err = errors.Join(err, verr)
 		}
 	}
-
-	return nil
+	return err
 }

--- a/pkg/utils/activity/event.go
+++ b/pkg/utils/activity/event.go
@@ -118,7 +118,11 @@ func (n Network) String() string {
 	}
 }
 
-func (n Network) Validate() error {
+// Check if the network is valid.
+// NOTE: this method must be named IsValid and not Validate to prevent confire from
+// calling this function during validation. Configurations that use a Network should
+// manually call IsValid in their Validation method.
+func (n Network) IsValid() error {
 	if n == UnknownNetwork {
 		return ErrUnknownNetwork
 	}

--- a/pkg/utils/ensign/config.go
+++ b/pkg/utils/ensign/config.go
@@ -1,6 +1,8 @@
 package ensign
 
 import (
+	"errors"
+
 	sdk "github.com/rotationalio/go-ensign"
 )
 
@@ -8,30 +10,38 @@ import (
 type Config struct {
 	ClientID     string `split_words:"true"`
 	ClientSecret string `split_words:"true"`
-	Endpoint     string `split_words:"true" default:"ensign.rotational.app:443"`
+	Endpoint     string `default:"ensign.rotational.app:443"`
 	AuthURL      string `split_words:"true" default:"https://auth.rotational.app"`
-	Insecure     bool   `split_words:"true" default:"false"`
-	Testing      bool   `split_words:"true" default:"false"`
+	Insecure     bool   `default:"false"`
+	Testing      bool   `default:"false"`
 }
 
-func (c Config) Validate() error {
+// Validate that the ensign config is ready for connection.
+// NOTE: This must be IsValid() and not Validate() to prevent confire from calling
+// this function to check if the configuration is valid. Configurations that embed an
+// ensign configuration should manually call IsValid in their Validation method.
+func (c Config) IsValid() (err error) {
+	if c.Testing {
+		return nil
+	}
+
 	if c.ClientID == "" {
-		return ErrMissingClientID
+		err = errors.Join(err, ErrMissingClientID)
 	}
 
 	if c.ClientSecret == "" {
-		return ErrMissingClientSecret
+		err = errors.Join(err, ErrMissingClientSecret)
 	}
 
 	if c.Endpoint == "" {
-		return ErrMissingEndpoint
+		err = errors.Join(err, ErrMissingEndpoint)
 	}
 
 	if c.AuthURL == "" {
-		return ErrMissingAuthURL
+		err = errors.Join(err, ErrMissingAuthURL)
 	}
 
-	return nil
+	return err
 }
 
 func (c Config) ClientOptions() []sdk.Option {

--- a/pkg/utils/ensign/config_test.go
+++ b/pkg/utils/ensign/config_test.go
@@ -15,24 +15,24 @@ func TestValidate(t *testing.T) {
 	}
 
 	// Should error if client id is missing.
-	require.ErrorIs(t, config.Validate(), ensign.ErrMissingClientID, "expected missing client id error")
+	require.ErrorIs(t, config.IsValid(), ensign.ErrMissingClientID, "expected missing client id error")
 
 	// Should error if client secret is missing.
 	config.ClientID = "client-id"
 	config.ClientSecret = ""
-	require.ErrorIs(t, config.Validate(), ensign.ErrMissingClientSecret, "expected missing client secret error")
+	require.ErrorIs(t, config.IsValid(), ensign.ErrMissingClientSecret, "expected missing client secret error")
 
 	// Should error if endpoint is missing.
 	config.ClientSecret = "client-secret"
 	config.Endpoint = ""
-	require.ErrorIs(t, config.Validate(), ensign.ErrMissingEndpoint, "expected missing endpoint error")
+	require.ErrorIs(t, config.IsValid(), ensign.ErrMissingEndpoint, "expected missing endpoint error")
 
 	// Should error if auth url is missing.
 	config.Endpoint = "ensign.rotational.app:443"
 	config.AuthURL = ""
-	require.ErrorIs(t, config.Validate(), ensign.ErrMissingAuthURL, "expected missing auth url error")
+	require.ErrorIs(t, config.IsValid(), ensign.ErrMissingAuthURL, "expected missing auth url error")
 
 	// Should not error if all required fields are present.
 	config.AuthURL = "https://auth.rotational.app"
-	require.NoError(t, config.Validate(), "expected no error for valid configuration")
+	require.NoError(t, config.IsValid(), "expected no error for valid configuration")
 }


### PR DESCRIPTION
### Scope of changes

The confire library automatically calls a configurations `Validate()` method if it implements it in order to process a valid configuration. We did not want the Ensign config to be validated unless the Activity config (which it was a member of) was enabled. Similarly the `Network` field also had a `Validate` method which is why those two errors were coming up. This PR fixes those problems. 

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  I have moved the associated Shortcut story to "Ready for Review"